### PR TITLE
ci: fix CI failures on dependabot PRs

### DIFF
--- a/.github/workflows/cursor-code-review.yml
+++ b/.github/workflows/cursor-code-review.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   code-review:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false && github.actor != 'dependabot[bot]'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/cursor-update-docs.yml
+++ b/.github/workflows/cursor-update-docs.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   docs:
-    if: ${{ !startsWith(github.head_ref, 'docs/') }}
+    if: ${{ !startsWith(github.head_ref, 'docs/') && github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,7 +100,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml
-          fail_ci_if_error: true
+          fail_ci_if_error: false
 
   test-workflow-complete:
     needs: ["test"]


### PR DESCRIPTION
## Summary
- Set codecov `fail_ci_if_error` to `false` in `test.yml` (matching `integration-test.yml`) since dependabot PRs lack access to the `CODECOV_TOKEN` secret, causing test jobs to fail even when all tests pass
- Skip Cursor code-review and docs-update workflows for dependabot PRs since they require `CURSOR_API_KEY` which is unavailable to dependabot

This unblocks PRs #575, #574, #563, #548, and #345.

## Test plan
- [ ] Verify this PR's own CI passes
- [ ] After merging, rebase dependabot PRs to pick up the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved continuous integration pipeline reliability and streamlined workflow automation triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->