### PR TITLE
Store json files in the native format

### DIFF
--- a/examples/knowledge_tuning/instructlab/document_pre_processing.ipynb
+++ b/examples/knowledge_tuning/instructlab/document_pre_processing.ipynb
@@ -86,7 +86,7 @@
     "seed_data = dp.get_processed_markdown_dataset(list_md_files)\n",
     "\n",
     "seed_data_path = f\"{output_dir}/seed_data.jsonl\"\n",
-    "seed_data.to_json(seed_data_path, orient=\"records\", lines=True)"
+    "seed_data.to_json(seed_data_path, orient=\"records\", lines=True, force_ascii=False)"
    ]
   }
  ],

--- a/examples/knowledge_tuning/instructlab/knowledge_generation_ja.ipynb
+++ b/examples/knowledge_tuning/instructlab/knowledge_generation_ja.ipynb
@@ -430,7 +430,7 @@
     "\n",
     "messages_data = create_simple_qa_dataset(generated_data)\n",
     "os.makedirs(output_dir, exist_ok=True)\n",
-    "messages_data.to_json(f\"{output_dir}/messages_data.jsonl\")"
+    "messages_data.to_json(f\"{output_dir}/messages_data.jsonl\", force_ascii=False)"
    ]
   }
  ],


### PR DESCRIPTION
Here is a request from our client-facing team in Japan.
The request was to save the intermediate json files in the utf-8 format. They are currently saved in the default format, where multibyte characters are represented in the unicode escape format.
```
$ head -1 messages_data_teigaku-genzei-ibm-v6.jsonl
{"messages":[{"content":"\u4ee4\u548c\uff16\u5e74\u5206\u6240\u5f97\u7a0e\u306e\u5b9a\u984d\u6e1b\u7a0e\u306e\u5bfe\u8c61\u8005\u306f\u8ab0\u3067\u3059\u304b\uff1f","role":"user"},{"content":"\u4ee4\u548c\uff16\u5e74\u5206\u6240\u5f97\u7a0e\u306e\u5b9a\u984d\u6e1b\u7a0e\u306e\u5bfe\u8c61\u8005\u306f\u3001\u4ee4\u548c\uff16\u5e74\u5206\u6240\u5f97\u7a0e\u306e\u7d0d\u7a0e\u8005\u3067\u3001\u5c45\u4f4f\u8005\u3067\u3042\u308a\u3001\u5408\u8a08\u6240\u5f97\u91d1\u984d\u304c1,805\u4e07\u5186\u4ee5\u4e0b\u306e\u4eba\u3067\u3059\u3002\n\n","role":"assistant"}]}
```
By saving the text in the utf-8 format, the files become much smaller and easier to read.
```
$ head -1 messages_data_teigaku-genzei-ibm-v6.jsonl | jq -c
{"messages":[{"content":"令和６年分所得税の定額減税の対象者は誰ですか？","role":"user"},{"content":"令和６年分所得税の定額減税の対象者は、令和６年分所得税の納税者で、居住者であり、合計所得金額が1,805万円以下の人です。\n\n","role":"assistant"}]}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved non-ASCII character preservation when exporting serialized data to JSON files in knowledge tuning examples, enabling proper handling of international character sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->