### PR TITLE
Fix deduplication logic

### DIFF
--- a/src/sdg_hub/core/utils/datautils.py
+++ b/src/sdg_hub/core/utils/datautils.py
@@ -48,9 +48,14 @@ def validate_no_duplicates(dataset: Dataset) -> None:
             for col in df.columns:
                 if df[col].dtype == "object":  # Only check object columns
                     df[col] = df[col].apply(
-                        lambda x: tuple(x)
-                        if hasattr(x, "__iter__") and not isinstance(x, (str, bytes))
-                        else x
+                        lambda x: (
+                            tuple(sorted(x.items()))
+                            if isinstance(x, dict)
+                            else tuple(x)
+                            if hasattr(x, "__iter__")
+                            and not isinstance(x, (str, bytes))
+                            else x
+                        )
                     )
             duplicate_count = int(df.duplicated(keep="first").sum())
         else:

--- a/tests/utils/test_datautils.py
+++ b/tests/utils/test_datautils.py
@@ -110,3 +110,23 @@ def test_validate_no_duplicates_with_string_lists():
     # Before the fix, this would throw: TypeError: unhashable type: 'numpy.ndarray'
     with pytest.raises(FlowValidationError, match="contains 1 duplicate rows"):
         validate_no_duplicates(dataset)
+
+
+def test_validate_no_duplicates_with_dictionaries():
+    """Test that dictionaries with different values are not considered duplicates."""
+    # Test the edge case where dict keys are same but values differ - should NOT be duplicates, should not RAISE
+    dataset = Dataset.from_dict(
+        {
+            "config": [
+                {"model": "gpt-4", "temp": 0.7},
+                {
+                    "model": "gpt-4",
+                    "temp": 0.9,
+                },  # Same keys, different values - should NOT be duplicate
+            ]
+        }
+    )
+
+    # Should pass validation (no duplicates)
+    result = validate_no_duplicates(dataset)
+    assert result is None  # Should not raise any exception


### PR DESCRIPTION
## Summary

Fixed TypeError: unhashable type:  'numpy.ndarray' in validate_no_duplicates() function that occurred when datasets contained numpy arrays or other complex data structures. Addresses #398 

## Changes

- Added special pathway to handle `unhashable` types to allow pandas `.duplicated()` to work
- Added special handling for `dict` type (sometimes `unhashable` but `tuple()` enforcement would work unexpectedly)
- Updated function docstring to reflect the new approach
- All existing tests pass with no behavioral changes
- Added new tests for list and dict types in incoming dataset

## Test Plan
- Verified existing unit tests still pass
- Function now handles datasets with numpy arrays and complex data types
- Maintains same validation behavior and error messages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - More reliable duplicate detection for complex value types (numpy arrays/scalars, set-derived values, and lists).
  - Avoids errors on empty datasets with an early exit.
  - Consistent duplicate counting and clear user-facing error when duplicates are found.

- Refactor
  - Deterministic preprocessing of non-string iterable values to improve stability.

- Tests
  - Added tests covering duplicate detection for array-like, set-derived, list-of-string, and dict scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->