### PR TITLE
feat: add TranslationBlock for multilingual SDG

### DIFF
--- a/examples/translation/README.md
+++ b/examples/translation/README.md
@@ -1,0 +1,207 @@
+# Translation Examples
+
+This directory contains examples demonstrating the use of the **TranslationBlock** for multilingual synthetic data generation.
+
+## Overview
+
+The **TranslationBlock** is an LLM-powered block that translates prompt scaffolding from one language to another while intelligently preserving content that is already in the target language. This is particularly useful for multilingual knowledge tuning workflows where:
+
+1. **Prompt templates** are in English (e.g., instructions, formatting rules)
+2. **Source documents and ICL examples** are already translated to the target language
+3. You want to translate only the scaffolding without touching the source content
+
+## How It Works
+
+The TranslationBlock uses an LLM with a carefully crafted prompt to:
+
+1. **Detect language boundaries** - Identifies which parts of the text are in the source language vs. target language
+2. **Translate selectively** - Translates only the source language text (e.g., English instructions)
+3. **Preserve structure** - Maintains all formatting, tags, and structure exactly
+4. **Protect target language content** - Leaves already-translated content completely unchanged
+
+This LLM-based approach is simple, flexible, and handles edge cases automatically without requiring hardcoded patterns.
+
+## Example: Spanish Knowledge Tuning
+
+See [spanish_knowledge_tuning_flow_example.yaml](./spanish_knowledge_tuning_flow_example.yaml) for a complete flow that:
+
+1. Builds an English prompt with Spanish documents and ICL examples
+2. Translates the English scaffolding to Spanish (preserving Spanish content)
+3. Generates Spanish Q&A pairs
+4. Parses and extracts the results
+
+### Flow Structure
+
+```yaml
+blocks:
+  # Step 1: Build prompt with English template + Spanish data
+  - block_type: PromptBuilderBlock
+    input_cols:
+      document_spanish: document
+      icl_document_spanish: icl_document
+      # ...
+    output_cols: english_prompt
+
+  # Step 2: Translate English scaffolding to Spanish
+  - block_type: TranslationBlock
+    input_cols: english_prompt
+    output_cols: spanish_prompt
+    source_language: "en"
+    target_language: "es"
+    temperature: 0.3  # Low temp for consistency
+
+  # Step 3: Generate Spanish Q&A
+  - block_type: LLMChatBlock
+    input_cols: spanish_prompt
+    output_cols: raw_response
+```
+
+## Usage in Python
+
+```python
+from sdg_hub.core.blocks.llm import TranslationBlock
+from sdg_hub.core.flow import Flow
+import pandas as pd
+
+# Create a TranslationBlock
+translation_block = TranslationBlock(
+    block_name="translate_to_spanish",
+    input_cols="english_prompt",
+    output_cols="spanish_prompt",
+    source_language="en",
+    target_language="es",
+    model="openai/gpt-4",
+    temperature=0.3,
+    max_tokens=8192
+)
+
+# Use in a dataset
+df = pd.DataFrame({
+    "english_prompt": [
+        [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Generate questions about: El documento en español..."}
+        ]
+    ]
+})
+
+result = translation_block.generate(df)
+print(result["spanish_prompt"][0])
+# Output: [
+#   {"role": "system", "content": "Eres un asistente útil."},
+#   {"role": "user", "content": "Genera preguntas sobre: El documento en español..."}
+# ]
+```
+
+## Supported Languages
+
+The TranslationBlock supports ISO 639-1 language codes. Common codes include:
+
+- `en` - English
+- `es` - Spanish
+- `fr` - French
+- `de` - German
+- `ja` - Japanese
+- `zh` - Chinese
+- `pt` - Portuguese
+- `ru` - Russian
+- `ar` - Arabic
+- `hi` - Hindi
+- `it` - Italian
+- `ko` - Korean
+
+You can use any language code - if it's not in the predefined list, the block will still work using the title-cased version of the code.
+
+## Key Features
+
+### 1. Format Agnostic
+
+Handles both **messages format** (list of dicts) and **plain text**:
+
+```python
+# Messages format
+messages = [{"role": "user", "content": "Hello"}]
+
+# Plain text
+text = "Hello world"
+```
+
+### 2. Async Support
+
+For large batches, use async mode:
+
+```python
+block = TranslationBlock(
+    ...,
+    async_mode=True
+)
+
+# Can be controlled at flow level with max_concurrency
+output = flow.generate(dataset, max_concurrency=50)
+```
+
+### 3. LiteLLM Integration
+
+Supports 100+ LLM providers via LiteLLM:
+
+```python
+# OpenAI
+model="openai/gpt-4"
+
+# Anthropic
+model="anthropic/claude-3-sonnet-20240229"
+
+# Local vLLM
+model="hosted_vllm/meta-llama/Llama-3-8B"
+api_base="http://localhost:8000/v1"
+```
+
+### 4. Configurable Parameters
+
+All LiteLLM parameters are supported:
+
+```python
+TranslationBlock(
+    ...,
+    temperature=0.3,      # Lower for more deterministic translation
+    max_tokens=8192,      # Large enough for full prompts
+    top_p=0.9,
+    frequency_penalty=0.0,
+    presence_penalty=0.0
+)
+```
+
+## Best Practices
+
+1. **Use low temperature (0.2-0.4)** for translation to ensure consistency
+2. **Set appropriate max_tokens** - translations can be longer than source text
+3. **Test with sample data** first to verify the LLM preserves your target language content
+4. **Use async_mode** for large datasets to maximize throughput
+5. **Monitor costs** - translation requires one LLM call per prompt (or per message if using messages format)
+
+## Troubleshooting
+
+### Issue: Translation changes my source documents
+
+**Solution**: The translation LLM should detect and preserve target language content automatically. If this happens:
+- Check that your source documents are clearly in the target language
+- Try a more capable model (e.g., GPT-4 instead of GPT-3.5)
+- Verify the source/target language codes are correct
+
+### Issue: Translations are inconsistent
+
+**Solution**: Lower the temperature parameter:
+```yaml
+temperature: 0.2  # More deterministic
+```
+
+### Issue: Out of memory with large prompts
+
+**Solution**: Increase max_tokens or split into smaller chunks:
+```yaml
+max_tokens: 16384  # Larger limit
+```
+
+## License
+
+Apache-2.0

--- a/examples/translation/quality_to_spanish_example.py
+++ b/examples/translation/quality_to_spanish_example.py
@@ -1,0 +1,154 @@
+"""
+Example usage of the QuALITY to Spanish translation flow.
+
+This script demonstrates how to:
+1. Load the QuALITY dataset
+2. Configure the translation flow with specific models
+3. Run translation on a subset of documents
+4. Inspect and save the results
+"""
+
+from datasets import load_dataset
+from sdg_hub.core.flow import Flow
+
+def main():
+    # ==========================================
+    # 1. Load QuALITY Dataset
+    # ==========================================
+    print("Loading QuALITY dataset...")
+    dataset = load_dataset("zitongyang/entigraph-quality-corpus", split="train")
+
+    # For testing, use a small subset (e.g., first 5 documents)
+    # For production, remove or increase this limit
+    dataset = dataset.select(range(5))
+
+    print(f"Loaded {len(dataset)} documents for translation")
+    print(f"Columns: {dataset.column_names}")
+
+    # ==========================================
+    # 2. Load Translation Flow
+    # ==========================================
+    print("\nLoading translation flow...")
+    flow = Flow.from_registry("translation/quality_to_spanish")
+
+    # ==========================================
+    # 3. Configure Models (External Configuration)
+    # ==========================================
+    print("\nConfiguring translation models...")
+
+    # Set translation model (GPT-4o recommended for cost/quality balance)
+    translation_blocks = [
+        "translate_document_llm",
+        "translate_icl_document_llm",
+        "translate_icl_query_1_llm",
+        "translate_icl_query_2_llm",
+        "translate_icl_query_3_llm",
+        "translate_domain_llm"
+    ]
+
+    for block_name in translation_blocks:
+        flow.set_model_config(
+            block_name,
+            model_name="gpt-4o-2024-11-20",
+            # Optional: Add provider-specific parameters
+            # api_key="your-api-key",  # If not using environment variables
+        )
+
+    # Set verification model (Claude 3.5 Sonnet for strong evaluation)
+    flow.set_model_config(
+        "verify_translation_llm",
+        model_name="claude-3-5-sonnet-20241022",
+        # Optional: Add provider-specific parameters
+        # api_key="your-api-key",  # If not using environment variables
+    )
+
+    print("Models configured:")
+    print(f"  Translation: gpt-4o-2024-11-20")
+    print(f"  Verification: claude-3-5-sonnet-20241022")
+
+    # ==========================================
+    # 4. Run Translation Flow
+    # ==========================================
+    print("\nRunning translation flow...")
+    print("This may take several minutes depending on the number of documents...")
+
+    translated_dataset = flow.run(dataset)
+
+    # ==========================================
+    # 5. Inspect Results
+    # ==========================================
+    print("\n" + "="*60)
+    print("TRANSLATION RESULTS")
+    print("="*60)
+
+    print(f"\nTotal documents processed: {len(translated_dataset)}")
+    print(f"Output columns: {translated_dataset.column_names}")
+
+    # Show summary statistics
+    if "translation_quality_score" in translated_dataset.column_names:
+        scores = [int(s) for s in translated_dataset["translation_quality_score"]]
+        print(f"\nTranslation Quality Scores:")
+        print(f"  Average: {sum(scores) / len(scores):.2f}")
+        print(f"  Min: {min(scores)}")
+        print(f"  Max: {max(scores)}")
+        print(f"  Score distribution:")
+        for score in range(1, 6):
+            count = scores.count(score)
+            print(f"    Score {score}: {count} ({count/len(scores)*100:.1f}%)")
+
+    # Display first translation example
+    print("\n" + "="*60)
+    print("EXAMPLE TRANSLATION (First Document)")
+    print("="*60)
+
+    example = translated_dataset[0]
+
+    print("\n[ENGLISH ORIGINAL (first 500 chars)]:")
+    print(example["document"][:500] + "...")
+
+    print("\n[SPANISH TRANSLATION (first 500 chars)]:")
+    print(example["document_spanish"][:500] + "...")
+
+    if "translation_quality_score" in example:
+        print(f"\n[QUALITY SCORE]: {example['translation_quality_score']}/5")
+        print(f"\n[QUALITY EXPLANATION]:")
+        print(example["translation_quality_explanation"][:500] + "...")
+
+    # ==========================================
+    # 6. Save Results
+    # ==========================================
+    output_path = "quality_spanish_translated.jsonl"
+    print(f"\n\nSaving translated dataset to {output_path}...")
+
+    translated_dataset.to_json(output_path)
+
+    print(f"✓ Translation complete! Results saved to {output_path}")
+
+    # ==========================================
+    # 7. Optional: Filter for High-Quality Only
+    # ==========================================
+    print("\n" + "="*60)
+    print("FILTERING FOR HIGH-QUALITY TRANSLATIONS")
+    print("="*60)
+
+    if "translation_quality_score" in translated_dataset.column_names:
+        # Note: The flow already includes a filter block for scores 4-5
+        # But if you want to manually filter later, you can do:
+        high_quality = translated_dataset.filter(
+            lambda x: int(x["translation_quality_score"]) >= 4
+        )
+
+        print(f"\nHigh-quality translations (score ≥4): {len(high_quality)}/{len(translated_dataset)}")
+
+        if len(high_quality) > 0:
+            high_quality_path = "quality_spanish_high_quality.jsonl"
+            high_quality.to_json(high_quality_path)
+            print(f"✓ High-quality subset saved to {high_quality_path}")
+
+
+if __name__ == "__main__":
+    # Make sure to set environment variables for API keys:
+    # export OPENAI_API_KEY="your-openai-key"
+    # export ANTHROPIC_API_KEY="your-anthropic-key"
+
+    main()

--- a/examples/translation/spanish_knowledge_tuning_flow_example.yaml
+++ b/examples/translation/spanish_knowledge_tuning_flow_example.yaml
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: Apache-2.0
+# Example flow demonstrating TranslationBlock for Spanish knowledge tuning
+# This flow shows how to translate English prompt scaffolding to Spanish while preserving
+# already-translated Spanish content (documents, ICL examples)
+
+metadata:
+  id: spanish-knowledge-tuning-example
+  name: "Spanish Knowledge Tuning with Translation"
+  description: "Generate Spanish knowledge tuning data by translating English prompt templates while preserving Spanish source documents"
+  version: "1.0.0"
+  author: "SDG Hub Contributors"
+
+  recommended_models:
+    default: "openai/gpt-4"
+    compatible: ["anthropic/claude-3-sonnet-20240229", "openai/gpt-3.5-turbo"]
+
+  tags:
+    - "translation"
+    - "multilingual"
+    - "spanish"
+    - "knowledge-tuning"
+
+  license: "Apache-2.0"
+
+  dataset_requirements:
+    required_columns:
+      - "document_spanish"          # Spanish document (already translated)
+      - "icl_document_spanish"      # Spanish ICL document
+      - "icl_query_1_spanish"       # Spanish ICL question 1
+      - "icl_query_2_spanish"       # Spanish ICL question 2
+      - "icl_query_3_spanish"       # Spanish ICL question 3
+      - "icl_response_1"            # ICL answer 1
+      - "icl_response_2"            # ICL answer 2
+      - "icl_response_3"            # ICL answer 3
+      - "domain"                    # Domain (e.g., "science", "history")
+      - "document_outline"          # Document outline/summary
+    description: "Input dataset should contain Spanish documents and ICL examples that are already translated and verified. The TranslationBlock will translate only the English prompt scaffolding."
+
+blocks:
+  # Step 1: Build English prompt using Spanish data
+  # This uses the standard English template but injects Spanish content
+  - block_type: PromptBuilderBlock
+    block_config:
+      block_name: build_english_prompt
+      input_cols:
+        document_spanish: document          # Map Spanish columns to template variables
+        icl_document_spanish: icl_document
+        icl_query_1_spanish: icl_query_1
+        icl_query_2_spanish: icl_query_2
+        icl_query_3_spanish: icl_query_3
+        icl_response_1: icl_response_1
+        icl_response_2: icl_response_2
+        icl_response_3: icl_response_3
+        domain: domain
+        document_outline: document_outline
+      output_cols: english_prompt
+      # Uses standard English template from instructlab flow
+      prompt_config_path: ../qa_generation/document_grounded_qa/multi_summary_qa/instructlab/generate_questions_responses.yaml
+      format_as_messages: true
+
+  # Step 2: Translate English prompt scaffolding to Spanish
+  # The LLM will detect Spanish content and preserve it unchanged
+  - block_type: TranslationBlock
+    block_config:
+      block_name: translate_to_spanish
+      input_cols: english_prompt
+      output_cols: spanish_prompt
+      source_language: "en"
+      target_language: "es"
+      # Translation-specific parameters
+      temperature: 0.3              # Low temperature for consistent translation
+      max_tokens: 8192              # Large enough for full prompts
+
+  # Step 3: Generate Spanish Q&A pairs
+  - block_type: LLMChatBlock
+    block_config:
+      block_name: generate_spanish_qa
+      input_cols: spanish_prompt
+      output_cols: raw_spanish_response
+      temperature: 0.7              # Higher temp for creative Q&A generation
+      max_tokens: 2048
+      async_mode: true
+
+  # Step 4: Parse the generated Q&A pairs
+  - block_type: LLMParserBlock
+    block_config:
+      block_name: parse_response
+      input_cols: raw_spanish_response
+      extract_content: true
+
+  # Step 5: Extract questions and answers
+  - block_type: TextParserBlock
+    block_config:
+      block_name: extract_qa_pairs
+      input_cols: parse_response_content
+      output_cols: [question_spanish, response_spanish]
+      parsing_pattern: "\\[(?:Question|QUESTION)\\]\\s*(.*?)\\s*\\[(?:Answer|ANSWER)\\]\\s*(.*?)\\s*(?=\\[(?:Question|QUESTION)\\]|$)"
+      parser_cleanup_tags: ["[END]"]

--- a/src/sdg_hub/core/blocks/llm/__init__.py
+++ b/src/sdg_hub/core/blocks/llm/__init__.py
@@ -12,6 +12,7 @@ from .llm_chat_block import LLMChatBlock
 from .llm_parser_block import LLMParserBlock
 from .prompt_builder_block import PromptBuilderBlock
 from .text_parser_block import TextParserBlock
+from .translation_block import TranslationBlock
 
 __all__ = [
     "LLMErrorHandler",
@@ -20,4 +21,5 @@ __all__ = [
     "LLMParserBlock",
     "PromptBuilderBlock",
     "TextParserBlock",
+    "TranslationBlock",
 ]

--- a/src/sdg_hub/core/blocks/llm/prompts/translate.yaml
+++ b/src/sdg_hub/core/blocks/llm/prompts/translate.yaml
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+# Translation prompt template for TranslationBlock
+# This template is used internally by TranslationBlock to translate text while preserving already-translated content
+
+- role: system
+  content: |
+    You are an expert technical translator.
+    Your task is to translate instructional and scaffolding text while preserving embedded content exactly.
+
+- role: user
+  content: |
+    Translate the following text from {{source_language_name}} to {{target_language_name}}.
+
+    CONTEXT:
+    The input may contain mixed-language content:
+    - Scaffolding, instructions, or rules written in {{source_language_name}} → TRANSLATE
+    - Embedded documents, examples, or data already written in {{target_language_name}} → DO NOT TRANSLATE
+
+    CRITICAL REQUIREMENTS (MUST FOLLOW):
+    1. Translate ONLY text written in {{source_language_name}}
+    2. Any text already in {{target_language_name}} MUST remain COMPLETELY UNCHANGED
+    3. Preserve ALL formatting, whitespace, punctuation, and line breaks EXACTLY
+    4. Preserve ALL structural markers and tags EXACTLY, including but not limited to:
+       [QUESTION], [ANSWER], [END], [DOCUMENT], [Document]
+    5. Content inside or between structural tags is likely already in {{target_language_name}} —
+       leave it unchanged unless it is clearly written in {{source_language_name}}
+    6. If you are unsure whether a segment is in {{source_language_name}} or {{target_language_name}},
+       DO NOT translate it
+    7. Do NOT add explanations, comments, notes, or metadata
+    8. Output ONLY the translated text
+
+    VERIFICATION STEP (INTERNAL — DO NOT OUTPUT):
+    Before finalizing your answer, verify that:
+    - No {{target_language_name}} text was modified
+    - No tags or formatting were altered
+    - Only {{source_language_name}} text was translated
+
+    ### BEGIN TRANSLATION LOGIC EXAMPLES ###
+    These examples demonstrate TRANSLATION LOGIC ONLY.
+    They are NOT part of the text to translate.
+
+    Example 1:
+    Input:
+    SOURCE_LANG scaffolding text
+    [DOCUMENT]
+    TARGET_LANG content
+    [END]
+
+    Output:
+    TARGET_LANG scaffolding text
+    [DOCUMENT]
+    TARGET_LANG content
+    [END]
+
+    Example 2:
+    Input:
+    SOURCE_LANG instruction
+    [QUESTION]
+    TARGET_LANG question content
+    [ANSWER]
+    TARGET_LANG answer content
+    [END]
+
+    Output:
+    TARGET_LANG instruction
+    [QUESTION]
+    TARGET_LANG question content
+    [ANSWER]
+    TARGET_LANG answer content
+    [END]
+
+    ### END TRANSLATION LOGIC EXAMPLES ###
+
+    Text to translate:
+    {{content}}

--- a/src/sdg_hub/core/blocks/llm/translation_block.py
+++ b/src/sdg_hub/core/blocks/llm/translation_block.py
@@ -1,0 +1,718 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Translation block for multilingual SDG using LLM-based translation."""
+
+# Standard
+from typing import Any, Dict, List, Optional
+import asyncio
+import os
+
+from jinja2 import Template
+from litellm import acompletion, completion
+from pydantic import ConfigDict, Field, field_validator
+import litellm
+import pandas as pd
+
+from ...utils.error_handling import BlockValidationError
+from ...utils.logger_config import setup_logger
+
+# Local
+from ..base import BaseBlock
+from ..registry import BlockRegistry
+
+litellm.drop_params = True
+logger = setup_logger(__name__)
+
+# ISO 639-1 language code to full name mapping
+LANGUAGE_NAMES = {
+    "en": "English",
+    "es": "Spanish",
+    "fr": "French",
+    "de": "German",
+    "ja": "Japanese",
+    "zh": "Chinese",
+    "pt": "Portuguese",
+    "ru": "Russian",
+    "ar": "Arabic",
+    "hi": "Hindi",
+    "it": "Italian",
+    "ko": "Korean",
+    "nl": "Dutch",
+    "pl": "Polish",
+    "sv": "Swedish",
+    "tr": "Turkish",
+    "vi": "Vietnamese",
+    "th": "Thai",
+    "id": "Indonesian",
+    "he": "Hebrew",
+}
+
+
+@BlockRegistry.register(
+    "TranslationBlock",
+    "llm",
+    "Translates prompts from source to target language using LLM",
+)
+class TranslationBlock(BaseBlock):
+    """Translates prompt content from source language to target language.
+
+    This block uses an LLM to intelligently translate prompt scaffolding while
+    preserving content that is already in the target language. It's designed for
+    multilingual synthetic data generation workflows where templates need translation
+    but injected content (documents, ICL examples) should remain unchanged.
+
+    Parameters
+    ----------
+    block_name : str
+        Unique identifier for the block.
+    input_cols : str
+        Input column containing prompts (messages or text format).
+    output_cols : str
+        Output column for translated prompts.
+    source_language : str
+        Source language ISO 639-1 code (e.g., "en" for English).
+    target_language : str
+        Target language ISO 639-1 code (e.g., "es" for Spanish).
+    model : Optional[str], optional
+        LiteLLM model identifier. Can be set via flow.set_model_config().
+    api_key : Optional[str], optional
+        API key for the provider. Falls back to environment variables.
+    api_base : Optional[str], optional
+        Base URL for the API. Required for local models.
+    async_mode : bool, optional
+        Whether to use async processing, by default False.
+    timeout : float, optional
+        Request timeout in seconds, by default 120.0.
+    num_retries : int, optional
+        Number of retry attempts, by default 6.
+    drop_params : bool, optional
+        Whether to drop unsupported parameters, by default True.
+    **kwargs : Any
+        Additional LiteLLM completion parameters (temperature, max_tokens, etc.).
+
+    Examples
+    --------
+    >>> # Translate English prompts to Spanish
+    >>> block = TranslationBlock(
+    ...     block_name="translate_to_spanish",
+    ...     input_cols="english_prompt",
+    ...     output_cols="spanish_prompt",
+    ...     source_language="en",
+    ...     target_language="es",
+    ...     model="openai/gpt-4",
+    ...     temperature=0.3
+    ... )
+
+    >>> # In a flow YAML
+    >>> # - block_type: TranslationBlock
+    >>> #   block_config:
+    >>> #     block_name: translate_prompt
+    >>> #     input_cols: english_prompt
+    >>> #     output_cols: spanish_prompt
+    >>> #     source_language: "en"
+    >>> #     target_language: "es"
+    >>> #     temperature: 0.3
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    # Translation-specific fields
+    source_language: str = Field(
+        ..., description="Source language ISO 639-1 code (e.g., 'en')"
+    )
+    target_language: str = Field(
+        ..., description="Target language ISO 639-1 code (e.g., 'es')"
+    )
+
+    # LiteLLM fields (same pattern as LLMChatBlock - all exclude=True)
+    model: Optional[str] = Field(
+        None, exclude=True, description="Model identifier in LiteLLM format"
+    )
+    api_key: Optional[str] = Field(
+        None, exclude=True, description="API key for the provider"
+    )
+    api_base: Optional[str] = Field(
+        None, exclude=True, description="Base URL for the API"
+    )
+    async_mode: bool = Field(
+        False, exclude=True, description="Whether to use async processing"
+    )
+    timeout: float = Field(
+        120.0, exclude=True, description="Request timeout in seconds"
+    )
+    num_retries: int = Field(
+        6, exclude=True, description="Number of retry attempts"
+    )
+    drop_params: bool = Field(
+        True, description="Whether to drop unsupported parameters"
+    )
+
+    @field_validator("source_language", "target_language")
+    @classmethod
+    def validate_language_code(cls, v: str) -> str:
+        """Validate that language code is supported."""
+        if v not in LANGUAGE_NAMES:
+            logger.warning(
+                "Language code '%s' not in predefined list. Proceeding anyway. "
+                "Supported codes: %s",
+                v,
+                ", ".join(sorted(LANGUAGE_NAMES.keys())),
+            )
+        return v
+
+    @field_validator("input_cols")
+    @classmethod
+    def validate_single_input_col(cls, v):
+        """Ensure exactly one input column."""
+        if isinstance(v, str):
+            return [v]
+        if isinstance(v, list) and len(v) == 1:
+            return v
+        if isinstance(v, list) and len(v) != 1:
+            raise ValueError(
+                f"TranslationBlock expects exactly one input column, got {len(v)}: {v}"
+            )
+        raise ValueError(f"Invalid input_cols format: {v}")
+
+    @field_validator("output_cols")
+    @classmethod
+    def validate_single_output_col(cls, v):
+        """Ensure exactly one output column."""
+        if isinstance(v, str):
+            return [v]
+        if isinstance(v, list) and len(v) == 1:
+            return v
+        if isinstance(v, list) and len(v) != 1:
+            raise ValueError(
+                f"TranslationBlock expects exactly one output column, got {len(v)}: {v}"
+            )
+        raise ValueError(f"Invalid output_cols format: {v}")
+
+    def model_post_init(self, __context) -> None:
+        """Initialize after Pydantic validation."""
+        super().model_post_init(__context)
+
+        # Load translation prompt template
+        template_path = os.path.join(
+            os.path.dirname(__file__), "prompts", "translate.yaml"
+        )
+        try:
+            with open(template_path, "r", encoding="utf-8") as f:
+                import yaml
+
+                self._translation_template = yaml.safe_load(f)
+        except FileNotFoundError as e:
+            raise BlockValidationError(
+                f"Translation prompt template not found at {template_path}"
+            ) from e
+
+        # Log initialization only when model is configured
+        if self.model:
+            logger.info(
+                "Initialized TranslationBlock '%s' translating %s → %s with model '%s'",
+                self.block_name,
+                self.source_language,
+                self.target_language,
+                self.model,
+                extra={
+                    "block_name": self.block_name,
+                    "source_language": self.source_language,
+                    "target_language": self.target_language,
+                    "model": self.model,
+                    "async_mode": self.async_mode,
+                },
+            )
+
+    def generate(self, samples: pd.DataFrame, **kwargs: Any) -> pd.DataFrame:
+        """Generate translated prompts.
+
+        Parameters
+        ----------
+        samples : pd.DataFrame
+            Input dataset containing the prompts column.
+        **kwargs : Any
+            Runtime parameters that override initialization defaults.
+
+        Returns
+        -------
+        pd.DataFrame
+            Dataset with translated prompts added to the output column.
+
+        Raises
+        ------
+        BlockValidationError
+            If model is not configured before calling generate().
+        """
+        # Validate that model is configured
+        if not self.model:
+            raise BlockValidationError(
+                f"Model not configured for block '{self.block_name}'. "
+                f"Call flow.set_model_config() before generating."
+            )
+
+        # Extract flow-specific parameters
+        flow_max_concurrency = kwargs.pop("_flow_max_concurrency", None)
+
+        # Build completion kwargs from ALL fields + runtime overrides
+        completion_kwargs = self._build_completion_kwargs(**kwargs)
+
+        # Extract prompts from pandas DataFrame
+        prompts_list = samples[self.input_cols[0]].tolist()
+
+        # Log generation start
+        logger.info(
+            "Starting %s translation for %d samples (%s → %s)%s",
+            "async" if self.async_mode else "sync",
+            len(prompts_list),
+            self.source_language,
+            self.target_language,
+            (
+                f" (max_concurrency={flow_max_concurrency})"
+                if flow_max_concurrency
+                else ""
+            ),
+            extra={
+                "block_name": self.block_name,
+                "batch_size": len(prompts_list),
+                "async_mode": self.async_mode,
+                "flow_max_concurrency": flow_max_concurrency,
+            },
+        )
+
+        # Generate translations
+        if self.async_mode:
+            try:
+                # Check if there's already a running event loop
+                loop = asyncio.get_running_loop()
+                # Check if nest_asyncio is applied
+                nest_asyncio_applied = (
+                    hasattr(loop, "_nest_patched")
+                    or getattr(asyncio.run, "__module__", "") == "nest_asyncio"
+                )
+
+                if nest_asyncio_applied:
+                    translations = asyncio.run(
+                        self._generate_async(
+                            prompts_list, completion_kwargs, flow_max_concurrency
+                        )
+                    )
+                else:
+                    raise BlockValidationError(
+                        f"async_mode=True cannot be used from within a running event loop for '{self.block_name}'. "
+                        "Use an async entrypoint, set async_mode=False, or apply nest_asyncio.apply() in notebook environments."
+                    )
+            except RuntimeError:
+                # No running loop; safe to create one
+                translations = asyncio.run(
+                    self._generate_async(
+                        prompts_list, completion_kwargs, flow_max_concurrency
+                    )
+                )
+        else:
+            translations = self._generate_sync(prompts_list, completion_kwargs)
+
+        # Log completion
+        logger.info(
+            "Translation completed successfully for %d samples",
+            len(translations),
+            extra={
+                "block_name": self.block_name,
+                "batch_size": len(translations),
+            },
+        )
+
+        # Add translations as new column
+        result = samples.copy()
+        result[self.output_cols[0]] = translations
+        return result
+
+    def _build_completion_kwargs(self, **overrides) -> dict[str, Any]:
+        """Build kwargs for LiteLLM completion call.
+
+        Returns
+        -------
+        dict[str, Any]
+            Kwargs for litellm.completion() or litellm.acompletion().
+        """
+        # Start with extra fields (temperature, max_tokens, etc.)
+        extra_values = self.model_dump(exclude_unset=True)
+
+        # Remove block-operational fields that shouldn't go to LiteLLM
+        block_only_fields = {
+            "block_name",
+            "input_cols",
+            "output_cols",
+            "async_mode",
+            "source_language",
+            "target_language",
+        }
+
+        completion_kwargs = {
+            k: v for k, v in extra_values.items() if k not in block_only_fields
+        }
+
+        # Add essential LiteLLM fields
+        if self.model is not None:
+            completion_kwargs["model"] = self.model
+        if self.api_key is not None:
+            completion_kwargs["api_key"] = self.api_key
+        if self.api_base is not None:
+            completion_kwargs["api_base"] = self.api_base
+        if self.timeout is not None:
+            completion_kwargs["timeout"] = self.timeout
+        if self.num_retries is not None:
+            completion_kwargs["num_retries"] = self.num_retries
+
+        # Apply non-block-field overrides
+        non_block_overrides = {
+            k: v for k, v in overrides.items() if k not in self.__class__.model_fields
+        }
+        completion_kwargs.update(non_block_overrides)
+
+        # Ensure drop_params is set
+        completion_kwargs["drop_params"] = self.drop_params
+
+        return completion_kwargs
+
+    def _detect_input_format(self, input_data: Any) -> str:
+        """Detect if input is messages format or plain text.
+
+        Parameters
+        ----------
+        input_data : Any
+            Input data to check.
+
+        Returns
+        -------
+        str
+            Either "messages" or "text".
+
+        Raises
+        ------
+        BlockValidationError
+            If input format is unsupported.
+        """
+        if isinstance(input_data, list) and all(
+            isinstance(msg, dict) and "role" in msg and "content" in msg
+            for msg in input_data
+        ):
+            return "messages"
+        elif isinstance(input_data, str):
+            return "text"
+        else:
+            raise BlockValidationError(
+                f"Unsupported input format: {type(input_data)}. "
+                f"Expected list of messages or string."
+            )
+
+    def _build_translation_prompt(self, content: str) -> List[Dict[str, str]]:
+        """Build translation prompt from template.
+
+        Parameters
+        ----------
+        content : str
+            Text content to translate.
+
+        Returns
+        -------
+        List[Dict[str, str]]
+            Messages list for LLM completion.
+        """
+        # Get language names
+        source_lang_name = LANGUAGE_NAMES.get(
+            self.source_language, self.source_language.title()
+        )
+        target_lang_name = LANGUAGE_NAMES.get(
+            self.target_language, self.target_language.title()
+        )
+
+        # Render template
+        messages = []
+        for msg_template in self._translation_template:
+            content_template = Template(msg_template["content"])
+            rendered_content = content_template.render(
+                source_language_name=source_lang_name,
+                target_language_name=target_lang_name,
+                content=content,
+            ).strip()
+            messages.append({"role": msg_template["role"], "content": rendered_content})
+
+        return messages
+
+    def _translate_text(self, text: str, completion_kwargs: dict[str, Any]) -> str:
+        """Translate a single text string using LLM.
+
+        Parameters
+        ----------
+        text : str
+            Text to translate.
+        completion_kwargs : dict[str, Any]
+            Kwargs for LiteLLM completion.
+
+        Returns
+        -------
+        str
+            Translated text.
+        """
+        # Build translation prompt
+        messages = self._build_translation_prompt(text)
+
+        # Call LLM
+        response = completion(messages=messages, **completion_kwargs)
+
+        # Extract translated text
+        translated_text = response.choices[0].message.content
+
+        return translated_text
+
+    async def _translate_text_async(
+        self, text: str, completion_kwargs: dict[str, Any]
+    ) -> str:
+        """Translate a single text string using LLM (async).
+
+        Parameters
+        ----------
+        text : str
+            Text to translate.
+        completion_kwargs : dict[str, Any]
+            Kwargs for LiteLLM acompletion.
+
+        Returns
+        -------
+        str
+            Translated text.
+        """
+        # Build translation prompt
+        messages = self._build_translation_prompt(text)
+
+        # Call LLM
+        response = await acompletion(messages=messages, **completion_kwargs)
+
+        # Extract translated text
+        translated_text = response.choices[0].message.content
+
+        return translated_text
+
+    def _translate_messages(
+        self, messages: List[Dict[str, str]], completion_kwargs: dict[str, Any]
+    ) -> List[Dict[str, str]]:
+        """Translate each message's content while preserving roles.
+
+        Parameters
+        ----------
+        messages : List[Dict[str, str]]
+            List of messages to translate.
+        completion_kwargs : dict[str, Any]
+            Kwargs for LiteLLM completion.
+
+        Returns
+        -------
+        List[Dict[str, str]]
+            Translated messages.
+        """
+        translated_messages = []
+        for msg in messages:
+            translated_content = self._translate_text(msg["content"], completion_kwargs)
+            translated_messages.append(
+                {"role": msg["role"], "content": translated_content}
+            )
+        return translated_messages
+
+    async def _translate_messages_async(
+        self, messages: List[Dict[str, str]], completion_kwargs: dict[str, Any]
+    ) -> List[Dict[str, str]]:
+        """Translate each message's content while preserving roles (async).
+
+        Parameters
+        ----------
+        messages : List[Dict[str, str]]
+            List of messages to translate.
+        completion_kwargs : dict[str, Any]
+            Kwargs for LiteLLM acompletion.
+
+        Returns
+        -------
+        List[Dict[str, str]]
+            Translated messages.
+        """
+        translated_messages = []
+        for msg in messages:
+            translated_content = await self._translate_text_async(
+                msg["content"], completion_kwargs
+            )
+            translated_messages.append(
+                {"role": msg["role"], "content": translated_content}
+            )
+        return translated_messages
+
+    def _generate_sync(
+        self,
+        prompts_list: List[Any],
+        completion_kwargs: dict[str, Any],
+    ) -> List[Any]:
+        """Generate translations synchronously.
+
+        Parameters
+        ----------
+        prompts_list : List[Any]
+            List of prompts to translate.
+        completion_kwargs : dict[str, Any]
+            Kwargs for LiteLLM completion.
+
+        Returns
+        -------
+        List[Any]
+            List of translated prompts.
+        """
+        translations = []
+
+        for i, prompt in enumerate(prompts_list):
+            try:
+                # Detect format
+                format_type = self._detect_input_format(prompt)
+
+                # Translate based on format
+                if format_type == "messages":
+                    translation = self._translate_messages(prompt, completion_kwargs)
+                else:  # text
+                    translation = self._translate_text(prompt, completion_kwargs)
+
+                translations.append(translation)
+
+                # Log progress for large batches
+                if (i + 1) % 10 == 0:
+                    logger.debug(
+                        "Translated %d/%d prompts",
+                        i + 1,
+                        len(prompts_list),
+                        extra={
+                            "block_name": self.block_name,
+                            "progress": f"{i + 1}/{len(prompts_list)}",
+                        },
+                    )
+
+            except Exception as e:
+                logger.error(
+                    "Failed to translate prompt %d: %s",
+                    i,
+                    str(e),
+                    extra={
+                        "block_name": self.block_name,
+                        "sample_index": i,
+                        "error": str(e),
+                    },
+                )
+                raise
+
+        return translations
+
+    async def _generate_async(
+        self,
+        prompts_list: List[Any],
+        completion_kwargs: dict[str, Any],
+        flow_max_concurrency: Optional[int] = None,
+    ) -> List[Any]:
+        """Generate translations asynchronously.
+
+        Parameters
+        ----------
+        prompts_list : List[Any]
+            List of prompts to translate.
+        completion_kwargs : dict[str, Any]
+            Kwargs for LiteLLM acompletion.
+        flow_max_concurrency : Optional[int], optional
+            Maximum concurrency for async requests.
+
+        Returns
+        -------
+        List[Any]
+            List of translated prompts.
+        """
+
+        async def translate_single(prompt: Any, semaphore: Optional[asyncio.Semaphore] = None) -> Any:
+            """Translate a single prompt with optional concurrency control."""
+            # Detect format
+            format_type = self._detect_input_format(prompt)
+
+            # Translate based on format
+            if semaphore:
+                async with semaphore:
+                    if format_type == "messages":
+                        return await self._translate_messages_async(
+                            prompt, completion_kwargs
+                        )
+                    else:  # text
+                        return await self._translate_text_async(
+                            prompt, completion_kwargs
+                        )
+            else:
+                if format_type == "messages":
+                    return await self._translate_messages_async(
+                        prompt, completion_kwargs
+                    )
+                else:  # text
+                    return await self._translate_text_async(prompt, completion_kwargs)
+
+        try:
+            if flow_max_concurrency is not None:
+                # Validate max_concurrency parameter
+                if flow_max_concurrency < 1:
+                    raise ValueError(
+                        f"max_concurrency must be greater than 0, got {flow_max_concurrency}"
+                    )
+
+                # Use semaphore for concurrency control
+                semaphore = asyncio.Semaphore(flow_max_concurrency)
+                tasks = [
+                    translate_single(prompt, semaphore) for prompt in prompts_list
+                ]
+            else:
+                # No concurrency limit
+                tasks = [translate_single(prompt) for prompt in prompts_list]
+
+            translations = await asyncio.gather(*tasks)
+            return translations
+
+        except Exception as e:
+            logger.error(
+                "Failed to generate async translations: %s",
+                str(e),
+                extra={
+                    "block_name": self.block_name,
+                    "batch_size": len(prompts_list),
+                    "error": str(e),
+                },
+            )
+            raise
+
+    def _validate_custom(self, dataset: pd.DataFrame) -> None:
+        """Custom validation for TranslationBlock input format.
+
+        Parameters
+        ----------
+        dataset : pd.DataFrame
+            The dataset to validate.
+
+        Raises
+        ------
+        BlockValidationError
+            If input format validation fails.
+        """
+        prompts_col = dataset[self.input_cols[0]]
+
+        # Check that all prompts are either messages or text
+        for idx, prompt in prompts_col.items():
+            try:
+                self._detect_input_format(prompt)
+            except BlockValidationError as e:
+                raise BlockValidationError(
+                    f"Invalid prompt format in row {idx}: {str(e)}",
+                    details=f"Block: {self.block_name}, Row: {idx}, Value type: {type(prompt)}",
+                ) from e
+
+    def __repr__(self) -> str:
+        """String representation of the block."""
+        return (
+            f"TranslationBlock(name='{self.block_name}', "
+            f"{self.source_language}→{self.target_language}, "
+            f"model='{self.model}', async_mode={self.async_mode})"
+        )

--- a/tests/blocks/llm/test_translation_block.py
+++ b/tests/blocks/llm/test_translation_block.py
@@ -1,0 +1,572 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for TranslationBlock."""
+
+# Standard
+from unittest.mock import MagicMock, patch
+
+# Third Party
+import pandas as pd
+import pytest
+
+# First Party
+from sdg_hub.core.blocks.llm import TranslationBlock
+from sdg_hub.core.utils.error_handling import BlockValidationError
+
+
+class MockMessage:
+    """Mock message class that behaves like LiteLLM message."""
+
+    def __init__(self, content):
+        self.content = content
+
+
+@pytest.fixture
+def mock_litellm_completion():
+    """Mock LiteLLM completion function."""
+    with patch(
+        "sdg_hub.core.blocks.llm.translation_block.completion"
+    ) as mock_completion:
+        mock_response = MagicMock()
+        choice = MagicMock()
+        choice.message = MockMessage("Traducido exitosamente")  # Translated text
+        mock_response.choices = [choice]
+        mock_completion.return_value = mock_response
+        yield mock_completion
+
+
+@pytest.fixture
+def mock_litellm_acompletion():
+    """Mock LiteLLM async completion function."""
+    with patch(
+        "sdg_hub.core.blocks.llm.translation_block.acompletion"
+    ) as mock_acompletion:
+        mock_response = MagicMock()
+        choice = MagicMock()
+        choice.message = MockMessage("Traducido async")  # Translated text
+        mock_response.choices = [choice]
+        mock_acompletion.return_value = mock_response
+        yield mock_acompletion
+
+
+class TestTranslationBlockInitialization:
+    """Test TranslationBlock initialization."""
+
+    def test_init_with_valid_params(self):
+        """Test initialization with valid parameters."""
+        block = TranslationBlock(
+            block_name="test_translation",
+            input_cols="english_text",
+            output_cols="spanish_text",
+            source_language="en",
+            target_language="es",
+            model="openai/gpt-4",
+        )
+
+        assert block.block_name == "test_translation"
+        assert block.input_cols == ["english_text"]
+        assert block.output_cols == ["spanish_text"]
+        assert block.source_language == "en"
+        assert block.target_language == "es"
+        assert block.model == "openai/gpt-4"
+
+    def test_init_with_unsupported_language_code(self, caplog):
+        """Test initialization with unsupported language code logs warning."""
+        block = TranslationBlock(
+            block_name="test_translation",
+            input_cols="text",
+            output_cols="translated",
+            source_language="en",
+            target_language="xyz",  # Unsupported code
+            model="openai/gpt-4",
+        )
+
+        assert block.target_language == "xyz"
+        # Check that warning was logged
+        assert "Language code 'xyz' not in predefined list" in caplog.text
+
+    def test_init_normalizes_input_cols(self):
+        """Test that input_cols is normalized to list."""
+        block = TranslationBlock(
+            block_name="test",
+            input_cols="text",  # String
+            output_cols="translated",
+            source_language="en",
+            target_language="es",
+            model="openai/gpt-4",
+        )
+
+        assert block.input_cols == ["text"]
+
+    def test_init_normalizes_output_cols(self):
+        """Test that output_cols is normalized to list."""
+        block = TranslationBlock(
+            block_name="test",
+            input_cols="text",
+            output_cols="translated",  # String
+            source_language="en",
+            target_language="es",
+            model="openai/gpt-4",
+        )
+
+        assert block.output_cols == ["translated"]
+
+    def test_init_rejects_multiple_input_cols(self):
+        """Test that multiple input columns are rejected."""
+        with pytest.raises(ValueError, match="exactly one input column"):
+            TranslationBlock(
+                block_name="test",
+                input_cols=["col1", "col2"],
+                output_cols="translated",
+                source_language="en",
+                target_language="es",
+                model="openai/gpt-4",
+            )
+
+    def test_init_rejects_multiple_output_cols(self):
+        """Test that multiple output columns are rejected."""
+        with pytest.raises(ValueError, match="exactly one output column"):
+            TranslationBlock(
+                block_name="test",
+                input_cols="text",
+                output_cols=["col1", "col2"],
+                source_language="en",
+                target_language="es",
+                model="openai/gpt-4",
+            )
+
+    def test_init_with_litellm_params(self):
+        """Test initialization with LiteLLM parameters."""
+        block = TranslationBlock(
+            block_name="test",
+            input_cols="text",
+            output_cols="translated",
+            source_language="en",
+            target_language="es",
+            model="openai/gpt-4",
+            temperature=0.3,
+            max_tokens=2048,
+            top_p=0.9,
+        )
+
+        # These should be stored via extra="allow"
+        assert hasattr(block, "temperature")
+        assert hasattr(block, "max_tokens")
+        assert hasattr(block, "top_p")
+
+
+class TestTranslationBlockFormatDetection:
+    """Test input format detection."""
+
+    def test_detect_messages_format(self):
+        """Test detection of messages format."""
+        block = TranslationBlock(
+            block_name="test",
+            input_cols="text",
+            output_cols="translated",
+            source_language="en",
+            target_language="es",
+            model="openai/gpt-4",
+        )
+
+        messages = [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Hello world"},
+        ]
+
+        assert block._detect_input_format(messages) == "messages"
+
+    def test_detect_text_format(self):
+        """Test detection of text format."""
+        block = TranslationBlock(
+            block_name="test",
+            input_cols="text",
+            output_cols="translated",
+            source_language="en",
+            target_language="es",
+            model="openai/gpt-4",
+        )
+
+        text = "Hello world"
+
+        assert block._detect_input_format(text) == "text"
+
+    def test_detect_invalid_format(self):
+        """Test detection of invalid format."""
+        block = TranslationBlock(
+            block_name="test",
+            input_cols="text",
+            output_cols="translated",
+            source_language="en",
+            target_language="es",
+            model="openai/gpt-4",
+        )
+
+        with pytest.raises(BlockValidationError, match="Unsupported input format"):
+            block._detect_input_format({"invalid": "format"})
+
+
+class TestTranslationBlockTextTranslation:
+    """Test translation of plain text."""
+
+    def test_translate_text_sync(self, mock_litellm_completion):
+        """Test synchronous text translation."""
+        block = TranslationBlock(
+            block_name="test",
+            input_cols="text",
+            output_cols="translated",
+            source_language="en",
+            target_language="es",
+            model="openai/gpt-4",
+        )
+
+        text = "Hello world"
+        completion_kwargs = {"model": "openai/gpt-4"}
+
+        result = block._translate_text(text, completion_kwargs)
+
+        assert result == "Traducido exitosamente"
+        mock_litellm_completion.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_translate_text_async(self, mock_litellm_acompletion):
+        """Test asynchronous text translation."""
+        block = TranslationBlock(
+            block_name="test",
+            input_cols="text",
+            output_cols="translated",
+            source_language="en",
+            target_language="es",
+            model="openai/gpt-4",
+        )
+
+        text = "Hello world"
+        completion_kwargs = {"model": "openai/gpt-4"}
+
+        result = await block._translate_text_async(text, completion_kwargs)
+
+        assert result == "Traducido async"
+        mock_litellm_acompletion.assert_called_once()
+
+
+class TestTranslationBlockMessagesTranslation:
+    """Test translation of messages format."""
+
+    def test_translate_messages_sync(self, mock_litellm_completion):
+        """Test synchronous messages translation."""
+        block = TranslationBlock(
+            block_name="test",
+            input_cols="messages",
+            output_cols="translated",
+            source_language="en",
+            target_language="es",
+            model="openai/gpt-4",
+        )
+
+        messages = [
+            {"role": "system", "content": "You are helpful"},
+            {"role": "user", "content": "Hello world"},
+        ]
+        completion_kwargs = {"model": "openai/gpt-4"}
+
+        result = block._translate_messages(messages, completion_kwargs)
+
+        assert len(result) == 2
+        assert result[0]["role"] == "system"
+        assert result[0]["content"] == "Traducido exitosamente"
+        assert result[1]["role"] == "user"
+        assert result[1]["content"] == "Traducido exitosamente"
+        assert mock_litellm_completion.call_count == 2  # Once per message
+
+    @pytest.mark.asyncio
+    async def test_translate_messages_async(self, mock_litellm_acompletion):
+        """Test asynchronous messages translation."""
+        block = TranslationBlock(
+            block_name="test",
+            input_cols="messages",
+            output_cols="translated",
+            source_language="en",
+            target_language="es",
+            model="openai/gpt-4",
+        )
+
+        messages = [
+            {"role": "system", "content": "You are helpful"},
+            {"role": "user", "content": "Hello world"},
+        ]
+        completion_kwargs = {"model": "openai/gpt-4"}
+
+        result = await block._translate_messages_async(messages, completion_kwargs)
+
+        assert len(result) == 2
+        assert result[0]["role"] == "system"
+        assert result[0]["content"] == "Traducido async"
+        assert result[1]["role"] == "user"
+        assert result[1]["content"] == "Traducido async"
+        assert mock_litellm_acompletion.call_count == 2
+
+
+class TestTranslationBlockGenerate:
+    """Test the main generate() method."""
+
+    def test_generate_with_text_format(self, mock_litellm_completion):
+        """Test generate with text format input."""
+        block = TranslationBlock(
+            block_name="test",
+            input_cols="text",
+            output_cols="translated",
+            source_language="en",
+            target_language="es",
+            model="openai/gpt-4",
+        )
+
+        df = pd.DataFrame({"text": ["Hello", "World"]})
+
+        result = block.generate(df)
+
+        assert "translated" in result.columns
+        assert len(result) == 2
+        assert result["translated"].tolist() == [
+            "Traducido exitosamente",
+            "Traducido exitosamente",
+        ]
+
+    def test_generate_with_messages_format(self, mock_litellm_completion):
+        """Test generate with messages format input."""
+        block = TranslationBlock(
+            block_name="test",
+            input_cols="messages",
+            output_cols="translated",
+            source_language="en",
+            target_language="es",
+            model="openai/gpt-4",
+        )
+
+        messages1 = [{"role": "user", "content": "Hello"}]
+        messages2 = [{"role": "user", "content": "World"}]
+
+        df = pd.DataFrame({"messages": [messages1, messages2]})
+
+        result = block.generate(df)
+
+        assert "translated" in result.columns
+        assert len(result) == 2
+        assert all(isinstance(msg, list) for msg in result["translated"])
+
+    def test_generate_without_model_raises_error(self):
+        """Test that generate() without model raises error."""
+        block = TranslationBlock(
+            block_name="test",
+            input_cols="text",
+            output_cols="translated",
+            source_language="en",
+            target_language="es",
+            # No model specified
+        )
+
+        df = pd.DataFrame({"text": ["Hello"]})
+
+        with pytest.raises(BlockValidationError, match="Model not configured"):
+            block.generate(df)
+
+    def test_generate_preserves_original_columns(self, mock_litellm_completion):
+        """Test that generate preserves original DataFrame columns."""
+        block = TranslationBlock(
+            block_name="test",
+            input_cols="text",
+            output_cols="translated",
+            source_language="en",
+            target_language="es",
+            model="openai/gpt-4",
+        )
+
+        df = pd.DataFrame({"text": ["Hello"], "other_col": ["data"]})
+
+        result = block.generate(df)
+
+        assert "text" in result.columns
+        assert "other_col" in result.columns
+        assert "translated" in result.columns
+
+
+class TestTranslationBlockValidation:
+    """Test custom validation logic."""
+
+    def test_validate_valid_text_format(self, mock_litellm_completion):
+        """Test validation accepts valid text format."""
+        block = TranslationBlock(
+            block_name="test",
+            input_cols="text",
+            output_cols="translated",
+            source_language="en",
+            target_language="es",
+            model="openai/gpt-4",
+        )
+
+        df = pd.DataFrame({"text": ["Hello", "World"]})
+
+        # Should not raise
+        block._validate_custom(df)
+
+    def test_validate_valid_messages_format(self, mock_litellm_completion):
+        """Test validation accepts valid messages format."""
+        block = TranslationBlock(
+            block_name="test",
+            input_cols="messages",
+            output_cols="translated",
+            source_language="en",
+            target_language="es",
+            model="openai/gpt-4",
+        )
+
+        messages1 = [{"role": "user", "content": "Hello"}]
+        messages2 = [{"role": "user", "content": "World"}]
+
+        df = pd.DataFrame({"messages": [messages1, messages2]})
+
+        # Should not raise
+        block._validate_custom(df)
+
+    def test_validate_invalid_format_raises_error(self, mock_litellm_completion):
+        """Test validation rejects invalid format."""
+        block = TranslationBlock(
+            block_name="test",
+            input_cols="text",
+            output_cols="translated",
+            source_language="en",
+            target_language="es",
+            model="openai/gpt-4",
+        )
+
+        df = pd.DataFrame({"text": [{"invalid": "format"}]})
+
+        with pytest.raises(BlockValidationError, match="Invalid prompt format"):
+            block._validate_custom(df)
+
+
+class TestTranslationBlockPromptBuilding:
+    """Test translation prompt building."""
+
+    def test_build_translation_prompt(self):
+        """Test building translation prompt from template."""
+        block = TranslationBlock(
+            block_name="test",
+            input_cols="text",
+            output_cols="translated",
+            source_language="en",
+            target_language="es",
+            model="openai/gpt-4",
+        )
+
+        content = "Hello world"
+        messages = block._build_translation_prompt(content)
+
+        assert isinstance(messages, list)
+        assert len(messages) == 2  # system + user
+        assert messages[0]["role"] == "system"
+        assert messages[1]["role"] == "user"
+        assert "English" in messages[1]["content"]
+        assert "Spanish" in messages[1]["content"]
+        assert "Hello world" in messages[1]["content"]
+
+    def test_build_translation_prompt_with_unsupported_language(self):
+        """Test prompt building with unsupported language code."""
+        block = TranslationBlock(
+            block_name="test",
+            input_cols="text",
+            output_cols="translated",
+            source_language="xyz",  # Unsupported
+            target_language="abc",  # Unsupported
+            model="openai/gpt-4",
+        )
+
+        content = "Hello world"
+        messages = block._build_translation_prompt(content)
+
+        # Should still work, using title-cased version of code
+        assert "Xyz" in messages[1]["content"]
+        assert "Abc" in messages[1]["content"]
+
+
+class TestTranslationBlockCompletionKwargs:
+    """Test building completion kwargs."""
+
+    def test_build_completion_kwargs_basic(self):
+        """Test building basic completion kwargs."""
+        block = TranslationBlock(
+            block_name="test",
+            input_cols="text",
+            output_cols="translated",
+            source_language="en",
+            target_language="es",
+            model="openai/gpt-4",
+            temperature=0.3,
+        )
+
+        kwargs = block._build_completion_kwargs()
+
+        assert kwargs["model"] == "openai/gpt-4"
+        assert kwargs["temperature"] == 0.3
+        assert kwargs["drop_params"] is True
+        assert "source_language" not in kwargs  # Block-only field
+        assert "target_language" not in kwargs  # Block-only field
+
+    def test_build_completion_kwargs_with_overrides(self):
+        """Test building completion kwargs with runtime overrides."""
+        block = TranslationBlock(
+            block_name="test",
+            input_cols="text",
+            output_cols="translated",
+            source_language="en",
+            target_language="es",
+            model="openai/gpt-4",
+            temperature=0.3,
+        )
+
+        kwargs = block._build_completion_kwargs(temperature=0.7, max_tokens=1000)
+
+        assert kwargs["temperature"] == 0.7  # Overridden
+        assert kwargs["max_tokens"] == 1000  # New param
+
+    def test_build_completion_kwargs_excludes_block_fields(self):
+        """Test that block-only fields are excluded from completion kwargs."""
+        block = TranslationBlock(
+            block_name="test",
+            input_cols="text",
+            output_cols="translated",
+            source_language="en",
+            target_language="es",
+            model="openai/gpt-4",
+        )
+
+        kwargs = block._build_completion_kwargs()
+
+        assert "block_name" not in kwargs
+        assert "input_cols" not in kwargs
+        assert "output_cols" not in kwargs
+        assert "source_language" not in kwargs
+        assert "target_language" not in kwargs
+        assert "async_mode" not in kwargs
+
+
+class TestTranslationBlockRepr:
+    """Test string representation."""
+
+    def test_repr(self):
+        """Test __repr__ output."""
+        block = TranslationBlock(
+            block_name="test_translation",
+            input_cols="text",
+            output_cols="translated",
+            source_language="en",
+            target_language="es",
+            model="openai/gpt-4",
+            async_mode=True,
+        )
+
+        repr_str = repr(block)
+
+        assert "TranslationBlock" in repr_str
+        assert "test_translation" in repr_str
+        assert "en→es" in repr_str
+        assert "openai/gpt-4" in repr_str
+        assert "async_mode=True" in repr_str


### PR DESCRIPTION
Add a new LLM-powered TranslationBlock that translates prompt scaffolding from one language to another while preserving content already in the target language.

## Discussion: 
In order to achieve generic multi-lingual SDG through sdg hub, I have 3 options that I have narrowed down, and I'd like to use this PR as space to discuss which to move forward with:

### Option 1: a TranslationBlock as already part of this PR's commit:

use a TranslationBlock on fully rendered prompts. This is the most sdg-hub native way, but it has notable drawbacks:

Pros:

- Works within SDG Hub paradigm
- No framework changes needed
- Blocks remain composable

Cons:

- Redundant: Translates same template text number of times (n = number of rows), can be slow and expensive
- Stochastic: Different translations each time is possible (although unlikely)

### Option 2: Manual Pre-Translation, Outside of the Blocks / Flows

This is the process I have used for performing the spanish sdg experiments.

Process:
- Translate prompt YAMLs manually, which is used by new language specific flow(s)
- Eg.: translate detailed_summary.yaml → detailed_summary_es.yaml
- Create Spanish flow that references *_es.yaml files
- Can be 'scriptified' similar to the example utility methods used in the knowledge notebook.
- Achievable in a notebook format, which can accept source and target langs as env vars and achieve this seamlessly

Pros:

- Translate once, use forever
- No redundancy or cost waste
- Deterministic translations

Cons:

- Process outside the patterns of SDG Hub
- Not automated within framework with the blocks

### Option 3: Revamp / Modify Flow class to allow for some meta flow initializations / pre-init hooks

#### New Primitive: FlowInitializer
```
class FlowInitializer(ABC):
    """Abstract base for flow-level initialization logic."""

    @abstractmethod
    def initialize(self, flow: Flow) -> None:
        """Run initialization before flow execution."""
        pass
```
```
class PromptTranslationInitializer(FlowInitializer):
    """Translates all prompt templates in a flow before execution."""

    def __init__(self, target_language: str, model: str):
        self.target_language = target_language
        self.model = model

    def initialize(self, flow: Flow) -> None:
        # Find all PromptBuilderBlocks
        # Translate their prompt_config_path files
        # Save as *_<lang>.yaml
        # Update blocks to use translated paths
        pass
```
#### Modified Flow class:
```
class Flow:
    initializers: list[FlowInitializer] = Field(default_factory=list)

    def generate(self, dataset, **kwargs):
        # Run initializers first
        for initializer in self.initializers:
            initializer.initialize(self)

        # Then execute blocks normally
        ...
```
Usage:

```
metadata:
  name: My Flow

initializers:
  - initializer_type: PromptTranslationInitializer
    target_language: es
    model: openai/gpt-4

blocks:
  # ... regular blocks
```
Pros:

- Native SDG Hub pattern
- Composable initializers

Cons:

- Requires significant framework changes
