### PR TITLE
docs: replace flow structure TODO with reference link

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -33,9 +33,6 @@ SDG Hub organizes blocks into logical categories:
 
 **Flows** are YAML-defined pipelines that orchestrate multiple blocks into complete data processing workflows.
 
-### Flow Structure
-#TODO: Add flow structure
-
 ### Flow Execution Model
 
 Flows execute blocks sequentially:
@@ -57,6 +54,8 @@ Each block:
 - **⚙️ Parameterization** - Customize behavior without code changes
 - **🛡️ Validation** - Built-in checks for configuration and data compatibility
 - **📊 Monitoring** - Execution tracking and performance metrics
+
+For detailed flow structure and YAML configuration examples, see [Flow System Overview](flows/overview.md).
 
 ## 🔍 Auto-Discovery System
 


### PR DESCRIPTION
## Summary
Replaced Flow Structure TODO with a reference link to Flow System Overview documentation.

## Changes
- Removed Flow Structure subsection with TODO comment in `docs/concepts.md`
- Added reference link at the end of Flows section pointing to `flows/overview.md` for detailed structure and YAML configuration examples

Closes #433

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Removed outdated placeholder sections from documentation
* Added cross-references to Flow System Overview, improving navigation to flow structure information and YAML configuration examples

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->