### PR TITLE
Revert "chore(deps): bump pypa/gh-action-pypi-publish from 1.12.4 to 1.13.0"

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -78,7 +78,7 @@ jobs:
                   path: dist
 
             - name: "Upload to Test PyPI"
-              uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+              uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
               with:
                   repository-url: https://test.pypi.org/legacy/
 
@@ -130,4 +130,4 @@ jobs:
                   rm ./dist/*.sigstore.json
 
             - name: "Upload to PyPI"
-              uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+              uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4


### PR DESCRIPTION
Reverts Red-Hat-AI-Innovation-Team/sdg_hub#381

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Updated the package publishing workflow to enhance reliability and consistency for Test PyPI and PyPI uploads.
  * Improves reproducibility and alignment between test and production release steps, ensuring smoother delivery of future releases.
  * No changes to application behavior or public interfaces; end users are unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->