### PR TITLE
Fix broken links in web docs with docsify, fix stale sections

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -52,11 +52,11 @@ Learn about the modular block architecture that powers SDG Hub:
 - **[Custom Blocks](blocks/custom-blocks.md)** - Building your own processing blocks
 
 ### Flow System
-Master the orchestration system for building complete pipelines:
-- **[Flow Overview](flows/overview.md)** - Understanding flow orchestration
-- **[YAML Configuration](flows/yaml-configuration.md)** - Structure and parameters
+Master the orchestration system for building complete flows:
+- **[Flow Overview](flows/overview.md)** - Understanding flow orchestration and YAML structure
 - **[Flow Discovery](flows/discovery.md)** - Registry and auto-discovery system
-- **[Custom Flows](flows/custom-flows.md)** - Building custom pipeline flows
+- **[Custom Flows](flows/custom-flows.md)** - Building custom flows
+- **[Available Flows](flows/available-flows.md)** - Pre-built flows in the ecosystem
 
 ### Advanced Topics
 - **[API Reference](api-reference.md)** - Complete API documentation

--- a/docs/blocks/overview.md
+++ b/docs/blocks/overview.md
@@ -141,7 +141,7 @@ result = block.generate(dataset)  # ❌ Error!
 
 Ready to dive deeper? Explore specific block categories:
 
-- **[LLM Blocks](llm-blocks.md)** - AI-powered language model operations
-- **[Transform Blocks](transform-blocks.md)** - Data manipulation and reshaping
-- **[Filtering Blocks](filtering-blocks.md)** - Quality control and validation
-- **[Custom Blocks](custom-blocks.md)** - Build your own processing blocks
+- **[LLM Blocks](blocks/llm-blocks.md)** - AI-powered language model operations
+- **[Transform Blocks](blocks/transform-blocks.md)** - Data manipulation and reshaping
+- **[Filtering Blocks](blocks/filtering-blocks.md)** - Quality control and validation
+- **[Custom Blocks](blocks/custom-blocks.md)** - Build your own processing blocks

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -187,6 +187,6 @@ print(f"Output columns: {result['final_dataset']['columns']}")
 Now that you understand the core concepts:
 
 1. **[Explore Block Types](blocks/overview.md)** - Learn about specific block categories
-2. **[Master Flow Configuration](flows/yaml-configuration.md)** - Deep dive into YAML structure
+2. **[Understand Flow System](flows/overview.md)** - Chain blocks into complete flows
 3. **[Build Custom Components](blocks/custom-blocks.md)** - Create your own blocks
-4. **[Advanced Patterns](flows/custom-flows.md)** - Build sophisticated pipelines
+4. **[Advanced Patterns](flows/custom-flows.md)** - Build sophisticated flows

--- a/docs/flows/discovery.md
+++ b/docs/flows/discovery.md
@@ -467,6 +467,6 @@ If your new tag represents a common pattern others might use, consider updating 
 Master flow discovery and organization:
 
 - **[Custom Flows](custom-flows.md)** - Build and organize your own flows
-- **[YAML Configuration](yaml-configuration.md)** - Advanced configuration techniques
+- **[Flow Overview](overview.md)** - YAML structure and configuration
 - **[Development Guide](../development.md)** - Contribute flows to the ecosystem
 - **[API Reference](../api-reference.md)** - Complete technical documentation


### PR DESCRIPTION
## Fix broken documentation links in Docsify

### Summary
Fixed broken internal links in documentation that were causing 404 errors when clicking navigation links in the Docsify site.

### Changes
- **Fixed missing file references**: Replaced all references to non-existent `flows/yaml-configuration.md` with `flows/overview.md`
- **Updated link text**: Changed "Master Flow Configuration" to "Understand Flow System" for consistency with current terminology
- **Consolidated content**: Merged YAML configuration link into Flow Overview description in README
- **Fixed relative paths**: Corrected link paths in `blocks/overview.md` to use proper Docsify routing

### Files Changed
- `docs/blocks/overview.md` - Fixed block category links
- `docs/concepts.md` - Updated flow system link and description
- `docs/README.md` - Removed broken link, added Available Flows link
- `docs/flows/discovery.md` - Fixed YAML configuration link

All internal documentation links now work correctly on Docsify webpages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation structure and navigation links for improved discoverability.
  * Standardized terminology across documentation (flows vs. pipelines).
  * Reorganized documentation sections for better clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->