### PR TITLE
Readability improvements for instructlab document pre-processing notebook

### DIFF
--- a/examples/knowledge_tuning/instructlab/document_pre_processing.ipynb
+++ b/examples/knowledge_tuning/instructlab/document_pre_processing.ipynb
@@ -28,8 +28,8 @@
     "### Using docling v1\n",
     "\n",
     "```python\n",
-    "data_dir = 'document_collection/ibm-annual-report'\n",
-    "!OMP_NUM_THREADS=32 mamba run -n docling python ../scripts/docparser.py --input-dir {data_dir} --output-dir {data_dir}\n",
+    "data_dir = \"document_collection/ibm-annual-report\"\n",
+    "!OMP_NUM_THREADS=32 mamba run -n docling python docparser.py --input-dir {data_dir} --output-dir {data_dir}\n",
     "```"
    ]
   },
@@ -47,7 +47,7 @@
    "outputs": [],
    "source": [
     "data_dir = \"document_collection/ibm-annual-report\"\n",
-    "# !OMP_NUM_THREADS=32 mamba run -n docling python ../scripts/docparser_v2.py --input-dir {data_dir} --output-dir {data_dir} --c docling_v2_config.yaml\n",
+    "# !OMP_NUM_THREADS=32 mamba run -n docling python docparser_v2.py --input-dir {data_dir} --output-dir {data_dir} --c docling_v2_config.yaml\n",
     "!python docparser_v2.py --input-dir {data_dir} --output-dir {data_dir} -c docling_v2_config.yaml"
    ]
   },
@@ -70,27 +70,29 @@
     "sys.path.insert(0, os.path.dirname(os.path.join(os.getcwd())))\n",
     "from knowledge_utils import DocProcessor\n",
     "\n",
-    "output_dir = f\"sdg_demo_output/\"\n",
-    "# This is where your PDFs are stored\n",
-    "# data_dir = '../document_collection/ibm-annual-report'\n",
+    "output_dir = \"sdg_demo_output\"\n",
+    "\n",
+    "# data_dir is where your PDFs are stored\n",
     "# It also have your QNA yaml file\n",
-    "dp = DocProcessor(data_dir, user_config_path=f\"{data_dir}/qna.yaml\")\n",
+    "user_config_path = f\"{data_dir}/qna.yaml\"\n",
+    "dp = DocProcessor(data_dir, user_config_path=user_config_path)\n",
     "\n",
     "### Using docling v1 json\n",
     "# seed_data = dp.get_processed_dataset()\n",
     "\n",
     "### Using markdown file\n",
-    "seed_data = dp.get_processed_markdown_dataset([f\"{data_dir}/ibm-annual-report-2024.md\"])\n",
-    "\n",
     "# Note: For now v2 json is not supported\n",
+    "list_md_files = [f\"{data_dir}/ibm-annual-report-2024.md\"]\n",
+    "seed_data = dp.get_processed_markdown_dataset(list_md_files)\n",
     "\n",
-    "seed_data.to_json(f\"{output_dir}/seed_data.jsonl\", orient=\"records\", lines=True)"
+    "seed_data_path = f\"{output_dir}/seed_data.jsonl\"\n",
+    "seed_data.to_json(seed_data_path, orient=\"records\", lines=True)"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "docling",
+   "display_name": "sdg_hub-py312",
    "language": "python",
    "name": "python3"
   },
@@ -104,7 +106,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.16"
+   "version": "3.12.11"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR improves the readability of instructlab document pre-processing notebook by introducing variables for hardcoded paths. E.g.,
Before
```python
dp = DocProcessor(data_dir, user_config_path=f"{data_dir}/qna.yaml")
```
After
```python
user_config_path = f"{data_dir}/qna.yaml"
dp = DocProcessor(data_dir, user_config_path=user_config_path)
```
It also updates some comments for readability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for user configuration paths in the document processing workflow.

* **Refactor**
  * Improved markdown seed data file handling and output formatting.

* **Chores**
  * Updated Python version to 3.12.11 and notebook kernel environment to sdg_hub-py312.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->