### PR TITLE
Fix: Adjust max_concurrency when n > 1 for LLM completion requests

### DIFF
--- a/src/sdg_hub/core/blocks/llm/client_manager.py
+++ b/src/sdg_hub/core/blocks/llm/client_manager.py
@@ -214,7 +214,10 @@ class LLMClientManager:
             messages_list = messages
 
             if max_concurrency is not None:
-                if max_concurrency < 1: raise ValueError('max_concurrency must be greater than 0, got {max_concurrency}')
+                if max_concurrency < 1:
+                    raise ValueError(
+                        "max_concurrency must be greater than 0, got {max_concurrency}"
+                    )
                 # Adjust concurrency based on n parameter to avoid overwhelming API
                 # when n > 1 (multiple completions per request)
                 n_value = overrides.get("n") or self.config.n or 1

--- a/tests/blocks/llm/test_llm_chat_block.py
+++ b/tests/blocks/llm/test_llm_chat_block.py
@@ -488,7 +488,9 @@ class TestLLMChatBlock:
 class TestErrorHandling:
     """Test error handling for LLMChatBlock."""
 
-    def test_max_concurrency_value_error(self, mock_litellm_acompletion, sample_dataset):
+    def test_max_concurrency_value_error(
+        self, mock_litellm_acompletion, sample_dataset
+    ):
         """Test ValueError is raised when max_concurrency < 1."""
         block = LLMChatBlock(
             block_name="test_max_concurrency_error",
@@ -500,15 +502,21 @@ class TestErrorHandling:
         )
 
         # Test with max_concurrency = 0
-        with pytest.raises(ValueError, match="max_concurrency must be greater than 0, got"):
+        with pytest.raises(
+            ValueError, match="max_concurrency must be greater than 0, got"
+        ):
             block.generate(sample_dataset, _flow_max_concurrency=0)
 
         # Test with max_concurrency = -1
-        with pytest.raises(ValueError, match="max_concurrency must be greater than 0, got"):
+        with pytest.raises(
+            ValueError, match="max_concurrency must be greater than 0, got"
+        ):
             block.generate(sample_dataset, _flow_max_concurrency=-1)
 
         # Test with max_concurrency = -5
-        with pytest.raises(ValueError, match="max_concurrency must be greater than 0, got"):
+        with pytest.raises(
+            ValueError, match="max_concurrency must be greater than 0, got"
+        ):
             block.generate(sample_dataset, _flow_max_concurrency=-5)
 
     def test_litellm_rate_limit_error(self, sample_dataset):


### PR DESCRIPTION
## Summary
- Adjust max_concurrency when n > 1 to prevent overwhelming LLM APIs with concurrent requests that each generate multiple completions
- Add warning when max_concurrency < n to help users optimize their configuration

## Changes
- Modified `LLMClientManager.acreate_completion()` to calculate `adjusted_concurrency = max(1, max_concurrency // n_value)` when `n > 1`
- Added warning log when `max_concurrency < n` to alert users about potentially suboptimal performance
- Added debug logging to show the concurrency adjustment calculation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Multi-completion requests (n > 1) now validate max_concurrency (>0), automatically reduce effective concurrency per-request, and emit warnings/debug logs when adjustments occur; single-completion behavior unchanged. No public API changes.

- **Tests**
  - Added extensive tests covering validation, concurrency adjustment, warning/debug messages, and runtime override behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->