### PR TITLE
Allow API key in run.py

### DIFF
--- a/run.py
+++ b/run.py
@@ -83,7 +83,7 @@ def main(
         ds = ds.shuffle(seed=42).select(range(30))
         logger.info("Debug mode enabled. Using a subset of the dataset.")
 
-    openai_api_key = "EMPTY"
+    openai_api_key = os.environ.get("OPENAI_API_KEY", "EMPTY")
     openai_api_base = endpoint
 
     client = OpenAI(


### PR DESCRIPTION
Add OPENAI_API_KEY as a env variable to run.py to allow SDG to be tested against servers that require one. Adding to environment variable rather the command line param to avoid it appearing in the shell history.