### PR TITLE
fixing load_dataset caching side effect

### DIFF
--- a/src/sdg_hub/core/blocks/llm/llm_parser_block.py
+++ b/src/sdg_hub/core/blocks/llm/llm_parser_block.py
@@ -7,6 +7,7 @@ This module provides the LLMParserBlock for extracting specific fields
 
 # Standard
 from typing import Any
+from weakref import finalize
 import json
 
 # Third Party
@@ -15,7 +16,7 @@ from pydantic import Field, model_validator
 
 # Local
 from ...utils.logger_config import setup_logger
-from ...utils.temp_manager import cleanup_path, create_temp_file
+from ...utils.temp_manager import cleanup_path, create_temp_dir, create_temp_file
 from ..base import BaseBlock
 from ..registry import BlockRegistry
 
@@ -342,11 +343,24 @@ class LLMParserBlock(BaseBlock):
                 cleanup_path(tmp_jsonl_path)
             return Dataset.from_list([])
 
+        hf_cache_dir = None
         try:
-            ret = load_dataset(
-                "json", data_files=tmp_jsonl_path, split="train", keep_in_memory=False
+            hf_cache_dir = create_temp_dir(
+                prefix=f"{self.block_name}_llm_parser_hf_cache"
             )
+            ret = load_dataset(
+                "json",
+                data_files=tmp_jsonl_path,
+                split="train",
+                keep_in_memory=False,
+                cache_dir=str(hf_cache_dir),
+            )
+            finalize(ret, cleanup_path, hf_cache_dir)
             return ret
+        except Exception:
+            if hf_cache_dir is not None:
+                cleanup_path(hf_cache_dir)
+            raise
         finally:
             if cleanup_locally:
                 cleanup_path(tmp_jsonl_path)

--- a/src/sdg_hub/core/blocks/llm/text_parser_block.py
+++ b/src/sdg_hub/core/blocks/llm/text_parser_block.py
@@ -7,6 +7,7 @@ start/end tags, custom regex patterns, and cleanup operations.
 
 # Standard
 from typing import Any, Optional
+from weakref import finalize
 import json
 import re
 
@@ -16,7 +17,7 @@ from pydantic import Field, field_validator, model_validator
 
 # Local
 from ...utils.logger_config import setup_logger
-from ...utils.temp_manager import cleanup_path, create_temp_file
+from ...utils.temp_manager import cleanup_path, create_temp_dir, create_temp_file
 from ..base import BaseBlock
 from ..registry import BlockRegistry
 
@@ -345,11 +346,24 @@ class TextParserBlock(BaseBlock):
                 cleanup_path(tmp_jsonl_path)
             return Dataset.from_list([])
 
+        hf_cache_dir = None
         try:
-            ret = load_dataset(
-                "json", data_files=tmp_jsonl_path, split="train", keep_in_memory=False
+            hf_cache_dir = create_temp_dir(
+                prefix=f"{self.block_name}_text_parser_hf_cache"
             )
+            ret = load_dataset(
+                "json",
+                data_files=tmp_jsonl_path,
+                split="train",
+                keep_in_memory=False,
+                cache_dir=str(hf_cache_dir),
+            )
+            finalize(ret, cleanup_path, hf_cache_dir)
             return ret
+        except Exception:
+            if hf_cache_dir is not None:
+                cleanup_path(hf_cache_dir)
+            raise
         finally:
             if cleanup_locally:
                 cleanup_path(tmp_jsonl_path)


### PR DESCRIPTION
* Directed both `TextParserBlock` and `LLMParserBlock` to write Hugging Face dataset caches into block-specific temporary directories.
    * Registered `weakref.finalize` cleaners so the new cache directories are removed with the rest of the temporary resources.