### PR TITLE
docs: add DeepWiki badge and update documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![License](https://img.shields.io/github/license/Red-Hat-AI-Innovation-Team/sdg_hub)](https://github.com/Red-Hat-AI-Innovation-Team/sdg_hub/blob/main/LICENSE)
 [![Tests](https://github.com/Red-Hat-AI-Innovation-Team/sdg_hub/actions/workflows/test.yml/badge.svg)](https://github.com/Red-Hat-AI-Innovation-Team/sdg_hub/actions/workflows/test.yml)
 [![codecov](https://codecov.io/gh/Red-Hat-AI-Innovation-Team/sdg_hub/graph/badge.svg?token=SP75BCXWO2)](https://codecov.io/gh/Red-Hat-AI-Innovation-Team/sdg_hub)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/Red-Hat-AI-Innovation-Team/sdg_hub)
 
 <p align="center">
   <img src="docs/assets/sdg-hub-cover.png" alt="SDG Hub Cover" width="400">
@@ -12,7 +13,7 @@
 
 A modular Python framework for building synthetic data generation pipelines using composable blocks and flows. Transform datasets through **building-block composition** - mix and match LLM-powered and traditional processing blocks to create sophisticated data generation workflows.
 
-**📖 Full documentation available at: [https://ai-innovation.team/sdg_hub](https://ai-innovation.team/sdg_hub)**
+**📖 Full documentation available at: [DeepWiki](https://deepwiki.com/Red-Hat-AI-Innovation-Team/sdg_hub)**
 
 ## ✨ Key Features
 


### PR DESCRIPTION
## Summary
- Add DeepWiki badge to README for AI-powered documentation access
- Update documentation link to point to DeepWiki instead of the docsify site

## Notes
The `docs/` folder with docsify content is intentionally kept for now. GitHub Pages redirect can be configured separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation links to reference DeepWiki.
  * Added Ask DeepWiki badge to project documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->