### PR TITLE
fix: use isna() for null checks in melt_columns tests

### DIFF
--- a/tests/blocks/transform/test_melt_columns.py
+++ b/tests/blocks/transform/test_melt_columns.py
@@ -84,7 +84,7 @@ def test_flatten_columns_with_missing_values():
 
     result = block.generate(dataset)
     assert len(result) == 6  # 3 rows * 2 columns to flatten
-    assert None in result["summary"].tolist()
+    assert result["summary"].isna().any()  # Check for null values (None or NaN)
 
 
 def test_flatten_columns_with_all_columns():
@@ -152,8 +152,8 @@ def test_flatten_columns_with_empty_columns():
 
     result = block.generate(dataset)
 
-    # Verify that None values are preserved
-    assert None in result["summary"].tolist()
+    # Verify that null values are preserved (None becomes NaN in pandas 3.0+)
+    assert result["summary"].isna().any()
     # Verify that the column with None values still appears in dataset_type
     assert "summary_detailed" in result["dataset_type"].tolist()
 


### PR DESCRIPTION
## Summary
- Fix failing tests in `test_melt_columns.py` caused by pandas 3.0+ behavior change
- `None` values in string columns become `NaN`, so `None in list` returns `False`
- Use `isna().any()` instead of `None in list` for null value checks

## Test plan
- [x] Tests pass locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)