### PR TITLE
docs: document red-team prompt generation updates

### DIFF
--- a/docs/blocks/llm-blocks.md
+++ b/docs/blocks/llm-blocks.md
@@ -13,6 +13,9 @@ Constructs structured prompts from templates and data, with support for complex 
 ### TextParserBlock
 Extracts structured data from LLM responses using patterns, schemas, or parsing rules.
 
+### JSONParserBlock
+Parses JSON objects from model responses and expands fields into separate columns, including JSON embedded in surrounding text.
+
 ## 🚀 LLMChatBlock
 
 The unified chat block that replaces provider-specific implementations with a single, powerful interface.
@@ -664,6 +667,40 @@ print(result["reasoning"])  # Extracted reasoning
 - Each tag pair extracts all matches for that field
 - Tags can be any string (XML-style, markdown-style, custom)
 - Missing tags result in empty lists for that field
+
+## 🧩 JSONParserBlock
+
+JSONParserBlock is useful when your model returns JSON output and you want each JSON field as a dataset column.
+
+### Basic Usage
+
+```python
+from sdg_hub.core.blocks import JSONParserBlock
+from datasets import Dataset
+
+parser = JSONParserBlock(
+    block_name="parse_json_response",
+    input_cols=["response_text"],
+    output_cols=["prompt", "why_prompt_harmful"],  # Optional: select fields
+    drop_input=True
+)
+
+dataset = Dataset.from_dict({
+    "response_text": [
+        '{"prompt":"Example adversarial prompt","why_prompt_harmful":"Contains policy bypass intent"}'
+    ]
+})
+
+result = parser.generate(dataset)
+print(result["prompt"][0])
+```
+
+### JSONParserBlock Notes
+
+- `extract_embedded=True` (default) extracts JSON even when surrounded by extra text
+- `fix_trailing_commas=True` (default) repairs common LLM formatting issues
+- `field_prefix` lets you namespace parsed fields (for example, `parsed_`)
+- `drop_input=True` removes the raw JSON source column after parsing
 
 ## 🚀 Next Steps
 

--- a/docs/blocks/overview.md
+++ b/docs/blocks/overview.md
@@ -52,6 +52,7 @@ AI-powered blocks for language model operations:
 - **LLMChatBlock** - Direct chat with language models
 - **PromptBuilderBlock** - Construct prompts from templates
 - **TextParserBlock** - Extract structured data from LLM responses
+- **JSONParserBlock** - Parse JSON responses into structured columns
 
 ### 🔄 Transform Blocks (`transform/`)
 Data manipulation and transformation:
@@ -60,6 +61,7 @@ Data manipulation and transformation:
 - **TextConcatBlock** - Concatenate text from multiple columns
 - **IndexBasedMapperBlock** - Map values based on indices
 - **MeltColumnsBlock** - Reshape wide data to long format
+- **SamplerBlock** - Randomly sample values from list or weighted pools
 
 ### 🔍 Filtering Blocks (`filtering/`)
 Quality control and data validation:

--- a/docs/blocks/transform-blocks.md
+++ b/docs/blocks/transform-blocks.md
@@ -19,6 +19,9 @@ Maps values based on their position/index, useful for applying transformations b
 ### MeltColumnsBlock
 Reshapes data from wide format to long format, converting multiple columns into key-value pairs.
 
+### SamplerBlock
+Randomly samples values from list, set, or weighted dictionary columns. Use `num_samples=1` with `return_scalar=true` when downstream blocks expect a scalar value instead of a single-item list.
+
 ### UniformColumnValueSetter
 Replaces all values in a column with a single statistical aggregate (mode, min, max, mean, or median) computed from the data. Modifies the column in-place, useful for data normalization, creating baseline comparisons, or extracting dominant values.
 

--- a/docs/flows/available-flows.md
+++ b/docs/flows/available-flows.md
@@ -9,6 +9,7 @@ SDG Hub provides a rich ecosystem of pre-built flows for various data generation
 - **QA Generation Flows** - Create training datasets with question-answer pairs for knowledge tuning
 - **Text Analysis Flows** - Extract structured insights from unstructured text content
 - **Multilingual Flows** - Localized variants for non-English data generation
+- **Red Teaming Flows** - Generate adversarial prompts for AI safety evaluation
 
 All flows support:
 - Automatic discovery and registration
@@ -24,6 +25,47 @@ All flows support:
 | [Enhanced Multi-Summary QA](#enhanced-multi-summary-qa-flows) | 4 | Knowledge tuning dataset generation | `knowledge-tuning`, `document-internalization` |
 | [Multilingual QA](#japanese-multilingual-multi-summary-qa-flow) | 1 | Japanese language QA generation | `multilingual`, `japanese` |
 | [Text Analysis](#structured-text-insights-extraction-flow) | 1 | NLP insights extraction | `text-analysis`, `nlp` |
+| [Red Team Prompt Generation](#red-team-prompt-generation-flow) | 1 | Adversarial prompt generation for safety testing | `red-team`, `safety-testing` |
+
+---
+
+## Red Team Prompt Generation Flow
+
+**Name:** `Red Teaming Prompt Generation Flow`
+
+**Purpose:** Generate adversarial prompts for safety testing by combining policy concepts with sampled demographic, expertise, geography, style, exploit-stage, medium, temporal, and trust-signal context.
+
+**Location:** `src/sdg_hub/flows/red_team/prompt_generation/`
+
+### Architecture
+
+```yaml
+Input Concept → Row Replication → Multi-Dimension Sampling →
+PromptBuilderBlock → LLMChatBlock (json_schema response) →
+LLMResponseExtractorBlock → JSONParserBlock → Structured Prompt Dataset
+```
+
+### Input Requirements
+
+| Column | Description | Required |
+|--------|-------------|----------|
+| `policy_concept` | Safety policy topic to test | Yes |
+| `concept_definition` | Description of the policy concept | Yes |
+| `*_pool` columns | Optional sampling pools (demographics, expertise, geography, language styles, exploit stages, task medium, temporal context, trust signals) | No |
+
+### Output Columns
+
+- `prompt` - Generated adversarial prompt candidate
+- `why_prompt_harmful` - Harm rationale
+- `why_prompt_has_temporal_relevance` - Temporal-context rationale
+- `why_prompt_fits_exploit_stage` - Exploit-stage rationale
+- Additional `why_prompt_*` fields for region, demographic targeting, trust exploitation, instruction keywords, style, and expertise fit
+
+### Key Notes
+
+- Uses `SamplerBlock` with `num_samples: 1` and `return_scalar: true` so sampled dimensions are emitted as scalar values.
+- Uses `response_format.type: json_schema` for structured generation from the model.
+- Uses `JSONParserBlock` to expand parsed JSON fields into output columns and remove the raw extracted text when `drop_input: true`.
 
 ---
 


### PR DESCRIPTION
Keep flow and block docs aligned with the red-team prompt generation pipeline so users can understand required input pools, structured JSON outputs, and SamplerBlock scalar behavior.

Made-with: Cursor