### PR TITLE
docs: replace block example TODO with reference link

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -26,8 +26,7 @@ SDG Hub organizes blocks into logical categories:
 | **Filtering** | Quality control | Value-based filtering, threshold checks |
 | **Evaluation** | Quality assessment | Faithfulness scoring, relevancy evaluation |
 
-### Block Example
-#TODO: Add block example
+For detailed block examples and usage patterns, see [Block System Overview](blocks/overview.md).
 
 ## 🌊 Flows: Orchestrating Pipelines
 


### PR DESCRIPTION
## Summary
Replaced TODO comment with a reference link to the Block System Overview documentation for detailed examples and usage patterns.

## Changes
- Removed TODO at block example section in `docs/concepts.md`
- Added reference link pointing to `blocks/overview.md` for detailed examples

Closes #432

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated conceptual documentation with enhanced reference materials for block system details and usage patterns.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->