### PR TITLE
Rename BlockRegistry.show() to discover_blocks() API

### DIFF
--- a/src/sdg_hub/core/blocks/registry.py
+++ b/src/sdg_hub/core/blocks/registry.py
@@ -291,7 +291,7 @@ class BlockRegistry:
         }
 
     @classmethod
-    def show(cls) -> None:
+    def discover_blocks(cls) -> None:
         """Print a Rich-formatted table of all available blocks."""
         if not cls._metadata:
             console.print("[yellow]No blocks registered yet.[/yellow]")

--- a/tests/blocks/test_registry.py
+++ b/tests/blocks/test_registry.py
@@ -307,7 +307,7 @@ class TestBlockRegistry:
     def test_print_blocks_empty_registry(self):
         """Test printing blocks when registry is empty."""
         with patch("sdg_hub.core.blocks.registry.console") as mock_console:
-            BlockRegistry.show()
+            BlockRegistry.discover_blocks()
             mock_console.print.assert_called_once_with(
                 "[yellow]No blocks registered yet.[/yellow]"
             )
@@ -328,7 +328,7 @@ class TestBlockRegistry:
                 return samples
 
         with patch("sdg_hub.core.blocks.registry.console") as mock_console:
-            BlockRegistry.show()
+            BlockRegistry.discover_blocks()
 
             # Check that console.print was called (for table and summary)
             assert mock_console.print.call_count >= 2


### PR DESCRIPTION
## Summary
- Renamed `BlockRegistry.show()` method to `discover_blocks()` for better API naming
- Updated all test files to use the new method name

## Changes
- `src/sdg_hub/core/blocks/registry.py`: Renamed `show()` method to `discover_blocks()`
- `tests/blocks/test_registry.py`: Updated test calls to use new method name

Fixes #322

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Renamed BlockRegistry.show() to BlockRegistry.discover_blocks() for clearer intent. Behavior unchanged; it still prints the blocks table and summary. This is a public API change—update any usages accordingly.
- Tests
  - Updated tests to call the new method name; assertions and expected console output remain the same.
- Documentation
  - References to the old method name should be updated to reflect discover_blocks().

<!-- end of auto-generated comment: release notes by coderabbit.ai -->