### PR TITLE
chore: raise litellm version cap to <2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "datasets>=4.0.0",
     "httpx>=0.25.0,<1.0.0",
     "jinja2",
-    "litellm>=1.73.0,<1.75.0",
+    "litellm>=1.73.0,<2.0.0",         # raising cap since tests run without errors related to 'backoff' cap back to <1.75.0 if errors surface
     "rich",
     "pandas",
     "pydantic>=2.0.0,<3.0.0",         # cap before v3; adjust the lower bound to the minimum v2.x you’ve tested


### PR DESCRIPTION
## Summary
- Raises litellm version cap from `<1.75.0` to `<2.0.0`
- The original cap was added due to backoff-related errors in v1.75+, which appear to be resolved

## Test plan
- [x] All 608 unit tests pass with litellm 1.80.16
- [x] Integration test passes
- [x] All litellm imports work correctly (error_handler.py, llm_chat_block.py)
- [x] LLMChatBlock and LLMErrorHandler instantiation verified
- [x] Tenacity + litellm retry integration confirmed working

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated litellm dependency to support versions up to 2.0.0, enabling compatibility with a broader range of library versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->