### PR TITLE
fix: lighten integration test dependencies

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -127,6 +127,7 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
+          # Uses .[dev,integration] - lightweight, no torch/transformers
           tox -e py3-integrationcov
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,22 +51,7 @@ source = "https://github.com/Red-Hat-AI-Innovation-Team/sdg_hub"
 issues = "https://github.com/Red-Hat-AI-Innovation-Team/sdg_hub/issues"
 
 [project.optional-dependencies]
-examples = [
-    "tabulate>=0.9.0",
-    "transformers>=4.37.0",
-    "langchain-text-splitters",
-    "docling>=2.3.0",
-    "scikit-learn",
-    "polars",
-    "matplotlib",
-    "spacy",
-    "nltk",
-    "sentence-transformers",
-    "instructor",
-    "fastapi",
-    "nest-asyncio",
-    "ipykernel",
-]
+# Development and testing dependencies (lightweight, no ML libraries)
 dev = [
     "pre-commit>=3.0.4,<4.0",
     "pylint>=2.16.2,<4.0",
@@ -80,6 +65,28 @@ dev = [
     "pytest-env",
     # Integration testing dependencies
     "nbconvert>=7.0.0",
+]
+# Minimal dependencies for integration testing only
+# Integration tests run knowledge_generation.ipynb which only needs nest-asyncio
+integration = [
+    "nest-asyncio",
+]
+# Heavy dependencies for example notebooks (knowledge_mixing.ipynb, etc.)
+# NOT required for core functionality testing or integration tests
+examples = [
+    "tabulate>=0.9.0",
+    "transformers>=4.37.0",      # For knowledge_mixing.ipynb, NOT integration tests
+    "langchain-text-splitters",
+    "docling>=2.3.0",            # For document parsing examples
+    "scikit-learn",              # For raft_builder.py utility
+    "polars",                     # For knowledge_mixing_utils.py
+    "matplotlib",
+    "spacy",
+    "nltk",
+    "sentence-transformers",
+    "instructor",
+    "fastapi",
+    "ipykernel",
 ]
 
 [tool.setuptools_scm]

--- a/tox.ini
+++ b/tox.ini
@@ -22,28 +22,30 @@ commands =
     integration: {envpython} -m pytest {posargs:tests/integration}
 
 # Integration test environment - runs notebook-based integration tests
+# Lightweight: only requires nest-asyncio, NO torch/transformers needed
 [testenv:py3-integration]
-description = run integration tests (notebooks)
+description = run integration tests (notebooks) - lightweight, no torch/transformers needed
 package = wheel
 wheel_build_env = pkg
 passenv =
     OPENAI_API_KEY
 deps =
     .[dev]
-    .[examples]
+    .[integration]
 commands =
     {envpython} -m pytest {posargs:tests/integration -v -s}
 
 # Integration test environment with coverage - runs notebook-based integration tests with coverage collection
+# Lightweight: only requires nest-asyncio, NO torch/transformers needed
 [testenv:py3-integrationcov]
-description = run integration tests (notebooks) with coverage
+description = run integration tests (notebooks) with coverage - lightweight, no torch/transformers needed
 package = wheel
 wheel_build_env = pkg
 passenv =
     OPENAI_API_KEY
 deps =
     .[dev]
-    .[examples]
+    .[integration]
 commands =
     {envpython} -m pytest --cov=sdg_hub --cov-report term --cov-report=html:coverage-{env_name} --cov-report=xml:coverage-{env_name}.xml --html=durations/{env_name}.html tests/integration {posargs:-v -s}
 


### PR DESCRIPTION
## Changes

- Add [integration] group with only nest-asyncio
- Change tox integration envs from .[examples] to .[integration]
- knowledge_generation.ipynb only needs nest-asyncio, not torch/transformers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized development and testing dependencies for better maintainability.
  * Updated integration test configuration for improved test execution clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->