### PR TITLE
Fix up spellcheck, markdown lint, and pypi CI workflows

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -37,19 +37,19 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: "Harden Runner"
-              uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
+              uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0
               with:
                   egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
 
 
             - name: "Checkout"
-              uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
               with:
                   # for setuptools-scm
                   fetch-depth: 0
 
             - name: "Build and Inspect"
-              uses: hynek/build-and-inspect-python-package@b4fc3f6ba2b3da04f09659be99e2a29fb6146a61 # v2.6.0
+              uses: hynek/build-and-inspect-python-package@b5076c307dc91924a82ad150cdd1533b444d3310 # v2.12.0
 
     # push to Test PyPI on
     # - a new GitHub release is published
@@ -67,18 +67,18 @@ jobs:
 
         steps:
             - name: "Harden Runner"
-              uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
+              uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0
               with:
                   egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
 
             - name: "Download build artifacts"
-              uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
+              uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
               with:
                   name: Packages
                   path: dist
 
             - name: "Upload to Test PyPI"
-              uses: pypa/gh-action-pypi-publish@81e9d935c883d0b210363ab89cf05f3894778450 # v1.8.14
+              uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
               with:
                   repository-url: https://test.pypi.org/legacy/
 
@@ -99,22 +99,23 @@ jobs:
 
         steps:
             - name: "Harden Runner"
-              uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
+              uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0
               with:
                   egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
 
             - name: "Download build artifacts"
-              uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
+              uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
               with:
                   name: Packages
                   path: dist
 
             - name: "Sigstore sign package"
-              uses: sigstore/gh-action-sigstore-python@61f6a500bbfdd9a2a339cf033e5421951fbc1cd2 # v2.1.1
+              uses: sigstore/gh-action-sigstore-python@f514d46b907ebcd5bedc05145c03b69c1edd8b46 # v3.0.0
               with:
                   inputs: |
                       ./dist/*.tar.gz
                       ./dist/*.whl
+                  release-signing-artifacts: false
 
             - name: "Upload artifacts and signatures to GitHub release"
               run: |
@@ -126,7 +127,7 @@ jobs:
             # gh-action-pypi-publish has no option to ignore them.
             - name: "Remove sigstore signatures before uploading to PyPI"
               run: |
-                  rm ./dist/*.sigstore
+                  rm ./dist/*.sigstore.json
 
             - name: "Upload to PyPI"
-              uses: pypa/gh-action-pypi-publish@81e9d935c883d0b210363ab89cf05f3894778450 # v1.8.14
+              uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -32,14 +32,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Harden Runner"
-        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
+        uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0
         with:
          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
 
       - name: "Checkout"
-        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
       - name: Spellcheck
-        uses: rojopolis/spellcheck-github-actions@d354a4dc525c8067555c7481b60416cedb0060ff # v0.38.0
+        uses: rojopolis/spellcheck-github-actions@ed0756273a1658136c36d26e3d0353de35b98c8b # v0.47.0

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -7,9 +7,13 @@ config:
   code-block-style: false
   no-duplicate-header: false
   single-trailing-newline: false
+  no-multiple-blanks: false
+  blanks-around-lists: false
+  no-trailing-punctuation: false
 globs:
   - "**/*.md"
 ignores:
   - ".github/**"
   - "venv/**"
   - ".venv/**"
+  - ".tox/**"

--- a/.spellcheck-en-custom.txt
+++ b/.spellcheck-en-custom.txt
@@ -1,5 +1,25 @@
 # make spellcheck-sort
 # Please keep this file sorted:
 # SPDX-License-Identifier: Apache-2.0
+Composable
+composable
+customizable
+Dataflow
+Datasets
+dataset
+datasets
+icl
+instructlab
+jsonl
+LLM
+parallelization
+Reusability
+Scalability
+scalable
+scikit
 sdg
+src
 Tatsu
+TODO
+YAML
+yaml

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Blocks can be chained together to form a **Pipeline**. Pipelines enable:
 
 ### SDG Workflow: Full Workflow Automation
 
-Pipelines are further orchestrated into **SDG Workflows**, enabling seamless end-to-end processing. When invoking `sdg.generate`, it triggers a pipeline/ or multiple pipelines that processes data through all the configured blocks. 
+Pipelines are further orchestrated into **SDG Workflows**, enabling seamless end-to-end processing. When invoking `sdg.generate`, it triggers a pipeline/ or multiple pipelines that processes data through all the configured blocks.
 
 ---
 
@@ -50,7 +50,7 @@ The YAML configuration file, known as the **Flow**, is central to defining data 
 
 #### Key Features of a Flow
 
-1. **Modular Design**: 
+1. **Modular Design**:
    - Flows are composed of blocks, which can be chained together into pipelines.
    - Each block performs a specific task, such as generating, filtering, or transforming data.
 
@@ -113,7 +113,7 @@ Here is an example of a Flow configuration:
 
 ---
 
-## Sample usecases: 
+## Sample use cases:
 
 ### Knowledge generation
 
@@ -121,7 +121,7 @@ TODO
 
 ### Data Annotation
 
-The following command annotates the dataset located at [datasets/emotion/seed.jsonl](datasets/emotion/seed.jsonl) using the flow defined in [src/instructlab/sdg/flows/annotation/emotion/detailed_description_icl.yaml](src/instructlab/sdg/flows/annotation/emotion/detailed_description_icl.yaml) 
+The following command annotates the dataset located at [datasets/emotion/seed.jsonl](datasets/emotion/seed.jsonl) using the flow defined in [src/instructlab/sdg/flows/annotation/emotion/detailed_description_icl.yaml](src/instructlab/sdg/flows/annotation/emotion/detailed_description_icl.yaml)
 
 #### Command to Run the Annotation Workflow
 


### PR DESCRIPTION
Disable some markdown linting rules, clean up a bit of trailing whitespace in README.md, expand the custom spellcheck entries, and update the GitHub action versions in pypi checks.