### PR TITLE
fix: dry_run reports 0 LLM requests due to block key mismatch

### DIFF
--- a/src/sdg_hub/core/utils/time_estimator.py
+++ b/src/sdg_hub/core/utils/time_estimator.py
@@ -30,11 +30,11 @@ def is_llm_using_block(block_info: Dict) -> bool:
 
     Examples
     --------
-    >>> block = {"block_type": "LLMChatBlock", "parameters_used": {"model": "gpt-4"}}
+    >>> block = {"block_class": "LLMChatBlock", "parameters_used": {"model": "gpt-4"}}
     >>> is_llm_using_block(block)
     True
     """
-    block_type = block_info.get("block_type", "")
+    block_type = block_info.get("block_class", "")
 
     # Direct LLM blocks or evaluation/verification blocks
     if any(kw in block_type for kw in ["LLMChatBlock", "Evaluate", "Verify"]):

--- a/tests/flow/test_time_estimation.py
+++ b/tests/flow/test_time_estimation.py
@@ -217,7 +217,7 @@ class TestTimeEstimatorIntegration:
 
         # Test is_llm_using_block - block type detection
         llm_block_info = {
-            "block_type": "LLMChatBlock",
+            "block_class": "LLMChatBlock",
             "parameters_used": {"model": "test-model"},
         }
         assert is_llm_using_block(llm_block_info) is True
@@ -225,24 +225,24 @@ class TestTimeEstimatorIntegration:
         # Test is_llm_using_block - parameter-based detection
         # Block with model parameter but non-LLM block type
         llm_by_params_model = {
-            "block_type": "CustomBlock",
+            "block_class": "CustomBlock",
             "parameters_used": {"model": "test-model"},
         }
         assert is_llm_using_block(llm_by_params_model) is True
 
         llm_by_params_api_base = {
-            "block_type": "CustomBlock",
+            "block_class": "CustomBlock",
             "parameters_used": {"api_base": "http://localhost:8000"},
         }
         assert is_llm_using_block(llm_by_params_api_base) is True
 
         llm_by_params_api_key = {
-            "block_type": "CustomBlock",
+            "block_class": "CustomBlock",
             "parameters_used": {"api_key": "secret"},
         }
         assert is_llm_using_block(llm_by_params_api_key) is True
 
-        non_llm_block_info = {"block_type": "TextConcat", "parameters_used": {}}
+        non_llm_block_info = {"block_class": "TextConcat", "parameters_used": {}}
         assert is_llm_using_block(non_llm_block_info) is False
 
         # Test calculate_block_throughput
@@ -289,7 +289,7 @@ class TestTimeEstimatorIntegration:
             "blocks_executed": [
                 {
                     "block_name": "llm_block",
-                    "block_type": "LLMChatBlock",
+                    "block_class": "LLMChatBlock",
                     "execution_time_seconds": 4.0,
                     "input_rows": 5,
                     "output_rows": 5,
@@ -304,7 +304,7 @@ class TestTimeEstimatorIntegration:
             "blocks_executed": [
                 {
                     "block_name": "llm_block",
-                    "block_type": "LLMChatBlock",
+                    "block_class": "LLMChatBlock",
                     "execution_time_seconds": 1.0,
                     "input_rows": 1,
                     "output_rows": 1,
@@ -387,7 +387,7 @@ class TestTimeEstimatorIntegration:
                     "block_name": "high_throughput_block",
                     "execution_time_seconds": 0.1,
                     "input_rows": 100,
-                    "block_type": "LLMChatBlock",
+                    "block_class": "LLMChatBlock",
                     "parameters_used": {"model": "gpt-4"},
                 }
             ],
@@ -404,7 +404,7 @@ class TestTimeEstimatorIntegration:
                         "block_name": "high_throughput_block",
                         "execution_time_seconds": 0.2,
                         "input_rows": 200,
-                        "block_type": "LLMChatBlock",
+                        "block_class": "LLMChatBlock",
                         "parameters_used": {"model": "gpt-4"},
                     }
                 ],
@@ -450,14 +450,14 @@ class TestTimeEstimatorIntegration:
             "blocks_executed": [
                 {
                     "block_name": "block1",
-                    "block_type": "LLMChatBlock",
+                    "block_class": "LLMChatBlock",
                     "execution_time_seconds": 1.0,
                     "input_rows": 1,
                     "parameters_used": {"model": "test"},
                 },
                 {
                     "block_name": "block2",
-                    "block_type": "LLMChatBlock",
+                    "block_class": "LLMChatBlock",
                     "execution_time_seconds": 1.0,
                     "input_rows": 1,
                     "parameters_used": {"model": "test"},
@@ -471,7 +471,7 @@ class TestTimeEstimatorIntegration:
             "blocks_executed": [
                 {
                     "block_name": "block1",
-                    "block_type": "LLMChatBlock",
+                    "block_class": "LLMChatBlock",
                     "execution_time_seconds": 5.0,
                     "input_rows": 5,
                     "parameters_used": {"model": "test"},
@@ -498,14 +498,14 @@ class TestTimeEstimatorIntegration:
             "blocks_executed": [
                 {
                     "block_name": "transform_block",
-                    "block_type": "TransformBlock",  # Not an LLM block
+                    "block_class": "TransformBlock",  # Not an LLM block
                     "execution_time_seconds": 1.0,
                     "input_rows": 1,
                     "parameters_used": {},
                 },
                 {
                     "block_name": "llm_block",
-                    "block_type": "LLMChatBlock",  # LLM block
+                    "block_class": "LLMChatBlock",  # LLM block
                     "execution_time_seconds": 1.0,
                     "input_rows": 1,
                     "parameters_used": {"model": "test"},
@@ -519,14 +519,14 @@ class TestTimeEstimatorIntegration:
             "blocks_executed": [
                 {
                     "block_name": "transform_block",
-                    "block_type": "TransformBlock",
+                    "block_class": "TransformBlock",
                     "execution_time_seconds": 1.0,
                     "input_rows": 5,
                     "parameters_used": {},
                 },
                 {
                     "block_name": "llm_block",
-                    "block_type": "LLMChatBlock",
+                    "block_class": "LLMChatBlock",
                     "execution_time_seconds": 5.0,
                     "input_rows": 5,
                     "parameters_used": {"model": "test"},


### PR DESCRIPTION
## Summary
- `execution.py` was refactored in `97824a4` to rename `"block_type"` → `"block_class"`, but `time_estimator.py` was not updated
- `is_llm_using_block()` always read an empty string from the old key, so dry_run with `enable_time_estimation=True` reported 0 LLM requests and 0.0s estimated time
- Updated `time_estimator.py` to read `"block_class"` and aligned all test fixtures in `test_time_estimation.py`

## Test plan
- [x] `uv run pytest tests/flow/test_time_estimation.py -v` — all 15 tests pass
- [x] `uv run pytest tests/flow/ -v -m "not (examples or slow)"` — all 197 flow tests pass
- [x] `uv run ruff check src/sdg_hub/core/utils/time_estimator.py tests/flow/test_time_estimation.py` — clean
- [x] Manual dry_run with `LLMChatBlock` confirms non-zero LLM request count and per-block breakdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Updated block identification mechanism to improve accuracy in LLM detection and time estimation calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->