### PR TITLE
migrate knowledge_utils to pandas

### DIFF
--- a/examples/knowledge_tuning/knowledge_utils.py
+++ b/examples/knowledge_tuning/knowledge_utils.py
@@ -339,7 +339,7 @@ def build_raft_dataset(ds: Dataset, p, num_doc_in_context=4):
     return ds
 
 
-def create_knowledge_regular_ds(generated_dataset: Dataset):
+def create_knowledge_regular_ds(generated_dataset: Dataset) -> Dataset | None:
     """
     Create a knowledge dataset for the Skills Phase of knowledge tuning.
 
@@ -348,13 +348,11 @@ def create_knowledge_regular_ds(generated_dataset: Dataset):
 
     Parameters
     ----------
-    generated_dataset : Dataset
-        The input dataset containing generated knowledge content
+    generated_dataset (Dataset): The input dataset containing generated knowledge content
 
     Returns
     -------
-    Dataset
-        Processed dataset ready for skills phase training
+    Dataset | None: Processed dataset ready for skills phase training, or None if concatenation fails.
     """
     knowledge_ds = generate_knowledge_qa_dataset(
         generated_dataset, keep_context_separate=True
@@ -371,7 +369,7 @@ def create_knowledge_regular_ds(generated_dataset: Dataset):
 
 def create_knowledge_pretraining_ds(
     generated_dataset: Dataset, add_auxiliary_dataset: bool = True
-):
+) -> Dataset | None:
     # Phase 0.7 (Knowledge Phase)
     """
     Create a knowledge dataset for the Knowledge Phase of knowledge tuning.
@@ -386,7 +384,7 @@ def create_knowledge_pretraining_ds(
 
     Returns
     -------
-    Dataset: The generated knowledge dataset.
+    Dataset | None: The generated knowledge dataset, or None if concatenation fails.
     """
     knowledge_ds = generate_knowledge_qa_dataset(
         generated_dataset, keep_context_separate=False
@@ -789,7 +787,7 @@ class DocProcessor:
 
         Returns
         -------
-            Dataset: Dataset object.
+            Dataset | None: Dataset object, or None if concatenation fails.
         """
         datasets = []
         for json_fp in self.docling_jsons:


### PR DESCRIPTION
knowledge_utils has been broken due to the migration to pandas in 7e2da17f26c04fa785e589303bb82ac1c7391a48.
This PR is to fix it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Safer dataset merging: intermediate conversion to tabular format during concatenation to improve stability and reduce merge-related errors.
  * Public processing paths now explicitly allow and propagate empty/no-data outcomes, returning no result when appropriate.

* **Bug Fixes**
  * Strengthened error handling in concatenation and reconstruction steps to avoid silent failures.

* **Documentation**
  * Updated public signatures and docstrings to reflect nullable return behavior.

* **Chores**
  * Removed an unnecessary top-level startup import.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->