### PR TITLE
Migrate SamplePopulatorBlock to BaseBlock architecture

### DIFF
--- a/src/sdg_hub/blocks/loading/__init__.py
+++ b/src/sdg_hub/blocks/loading/__init__.py
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Data loading blocks for dataset population and enrichment.
+
+This module provides blocks for loading and populating datasets with data from
+external sources such as configuration files.
+"""
+
+from .sample_populator import SamplePopulatorBlock
+
+__all__ = [
+    "SamplePopulatorBlock",
+]

--- a/src/sdg_hub/blocks/loading/sample_populator.py
+++ b/src/sdg_hub/blocks/loading/sample_populator.py
@@ -1,0 +1,223 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Sample populator block for enriching datasets with configuration data.
+
+This module provides a block for populating datasets with data from configuration files,
+allowing for dynamic enrichment of samples based on key-value lookups.
+"""
+
+# Standard
+from typing import Any, Dict, List, Optional
+import os
+
+# Third Party
+from datasets import Dataset
+from pydantic import Field, field_validator
+import yaml
+
+# Local
+from ...logger_config import setup_logger
+from ..base import BaseBlock
+from ..registry import BlockRegistry
+
+logger = setup_logger(__name__)
+
+
+@BlockRegistry.register(
+    "SamplePopulatorBlock",
+    "loading",
+    "Populates datasets with data from configuration files based on key-value lookups",
+)
+class SamplePopulatorBlock(BaseBlock):
+    """Block for populating dataset with data from configuration files.
+
+    This block reads data from one or more configuration files and populates a
+    dataset with the data. The data is stored in a dictionary, with the keys
+    being the names of the configuration files.
+
+    The input_cols should specify the column to use as the lookup key.
+    The output_cols can be specified to control which columns are added, or left
+    empty to add all columns from the configuration files.
+
+    Attributes
+    ----------
+    block_name : str
+        Name of the block.
+    input_cols : Union[str, List[str]]
+        Input column name(s). Must specify exactly one column for lookup.
+    output_cols : Union[str, List[str], None]
+        Output column specification. If None, all config data is added.
+    config_paths : List[str]
+        List of paths to configuration files to load.
+    post_fix : str
+        Suffix to append to configuration filenames.
+    """
+
+    config_paths: List[str] = Field(
+        ..., description="List of paths to configuration files to load"
+    )
+    post_fix: str = Field(
+        default="", description="Suffix to append to configuration filenames"
+    )
+
+    # Internal fields for loaded configurations
+    configs: Optional[Dict[str, Any]] = Field(
+        None, description="Loaded configuration data", exclude=True
+    )
+
+    @field_validator("input_cols", mode="after")
+    @classmethod
+    def validate_input_cols_single(cls, v):
+        """Validate that exactly one input column is specified."""
+        if not v or len(v) != 1:
+            raise ValueError("SamplePopulatorBlock requires exactly one input column")
+        return v
+
+    def model_post_init(self, __context: Any) -> None:
+        """Initialize derived attributes after Pydantic validation."""
+        super().model_post_init(__context) if hasattr(super(), "model_post_init") else None
+        
+        # Load configuration files
+        self.configs = {}
+        for config_path in self.config_paths:
+            if self.post_fix:
+                config_name = config_path.replace(".yaml", f"_{self.post_fix}.yaml")
+            else:
+                config_name = config_path
+            
+            config_key = os.path.basename(config_path).split(".")[0]
+            self.configs[config_key] = self._load_config(config_name)
+        
+        # Set derived attributes
+        self.column_name = self.input_cols[0]  # Use first (and only) input column
+        
+        # Validate schema consistency across configurations
+        valid_configs = {k: v for k, v in self.configs.items() if v is not None}
+        if len(valid_configs) >= 2:
+            # Get all keys from all configs
+            all_keys = set()
+            config_keys = {}
+            for config_name, config_data in valid_configs.items():
+                keys = set(config_data.keys())
+                config_keys[config_name] = keys
+                all_keys.update(keys)
+            
+            # Check for missing keys in each config
+            warnings = []
+            for config_name, keys in config_keys.items():
+                missing_keys = all_keys - keys
+                if missing_keys:
+                    warnings.append(f"Config '{config_name}' is missing keys: {sorted(missing_keys)}")
+            
+            if warnings:
+                logger.warning(
+                    f"Schema inconsistencies detected in {self.block_name} configs:\n" +
+                    "\n".join(f"  - {w}" for w in warnings) +
+                    "\nThis may cause dataset schema conflicts. Consider standardizing your config files."
+                )
+
+    def _load_config(self, config_path: str) -> Optional[Dict[str, Any]]:
+        """Load a configuration file.
+
+        Parameters
+        ----------
+        config_path : str
+            Path to the configuration file.
+
+        Returns
+        -------
+        Optional[Dict[str, Any]]
+            Loaded configuration data or None if loading fails.
+        """
+        try:
+            with open(config_path, "r", encoding="utf-8") as f:
+                return yaml.safe_load(f)
+        except FileNotFoundError:
+            logger.error(f"Configuration file not found: {config_path}")
+            return None
+        except yaml.YAMLError as e:
+            logger.error(f"Error parsing YAML file {config_path}: {e}")
+            return None
+        except Exception as e:
+            logger.error(f"Unexpected error loading config {config_path}: {e}")
+            return None
+
+    def _validate_custom(self, dataset: Dataset) -> None:
+        """Validate that all lookup keys in the dataset have corresponding configs.
+
+        Parameters
+        ----------
+        dataset : Dataset
+            Input dataset to validate.
+
+        Raises
+        ------
+        ValueError
+            If any lookup keys are missing from the loaded configurations.
+        """
+        # Get unique lookup keys from the dataset
+        unique_keys = set(dataset[self.column_name])
+        
+        # Check which keys don't have corresponding configs
+        missing_configs = []
+        for key in unique_keys:
+            if key not in self.configs:
+                missing_configs.append(key)
+            elif self.configs[key] is None:
+                missing_configs.append(f"{key} (config failed to load)")
+        
+        if missing_configs:
+            available_configs = [k for k, v in self.configs.items() if v is not None]
+            raise ValueError(
+                f"Missing configurations for lookup keys: {missing_configs}. "
+                f"Available configs: {available_configs}. "
+                f"Please ensure all values in column '{self.column_name}' have corresponding YAML files."
+            )
+
+    def _generate(self, sample: Dict[str, Any]) -> Dict[str, Any]:
+        """Generate a new sample by populating it with configuration data.
+
+        Parameters
+        ----------
+        sample : Dict[str, Any]
+            Input sample to populate with configuration data.
+
+        Returns
+        -------
+        Dict[str, Any]
+            Sample populated with configuration data.
+
+        Raises
+        ------
+        KeyError
+            If the lookup key is not found in the configuration.
+        TypeError
+            If the configuration data is None (failed to load).
+        """
+        lookup_key = sample[self.column_name]
+        
+        if lookup_key not in self.configs:
+            raise KeyError(f"Lookup key '{lookup_key}' not found in configurations")
+        
+        config_data = self.configs[lookup_key]
+        if config_data is None:
+            raise TypeError(f"Configuration data for '{lookup_key}' is None (failed to load)")
+        
+        # Merge configuration data with sample
+        return {**sample, **config_data}
+
+    def generate(self, samples: Dataset) -> Dataset:
+        """Generate a new dataset with populated configuration data.
+
+        Parameters
+        ----------
+        samples : Dataset
+            Input dataset to populate with configuration data.
+
+        Returns
+        -------
+        Dataset
+            Dataset populated with configuration data.
+        """
+        # Use map for processing
+        samples = samples.map(self._generate)
+        return samples

--- a/tests/blocks/loading/test_sample_populator.py
+++ b/tests/blocks/loading/test_sample_populator.py
@@ -1,0 +1,407 @@
+"""Test suite for SamplePopulatorBlock functionality.
+
+This module contains tests for the new SamplePopulatorBlock class, which populates datasets
+with data from configuration files using the BaseBlock architecture.
+"""
+
+# Standard
+import os
+import tempfile
+
+# Third Party
+from datasets import Dataset
+import pytest
+import yaml
+
+# First Party
+from sdg_hub.blocks.loading import SamplePopulatorBlock
+from sdg_hub.utils.error_handling import MissingColumnError, EmptyDatasetError
+
+
+@pytest.fixture
+def temp_config_files():
+    """Create temporary config files for testing."""
+    configs = {
+        "coding": {
+            "examples": ["def hello():\n    print('Hello')", "class Test:\n    pass"],
+            "type": "programming",
+            "difficulty": "beginner",
+            "language": "python"
+        },
+        "writing": {
+            "examples": ["Write a story", "Compose a poem"],
+            "type": "composition",
+            "difficulty": "intermediate", 
+            "language": "english"
+        },
+        "math": {
+            "examples": ["2 + 2 = ?", "Solve: x + 5 = 10"],
+            "type": "calculation",
+            "difficulty": "easy",
+            "language": "mathematics"
+        },
+    }
+
+    temp_dir = tempfile.mkdtemp()
+    config_paths = []
+
+    for name, content in configs.items():
+        file_path = os.path.join(temp_dir, f"{name}.yaml")
+        with open(file_path, "w", encoding="utf-8") as f:
+            yaml.dump(content, f)
+        config_paths.append(file_path)
+
+    yield config_paths
+
+    # Cleanup
+    for path in config_paths:
+        if os.path.exists(path):
+            os.remove(path)
+    os.rmdir(temp_dir)
+
+
+@pytest.fixture
+def sample_dataset():
+    """Create a sample dataset for testing."""
+    return Dataset.from_dict(
+        {
+            "route": ["coding", "writing", "math"],
+            "user_id": [1, 2, 3],
+            "prompt": ["Help with code", "Write something", "Solve equation"]
+        }
+    )
+
+
+def test_sample_populator_basic(temp_config_files, sample_dataset):
+    """Test basic functionality of SamplePopulatorBlock."""
+    block = SamplePopulatorBlock(
+        block_name="test_populator",
+        input_cols="route",
+        config_paths=temp_config_files,
+    )
+
+    result = block.generate(sample_dataset)
+
+    # Check basic structure
+    assert len(result) == 3
+    assert "route" in result.column_names
+    assert "user_id" in result.column_names
+    assert "prompt" in result.column_names
+    assert "type" in result.column_names
+    assert "examples" in result.column_names
+
+    # Check data merging
+    row0 = result[0]  # coding
+    assert row0["route"] == "coding"
+    assert row0["type"] == "programming"
+    assert row0["language"] == "python"
+    assert row0["user_id"] == 1  # Original data preserved
+
+    row1 = result[1]  # writing
+    assert row1["route"] == "writing"
+    assert row1["type"] == "composition"
+    assert row1["language"] == "english"
+
+    row2 = result[2]  # math
+    assert row2["route"] == "math"
+    assert row2["type"] == "calculation"
+    assert row2["language"] == "mathematics"
+
+
+def test_sample_populator_with_postfix(temp_config_files):
+    """Test SamplePopulatorBlock with postfix parameter."""
+    # Create postfixed versions of config files
+    temp_dir = os.path.dirname(temp_config_files[0])
+    postfixed_paths = []
+    
+    for path in temp_config_files:
+        base, ext = os.path.splitext(path)
+        new_path = f"{base}_v2{ext}"
+        with open(path, "r") as src, open(new_path, "w") as dst:
+            dst.write(src.read())
+        postfixed_paths.append(new_path)
+
+    try:
+        block = SamplePopulatorBlock(
+            block_name="test_populator",
+            input_cols="route",
+            config_paths=temp_config_files,
+            post_fix="v2",
+        )
+        
+        dataset = Dataset.from_dict({"route": ["coding"], "user_id": [1]})
+        result = block.generate(dataset)
+        
+        # Should have loaded from postfixed files
+        assert result[0]["type"] == "programming"
+        
+    finally:
+        # Cleanup postfixed files
+        for path in postfixed_paths:
+            if os.path.exists(path):
+                os.remove(path)
+
+
+def test_sample_populator_list_input_cols(temp_config_files):
+    """Test with list input_cols."""
+    block = SamplePopulatorBlock(
+        block_name="test_populator",
+        input_cols=["route"],  # List instead of string
+        config_paths=temp_config_files,
+    )
+    
+    assert block.input_cols == ["route"]
+    assert block.column_name == "route"
+
+
+def test_sample_populator_empty_dataset(temp_config_files):
+    """Test with empty dataset."""
+    block = SamplePopulatorBlock(
+        block_name="test_populator",
+        input_cols="route",
+        config_paths=temp_config_files,
+    )
+    
+    empty_dataset = Dataset.from_dict({"route": [], "user_id": []})
+    
+    # Should raise EmptyDatasetError via BaseBlock validation
+    with pytest.raises(EmptyDatasetError):
+        block(empty_dataset)  # Use __call__ to trigger validation
+
+
+def test_sample_populator_duplicate_routes(temp_config_files):
+    """Test with duplicate route values."""
+    block = SamplePopulatorBlock(
+        block_name="test_populator",
+        input_cols="route",
+        config_paths=temp_config_files,
+    )
+    
+    dataset = Dataset.from_dict({
+        "route": ["coding", "coding", "writing"],
+        "user_id": [1, 2, 3]
+    })
+    
+    result = block.generate(dataset)
+    assert len(result) == 3
+    
+    # Both coding rows should have same config data
+    assert result[0]["type"] == "programming"
+    assert result[1]["type"] == "programming"
+    assert result[2]["type"] == "composition"
+
+
+def test_sample_populator_preserves_original_data(temp_config_files, sample_dataset):
+    """Test that original dataset columns are preserved."""
+    block = SamplePopulatorBlock(
+        block_name="test_populator",
+        input_cols="route",
+        config_paths=temp_config_files,
+    )
+
+    result = block.generate(sample_dataset)
+    
+    # All original columns should be preserved
+    for i, original_row in enumerate(sample_dataset):
+        result_row = result[i]
+        for key, value in original_row.items():
+            assert result_row[key] == value
+
+
+def test_sample_populator_schema_validation_warning(temp_config_files, caplog):
+    """Test that schema inconsistencies trigger warnings."""
+    # Create configs with different schemas
+    temp_dir = os.path.dirname(temp_config_files[0])
+    
+    config1 = {"type": "programming", "language": "python"}
+    config2 = {"type": "composition", "genre": "creative"}  # Different field
+    
+    config1_path = os.path.join(temp_dir, "test1.yaml")
+    config2_path = os.path.join(temp_dir, "test2.yaml")
+    
+    with open(config1_path, "w") as f:
+        yaml.dump(config1, f)
+    with open(config2_path, "w") as f:
+        yaml.dump(config2, f)
+    
+    try:
+        SamplePopulatorBlock(
+            block_name="test_validation",
+            input_cols="route",
+            config_paths=[config1_path, config2_path]
+        )
+        
+        # Check that warning was logged
+        assert "Schema inconsistencies detected" in caplog.text
+        
+    finally:
+        os.remove(config1_path)
+        os.remove(config2_path)
+
+
+def test_sample_populator_missing_column(temp_config_files):
+    """Test with missing input column in dataset."""
+    block = SamplePopulatorBlock(
+        block_name="test_populator",
+        input_cols="route",
+        config_paths=temp_config_files,
+    )
+    
+    dataset = Dataset.from_dict({"wrong_col": ["coding"], "user_id": [1]})
+    
+    with pytest.raises(MissingColumnError):
+        block(dataset)  # Use __call__ to trigger BaseBlock validation
+
+
+def test_sample_populator_missing_configs(temp_config_files):
+    """Test with dataset keys that don't have corresponding configs."""
+    block = SamplePopulatorBlock(
+        block_name="test_populator",
+        input_cols="route",
+        config_paths=temp_config_files,
+    )
+    
+    dataset = Dataset.from_dict({
+        "route": ["coding", "missing_key"],  # missing_key has no config
+        "user_id": [1, 2]
+    })
+    
+    with pytest.raises(ValueError, match="Missing configurations for lookup keys"):
+        block(dataset)
+
+
+def test_sample_populator_invalid_yaml(temp_config_files):
+    """Test handling of invalid YAML files."""
+    temp_dir = os.path.dirname(temp_config_files[0])
+    invalid_path = os.path.join(temp_dir, "invalid.yaml")
+    
+    with open(invalid_path, "w") as f:
+        f.write("invalid: yaml: content: [")  # Invalid YAML syntax
+
+    try:
+        paths_with_invalid = temp_config_files + [invalid_path]
+        block = SamplePopulatorBlock(
+            block_name="test_populator",
+            input_cols="route",
+            config_paths=paths_with_invalid,
+        )
+        
+        # Should handle invalid YAML gracefully
+        assert block.configs["invalid"] is None
+        
+    finally:
+        if os.path.exists(invalid_path):
+            os.remove(invalid_path)
+
+
+def test_sample_populator_missing_file(temp_config_files):
+    """Test handling of missing config files."""
+    missing_path = "/nonexistent/missing.yaml"
+    paths_with_missing = temp_config_files + [missing_path]
+    
+    block = SamplePopulatorBlock(
+        block_name="test_populator",
+        input_cols="route",
+        config_paths=paths_with_missing,
+    )
+    
+    # Should handle missing files gracefully
+    assert block.configs["missing"] is None
+
+
+def test_sample_populator_runtime_key_error(temp_config_files):
+    """Test runtime error when lookup key not found."""
+    block = SamplePopulatorBlock(
+        block_name="test_populator",
+        input_cols="route",
+        config_paths=temp_config_files,
+    )
+    
+    dataset = Dataset.from_dict({"route": ["nonexistent"], "user_id": [1]})
+    
+    with pytest.raises(KeyError, match="Lookup key 'nonexistent' not found"):
+        block.generate(dataset)
+
+
+def test_sample_populator_none_config_error(temp_config_files):
+    """Test runtime error when config data is None."""
+    block = SamplePopulatorBlock(
+        block_name="test_populator",
+        input_cols="route",
+        config_paths=temp_config_files,
+    )
+    
+    # Manually set config to None to simulate load failure
+    block.configs["coding"] = None
+    
+    dataset = Dataset.from_dict({"route": ["coding"], "user_id": [1]})
+    
+    with pytest.raises(TypeError, match="Configuration data for 'coding' is None"):
+        block.generate(dataset)
+
+
+def test_sample_populator_validation_errors(temp_config_files):
+    """Test Pydantic validation errors."""
+    
+    # Test multiple input columns not allowed
+    with pytest.raises(ValueError, match="exactly one input column"):
+        SamplePopulatorBlock(
+            block_name="test_populator",
+            input_cols=["route", "other"],
+            config_paths=temp_config_files,
+        )
+    
+    # Test empty input columns not allowed
+    with pytest.raises(ValueError, match="exactly one input column"):
+        SamplePopulatorBlock(
+            block_name="test_populator",
+            input_cols=[],
+            config_paths=temp_config_files,
+        )
+
+
+def test_sample_populator_baseblock_integration(temp_config_files):
+    """Test BaseBlock interface compliance."""
+    block = SamplePopulatorBlock(
+        block_name="test_populator",
+        input_cols="route",
+        config_paths=temp_config_files,
+    )
+    
+    # Test get_config method
+    config = block.get_config()
+    assert config["block_name"] == "test_populator"
+    assert config["input_cols"] == ["route"]
+    assert config["config_paths"] == temp_config_files
+    
+    # Test get_info method
+    info = block.get_info()
+    assert info["block_type"] == "SamplePopulatorBlock"
+    assert info["block_name"] == "test_populator"
+    
+    # Test string representation
+    repr_str = repr(block)
+    assert "SamplePopulatorBlock" in repr_str
+    assert "test_populator" in repr_str
+
+
+def test_sample_populator_full_pipeline(temp_config_files):
+    """Test complete pipeline using __call__ method."""
+    block = SamplePopulatorBlock(
+        block_name="test_populator",
+        input_cols="route",
+        config_paths=temp_config_files,
+    )
+    
+    dataset = Dataset.from_dict({
+        "route": ["coding", "writing"],
+        "task": ["implement function", "write essay"]
+    })
+    
+    # Use __call__ which triggers full validation and logging
+    result = block(dataset)
+    
+    assert len(result) == 2
+    assert result[0]["type"] == "programming"
+    assert result[1]["type"] == "composition"
+    assert result[0]["task"] == "implement function"  # Original data preserved


### PR DESCRIPTION
## Summary

This PR migrates the `SamplePopulatorBlock` from the old `utilblocks.py` to the new BaseBlock architecture, addressing issue #227. The block is now located in the `loading/` directory and follows the established patterns of other migrated blocks.

### Key Changes

- **New Location**: Moved from `utilblocks.py` to `src/sdg_hub/blocks/loading/sample_populator.py`
- **BaseBlock Integration**: Full integration with BaseBlock providing validation, logging, and standardized interfaces
- **Pydantic Validation**: Added comprehensive field validation and error handling
- **Schema Consistency**: Added validation to detect and warn about configuration schema mismatches
- **Error Handling**: Improved error messages and graceful handling of missing/invalid configs
- **Comprehensive Tests**: 16 tests covering functionality, validation, edge cases, and BaseBlock integration

### Usage Examples

#### Basic Usage
```python
from sdg_hub.blocks.loading import SamplePopulatorBlock
from datasets import Dataset

# Create a dataset with route identifiers
dataset = Dataset.from_dict({
    "route": ["coding", "writing", "math"],
    "user_id": [1, 2, 3],
    "prompt": ["Help with code", "Write something", "Solve equation"]
})

# Initialize the block with config files
block = SamplePopulatorBlock(
    block_name="populator",
    input_cols="route",  # Column containing lookup keys
    config_paths=[
        "configs/coding.yaml",
        "configs/writing.yaml", 
        "configs/math.yaml"
    ]
)

# Populate dataset with config data
result = block.generate(dataset)
```

#### Configuration File Example
```yaml
# configs/coding.yaml
examples:
  - "def hello():\n    print('Hello')"
  - "class Test:\n    pass"
type: "programming"
difficulty: "beginner"
language: "python"
```

#### YAML Flow Configuration
```yaml
- block_type: SamplePopulatorBlock
  block_config:
    block_name: populate_configs
    input_cols: route
    config_paths:
      - configs/coding.yaml
      - configs/writing.yaml
      - configs/math.yaml
```

### Features

- **Flexible Input**: Supports string or list input columns (validated to exactly one)
- **Post-fix Support**: Optional suffix for config filenames (`post_fix` parameter)
- **Schema Validation**: Warns about inconsistent schemas across config files
- **Robust Error Handling**: Graceful handling of missing files, invalid YAML, and runtime errors
- **BaseBlock Compliance**: Full integration with validation, logging, and metadata methods

### Testing

The implementation includes comprehensive tests covering:
- Basic functionality and data merging
- Edge cases (empty datasets, duplicate routes, missing configs)
- Error handling (validation errors, runtime errors)
- BaseBlock integration (get_config, get_info, __call__)
- Schema validation warnings

Run tests with:
```bash
pytest tests/blocks/loading/test_sample_populator.py -v
```

### Migration Notes

This can functionally replace the old `SamplePopulatorBlock` from `utilblocks.py`. The new implementation maintains backward compatibility while adding:
- Better error messages and validation
- Schema consistency checking
- Full BaseBlock integration
- Comprehensive test coverage

🤖 Generated with [Claude Code](https://claude.ai/code)