### PR TITLE
chore: remove deprecated LLMParserBlock

### DIFF
--- a/src/sdg_hub/core/blocks/__init__.py
+++ b/src/sdg_hub/core/blocks/__init__.py
@@ -9,7 +9,6 @@ from .base import BaseBlock
 from .filtering import ColumnValueFilterBlock
 from .llm import (
     LLMChatBlock,
-    LLMParserBlock,
     LLMResponseExtractorBlock,
     PromptBuilderBlock,
     TextParserBlock,
@@ -36,7 +35,6 @@ __all__ = [
     "TextConcatBlock",
     "UniformColumnValueSetter",
     "LLMChatBlock",
-    "LLMParserBlock",  # Deprecated alias for LLMResponseExtractorBlock
     "LLMResponseExtractorBlock",
     "TextParserBlock",
     "PromptBuilderBlock",

--- a/src/sdg_hub/core/blocks/llm/__init__.py
+++ b/src/sdg_hub/core/blocks/llm/__init__.py
@@ -9,7 +9,7 @@ local models (vLLM, Ollama), and more.
 # Local
 from .error_handler import ErrorCategory, LLMErrorHandler
 from .llm_chat_block import LLMChatBlock
-from .llm_response_extractor_block import LLMParserBlock, LLMResponseExtractorBlock
+from .llm_response_extractor_block import LLMResponseExtractorBlock
 from .prompt_builder_block import PromptBuilderBlock
 from .text_parser_block import TextParserBlock
 
@@ -17,7 +17,6 @@ __all__ = [
     "LLMErrorHandler",
     "ErrorCategory",
     "LLMChatBlock",
-    "LLMParserBlock",  # Deprecated alias for LLMResponseExtractorBlock
     "LLMResponseExtractorBlock",
     "PromptBuilderBlock",
     "TextParserBlock",

--- a/src/sdg_hub/core/blocks/llm/llm_response_extractor_block.py
+++ b/src/sdg_hub/core/blocks/llm/llm_response_extractor_block.py
@@ -328,22 +328,3 @@ class LLMResponseExtractorBlock(BaseBlock):
             new_data.extend(self._generate(sample))
 
         return pd.DataFrame(new_data)
-
-
-# Backwards compatibility alias (deprecated)
-# Register deprecated alias in BlockRegistry so old YAML flows still work
-@BlockRegistry.register(
-    "LLMParserBlock",
-    "llm",
-    "Deprecated: Use LLMResponseExtractorBlock instead",
-    deprecated=True,
-    replacement="LLMResponseExtractorBlock",
-)
-class LLMParserBlock(LLMResponseExtractorBlock):
-    """Deprecated alias for LLMResponseExtractorBlock.
-
-    This class exists for backwards compatibility with existing code and YAML flows.
-    Use LLMResponseExtractorBlock instead.
-    """
-
-    pass


### PR DESCRIPTION
## Summary
- Remove the deprecated `LLMParserBlock` class from `llm_response_extractor_block.py`
- Remove `LLMParserBlock` exports from `__init__.py` files
- Users should use `LLMResponseExtractorBlock` directly

## Test plan
- [x] Verified `LLMResponseExtractorBlock` imports successfully
- [x] Verified `LLMParserBlock` raises `ImportError` as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed LLMParserBlock from the public API. Code importing this deprecated class will fail and must be updated to use LLMResponseExtractorBlock instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->