### PR TITLE
fix: Add model_post_init to RenameColumnsBlock

### DIFF
--- a/src/sdg_hub/core/blocks/transform/rename_columns.py
+++ b/src/sdg_hub/core/blocks/transform/rename_columns.py
@@ -55,6 +55,16 @@ class RenameColumnsBlock(BaseBlock):
             )
         return v
 
+    def model_post_init(self, __context: Any) -> None:
+        """Initialize derived attributes after Pydantic validation."""
+        super().model_post_init(__context) if hasattr(
+            super(), "model_post_init"
+        ) else None
+
+        # Set output_cols to the new column names being created
+        if self.output_cols is None:
+            self.output_cols = list(self.input_cols.values())
+
     def generate(self, samples: pd.DataFrame, **kwargs: Any) -> pd.DataFrame:
         """Generate a dataset with renamed columns.
 

--- a/tests/blocks/transform/test_rename_columns.py
+++ b/tests/blocks/transform/test_rename_columns.py
@@ -83,3 +83,12 @@ def test_rename_columns_preserve_data():
     # Check that values are preserved
     assert result["new_name"].equals(dataset["old_name"])
     assert result["other_col"].equals(dataset["other_col"])
+
+
+def test_rename_columns_sets_output_cols():
+    """Test that output_cols is automatically set from input_cols values."""
+    block = RenameColumnsBlock(
+        block_name="test",
+        input_cols={"old_col": "new_col", "another": "renamed"},
+    )
+    assert block.output_cols == ["new_col", "renamed"]


### PR DESCRIPTION
Closes #543

## Summary
- Add `model_post_init` to `RenameColumnsBlock` to set `output_cols` from `input_cols.values()`
- Matches the pattern used by `DuplicateColumnsBlock`
- Add unit test to verify `output_cols` is automatically set

## Test plan
- [x] `test_rename_columns_sets_output_cols` verifies output_cols is set
- [x] All 5 rename columns tests pass

## Test script

```python
# Test that RenameColumnsBlock now exposes output_cols correctly
from sdg_hub.core.blocks.transform.rename_columns import RenameColumnsBlock
from sdg_hub.core.blocks.transform.duplicate_columns import DuplicateColumnsBlock

# Test 1: RenameColumnsBlock sets output_cols automatically
print("Test 1: RenameColumnsBlock sets output_cols")
rename_block = RenameColumnsBlock(
    block_name="rename",
    input_cols={"old_col": "new_col", "another": "renamed"},
)
print(f"  input_cols: {rename_block.input_cols}")
print(f"  output_cols: {rename_block.output_cols}")

# Test 2: Compare with DuplicateColumnsBlock (reference implementation)
print("\nTest 2: DuplicateColumnsBlock (reference) also sets output_cols")
dup_block = DuplicateColumnsBlock(
    block_name="duplicate",
    input_cols={"source": "copy"},
)
print(f"  input_cols: {dup_block.input_cols}")
print(f"  output_cols: {dup_block.output_cols}")

# Test 3: Both blocks now follow the same pattern
print("\nTest 3: Both blocks follow the same model_post_init pattern")
print(f"  RenameColumnsBlock has model_post_init: {hasattr(RenameColumnsBlock, 'model_post_init')}")
print(f"  DuplicateColumnsBlock has model_post_init: {hasattr(DuplicateColumnsBlock, 'model_post_init')}")
```

## Test output

```
[17:31:53] WARNING  Block 'LLMParserBlock' is deprecated. Use    registry.py:127
                    'LLMResponseExtractorBlock' instead.                        
Test 1: RenameColumnsBlock sets output_cols
  input_cols: {'old_col': 'new_col', 'another': 'renamed'}
  output_cols: ['new_col', 'renamed']

Test 2: DuplicateColumnsBlock (reference) also sets output_cols
  input_cols: {'source': 'copy'}
  output_cols: ['copy']

Test 3: Both blocks follow the same model_post_init pattern
  RenameColumnsBlock has model_post_init: True
  DuplicateColumnsBlock has model_post_init: True
```

## Unit tests

```
$ pytest tests/blocks/transform/test_rename_columns.py -v
5 passed
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The rename columns block now automatically derives output column names from input column mappings when not explicitly specified.

* **Tests**
  * Added test coverage for automatic output column derivation functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->