### PR TITLE
Remove openai dependency in pyproject toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ dependencies = [
     "httpx>=0.25.0,<1.0.0",
     "jinja2",
     "litellm>=1.73.0,<1.75.0",
-    "openai>=1.13.3,<1.100.0", # cap before v1.100.0 to avoid breaking changes noted in https://github.com/openai/openai-python/issues/2564
     "rich",
     "pydantic>=2.0.0,<3.0.0",         # cap before v3; adjust the lower bound to the minimum v2.x you’ve tested
     "python-dotenv>=1.0.0,<2.0.0",    # cap before v2 to avoid breaking changes


### PR DESCRIPTION
## Overview

We should not be directly relying on openai as we have no code references to openai directly. All our completions invocations are through `litellm` and hence, issues like https://github.com/openai/openai-python/issues/2564 should be handled at litellm directly, and we should have no bearing to track versions for openai-python.

## Resolution

Removing openai dependency from `pyproject.toml` entirely