### PR TITLE
Fix a mismatch in evaluate_relevancy prompt template

### DIFF
--- a/src/sdg_hub/configs/knowledge/evaluate_relevancy.yaml
+++ b/src/sdg_hub/configs/knowledge/evaluate_relevancy.yaml
@@ -9,7 +9,7 @@ principles: |
   
   For each question, assign a score of 1 point if the response meets the criteria, and 0 points if it does not. After evaluating each question, provide detailed feedback explaining your reasoning behind the scores awarded.
 
-  Conclude your evaluation with a final result, strictly using the following format: 'Total Score: X'. The total score should represent the sum of points assigned for each question, with a maximum possible score of 2 points.
+  Conclude your evaluation with a total score as a final result. The total score should represent the sum of points assigned for each question, with a maximum possible score of 2 points.
   Only evaluate the response based on the above criteria, do not create new questions.
 
 examples: |
@@ -48,7 +48,6 @@ examples: |
   [Start of Score]
   0
   [End of Score]
-
 
   Example 3:
   [Start of Question]


### PR DESCRIPTION
Mismatch in the principles and the examples sections of the prompt template.

In [evaluate_relevancy.yaml](src/sdg_hub/configs/knowledge/evaluate_relevancy.yaml), the principles section says
```
Conclude your evaluation with a final result, strictly using the following format: 'Total Score: X'.
```
which doesn't match the examples section.
```
[Start of Score]
2
[End of Score]
```

In this circumstance, many models, such as mixtral, llama-3.3, and phi-4, ignore the principle and answer in the format as the above example. However, llama-4 answers in the following format, which causes a type conversion error in the following `FilterByValueBlock` block.
```
[Start of Score]
Total Score: 2
[End of Score]
```
```
- block_type: FilterByValueBlock
  block_config:
    block_name: filter_relevancy
    filter_column: score
    filter_value: 2.0
    operation: operator.eq
    convert_dtype: float
  drop_columns:
    - feedback
    - score
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated evaluation instructions to allow more flexibility in how the total score is presented.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->