### PR TITLE
fix(ui): disable experimental webstorage to prevent Node.js 25.2.0 error

### DIFF
--- a/ui/start.sh
+++ b/ui/start.sh
@@ -341,4 +341,12 @@ echo -e "${YELLOW}Press Ctrl+C to stop all servers${NC}"
 echo ""
 
 cd frontend
+# Node.js 25.2.0 introduced a bug where html-webpack-plugin triggers a SecurityError
+# by accessing the experimental localStorage global (nodejs/node#60704).
+# Disable webstorage on Node 25+ where the bug exists. Append to any existing
+# NODE_OPTIONS so user-defined flags (e.g. --max-old-space-size) are preserved.
+NODE_MAJOR=$(node -e "console.log(process.versions.node.split('.')[0])")
+if [ "$NODE_MAJOR" -ge 25 ] 2>/dev/null; then
+    export NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--no-experimental-webstorage"
+fi
 BROWSER=none npm start


### PR DESCRIPTION
Node.js 25.2.0 introduced localStorage as a global that throws SecurityError when accessed without --localstorage-file. This breaks html-webpack-plugin during template compilation in react-scripts.

The fix conditionally passes --no-experimental-webstorage on Node 22+ (where the flag exists) and skips it on older versions.

Tested on Node 18.20.0, 22.22.0, 23.11.0, 24.0.0, 25.2.0, and 25.2.1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved startup compatibility with newer Node.js releases (including Node 25+); startup now handles newer runtime behavior while preserving existing startup options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->