### PR TITLE
chore: Init Packer GitHub workflow

### DIFF
--- a/.github/workflows/packer.yml
+++ b/.github/workflows/packer.yml
@@ -1,0 +1,15 @@
+name: Build AMI with Packer
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-ami:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # This is required for OIDC
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4


### PR DESCRIPTION
Add a basic workflow template to validate the proposed Packer GitHub workflow in #394. When merged into `main`, we should be able to test it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a manual workflow to build machine images (AMIs) using Packer.
- Chores
  - Added a GitHub Actions pipeline to streamline AMI builds, improving deployment readiness and consistency.
  - Configured secure permissions for workflow execution and repository access.
  - Included repository checkout step to ensure builds run against the latest code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->