### PR TITLE
Fix flow documentation: update parameter naming and add runtime_params section

### DIFF
--- a/docs/flows/overview.md
+++ b/docs/flows/overview.md
@@ -269,13 +269,29 @@ print(f"Sample output: {dry_result['sample_output']}")
 Customize flow behavior at runtime:
 
 ```python
-# Override default parameters
+# Override default runtime parameters
 result = flow.generate(
     dataset,
-    parameters={
+    runtime_params={
         "max_tokens": 200,
         "temperature": 0.9,
-        "enable_evaluation": False
+    }
+)
+```
+
+### Block-Specific Runtime Arguments
+
+You can enable or disable advanced features—such as "thinking mode"—for individual blocks at runtime using the `runtime_params` argument. This allows fine-grained control over block behavior without modifying the flow YAML.
+
+For example, to disable "thinking mode" for several blocks:
+
+```python
+# Set runtime_params for specific blocks
+result = flow.generate(
+    dataset, 
+    runtime_params = {
+    # LLMChatBlock blocks
+    "llm_chat_block_1": {"extra_body": {"chat_template_kwargs": {"enable_thinking": False}}},
     }
 )
 ```


### PR DESCRIPTION
## Summary
- Fix parameter naming in flow overview docs (changed 'parameters' to 'runtime_params')
- Add new section documenting block-specific runtime arguments
- Include example for disabling thinking mode in LLM blocks

## Changes
- Updated code examples to use correct `runtime_params` argument name
- Added "Block-Specific Runtime Arguments" section with practical examples

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated runtime configuration terminology from “parameters” to “runtime_params,” with revised labels.
  * Simplified examples by removing the enable_evaluation flag.
  * Added guidance and examples for per-block runtime overrides via runtime_params keyed by block IDs (e.g., disabling thinking mode for a specific LLM block).
  * Clarified coverage of global runtime parameters vs. per-block overrides, showing how runtime_params complements YAML configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->