### PR TITLE
Fix ColumnValueFilterBlock YAML serialization issue

### DIFF
--- a/tests/blocks/filtering/test_columnvaluefilter.py
+++ b/tests/blocks/filtering/test_columnvaluefilter.py
@@ -1,7 +1,6 @@
 """Tests for the ColumnValueFilterBlock implementation."""
 
 # Standard
-import operator
 
 # Third Party
 from datasets import Dataset, Features, Value
@@ -28,8 +27,8 @@ def filter_block():
         block_name="test_filter",
         input_cols="age",
         filter_value=30,
-        operation=operator.eq,
-        convert_dtype=int,
+        operation="eq",
+        convert_dtype="int",
     )
 
 
@@ -40,8 +39,8 @@ def filter_block_with_list():
         block_name="test_filter_list",
         input_cols="age",
         filter_value=[30, 35],
-        operation=operator.eq,
-        convert_dtype=int,
+        operation="eq",
+        convert_dtype="int",
     )
 
 
@@ -51,24 +50,24 @@ def test_filter_block_initialization():
         block_name="test_init",
         input_cols="age",
         filter_value=30,
-        operation=operator.eq,
-        convert_dtype=int,
+        operation="eq",
+        convert_dtype="int",
     )
     assert block.column_name == "age"
     assert block.value == [30]  # Note: value is always stored as a list
-    assert block.operation == operator.eq
-    assert block.convert_dtype == int
+    assert block.operation == "eq"
+    assert block.convert_dtype == "int"
 
 
 def test_filter_block_with_invalid_operation():
     """Test ColumnValueFilterBlock initialization with invalid operation."""
-    with pytest.raises(ValueError, match="Operation must be from operator module"):
+    with pytest.raises(ValueError, match="Unsupported operation 'invalid'"):
         ColumnValueFilterBlock(
             block_name="test_invalid_op",
             input_cols="age",
             filter_value=30,
-            operation=lambda x, y: x == y,  # Invalid operation
-            convert_dtype=int,
+            operation="invalid",  # Invalid operation string
+            convert_dtype="int",
         )
 
 
@@ -94,8 +93,8 @@ def test_filter_block_with_greater_than():
         block_name="test_gt",
         input_cols="age",
         filter_value=30,
-        operation=operator.gt,
-        convert_dtype=int,
+        operation="gt",
+        convert_dtype="int",
     )
     dataset = Dataset.from_dict(
         {"age": ["25", "30", "35", "40", "45"]},
@@ -112,8 +111,8 @@ def test_filter_block_with_less_than():
         block_name="test_lt",
         input_cols="age",
         filter_value=35,
-        operation=operator.lt,
-        convert_dtype=int,
+        operation="lt",
+        convert_dtype="int",
     )
     dataset = Dataset.from_dict(
         {"age": ["25", "30", "35", "40", "45"]},
@@ -130,8 +129,8 @@ def test_filter_block_with_invalid_column():
         block_name="test_invalid_col",
         input_cols="nonexistent",
         filter_value=30,
-        operation=operator.eq,
-        convert_dtype=int,
+        operation="eq",
+        convert_dtype="int",
     )
     dataset = Dataset.from_dict(
         {"age": ["25", "30", "35"]},
@@ -147,8 +146,8 @@ def test_filter_block_with_empty_dataset():
         block_name="test_empty",
         input_cols="age",
         filter_value=30,
-        operation=operator.eq,
-        convert_dtype=int,
+        operation="eq",
+        convert_dtype="int",
     )
     dataset = Dataset.from_dict(
         {"age": []},
@@ -165,8 +164,8 @@ def test_filter_block_with_multiple_input_cols():
         block_name="test_multi_input",
         input_cols=["age", "metadata"],  # Filter column is first
         filter_value=30,
-        operation=operator.eq,
-        convert_dtype=int,
+        operation="eq",
+        convert_dtype="int",
     )
     assert block.input_cols == ["age", "metadata"]
     assert block.output_cols == []
@@ -180,8 +179,8 @@ def test_filter_block_single_input_col():
         block_name="test_single",
         input_cols="score",
         filter_value=2.0,
-        operation=operator.ge,
-        convert_dtype=float,
+        operation="ge",
+        convert_dtype="float",
     )
     assert block.input_cols == ["score"]
     assert block.output_cols == []
@@ -194,18 +193,18 @@ def test_filter_block_empty_input_cols():
             block_name="test_empty_input",
             input_cols=[],
             filter_value=2.0,
-            operation=operator.ge,
-            convert_dtype=float,
+            operation="ge",
+            convert_dtype="float",
         )
 
 
 def test_filter_block_with_contains():
-    """Test filtering with operator.contains."""
+    """Test filtering with contains operation."""
     block = ColumnValueFilterBlock(
         block_name="test_contains",
         input_cols="text",
         filter_value="world",
-        operation=operator.contains,
+        operation="contains",
     )
     dataset = Dataset.from_dict(
         {"text": ["hello world", "goodbye moon", "hello there", "world peace"]},
@@ -217,12 +216,12 @@ def test_filter_block_with_contains():
 
 
 def test_filter_block_with_contains_multiple_values():
-    """Test filtering with operator.contains and multiple filter values."""
+    """Test filtering with contains operation and multiple filter values."""
     block = ColumnValueFilterBlock(
         block_name="test_contains_multi",
         input_cols="text",
         filter_value=["world", "moon"],
-        operation=operator.contains,
+        operation="contains",
     )
     dataset = Dataset.from_dict(
         {"text": ["hello world", "goodbye moon", "hello there", "world peace", "moon landing"]},
@@ -231,3 +230,103 @@ def test_filter_block_with_contains_multiple_values():
     filtered_dataset = block(dataset)
     assert len(filtered_dataset) == 4
     assert filtered_dataset["text"] == ["hello world", "goodbye moon", "world peace", "moon landing"]
+
+
+def test_filter_block_with_all_operations():
+    """Test all supported operations work correctly."""
+    dataset = Dataset.from_dict(
+        {"score": ["10", "20", "30", "40", "50"]},
+        features=Features({"score": Value("string")}),
+    )
+    
+    # Test eq
+    block_eq = ColumnValueFilterBlock(
+        block_name="test_eq", input_cols="score", filter_value=30, operation="eq", convert_dtype="int"
+    )
+    result = block_eq(dataset)
+    assert result["score"] == [30]
+    
+    # Test ne
+    block_ne = ColumnValueFilterBlock(
+        block_name="test_ne", input_cols="score", filter_value=30, operation="ne", convert_dtype="int"
+    )
+    result = block_ne(dataset)
+    assert result["score"] == [10, 20, 40, 50]
+    
+    # Test le 
+    block_le = ColumnValueFilterBlock(
+        block_name="test_le", input_cols="score", filter_value=30, operation="le", convert_dtype="int"
+    )
+    result = block_le(dataset)
+    assert result["score"] == [10, 20, 30]
+    
+    # Test ge
+    block_ge = ColumnValueFilterBlock(
+        block_name="test_ge", input_cols="score", filter_value=30, operation="ge", convert_dtype="int"
+    )
+    result = block_ge(dataset)
+    assert result["score"] == [30, 40, 50]
+
+
+def test_filter_block_with_in_operation():
+    """Test filtering with 'in' operation."""
+    block = ColumnValueFilterBlock(
+        block_name="test_in",
+        input_cols="category",
+        filter_value=["science", "history"],
+        operation="in",
+    )
+    dataset = Dataset.from_dict(
+        {"category": ["science", "math", "history", "art", "science"]},
+        features=Features({"category": Value("string")}),
+    )
+    filtered_dataset = block(dataset)
+    assert len(filtered_dataset) == 3
+    assert filtered_dataset["category"] == ["science", "history", "science"]
+
+
+def test_filter_block_without_conversion():
+    """Test filtering without data type conversion."""
+    block = ColumnValueFilterBlock(
+        block_name="test_no_convert",
+        input_cols="name",
+        filter_value="Alice",
+        operation="eq",
+    )
+    dataset = Dataset.from_dict(
+        {"name": ["Alice", "Bob", "Charlie", "Alice"]},
+        features=Features({"name": Value("string")}),
+    )
+    filtered_dataset = block(dataset)
+    assert len(filtered_dataset) == 2
+    assert filtered_dataset["name"] == ["Alice", "Alice"]
+
+
+def test_filter_block_with_invalid_dtype():
+    """Test ColumnValueFilterBlock initialization with invalid dtype."""
+    with pytest.raises(ValueError, match="Unsupported dtype 'invalid'"):
+        ColumnValueFilterBlock(
+            block_name="test_invalid_dtype",
+            input_cols="score",
+            filter_value=30,
+            operation="eq",
+            convert_dtype="invalid",
+        )
+
+
+def test_filter_block_float_conversion():
+    """Test filtering with float conversion."""
+    block = ColumnValueFilterBlock(
+        block_name="test_float",
+        input_cols="price",
+        filter_value=19.99,
+        operation="gt",
+        convert_dtype="float",
+    )
+    dataset = Dataset.from_dict(
+        {"price": ["9.99", "19.99", "29.99", "invalid", "39.99"]},
+        features=Features({"price": Value("string")}),
+    )
+    filtered_dataset = block(dataset)
+    assert len(filtered_dataset) == 2
+    assert filtered_dataset["price"] == [29.99, 39.99]


### PR DESCRIPTION
## Summary
- Fix ColumnValueFilterBlock to support YAML serialization by replacing Callable and Type parameters with string-based configuration
- Replace `operation: Callable` parameter with `operation: str` using mapping dictionary
- Replace `convert_dtype: Type` parameter with `convert_dtype: str` using mapping dictionary  
- Add comprehensive validation for supported operations and data types
- Update all tests to use new string-based API and add extensive test coverage

## Changes
- Added `OPERATION_MAP` supporting: "eq", "ne", "lt", "le", "gt", "ge", "contains", "in"
- Added `DTYPE_MAP` supporting: "int", "float"
- Updated field validators to check against supported string values
- Convert string parameters to actual functions/types in `model_post_init`
- Updated all existing tests and added new comprehensive test cases

## Test plan
- [x] All existing tests pass with new string-based API
- [x] New tests cover all supported operations: eq, ne, lt, le, gt, ge, contains, in
- [x] New tests cover both int and float dtype conversions
- [x] New tests verify proper error handling for invalid operations/dtypes
- [x] Manual testing confirms YAML serialization now works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated filtering options to use string identifiers for operations and data type conversions, improving clarity and validation of filter settings.

* **Bug Fixes**
  * Enhanced error handling for unsupported operations and data type conversions, providing clearer feedback to users.

* **Tests**
  * Expanded test coverage to include more filtering operations and scenarios, ensuring more robust and reliable filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->