### PR TITLE
chore: update red-team flow default model to gemma-2-9b-it-abliterated

### DIFF
--- a/src/sdg_hub/flows/red_team/prompt_generation/flow.yaml
+++ b/src/sdg_hub/flows/red_team/prompt_generation/flow.yaml
@@ -5,13 +5,7 @@ metadata:
   version: 1.0.0
   author: Chatterbox Labs
   recommended_models:
-    default: openai/gpt-4
-    compatible:
-    - openai/gpt-4o
-    - meta-llama/Llama-3.3-70B-Instruct
-    - anthropic/claude-3-5-sonnet
-    experimental:
-    - openai/gpt-3.5-turbo
+    default: IlyaGusev/gemma-2-9b-it-abliterated
   tags:
   - red-team
   - adversarial


### PR DESCRIPTION
## Summary
- Update default model for the red-team prompt generation flow to `IlyaGusev/gemma-2-9b-it-abliterated`
- Remove `compatible` and `experimental` model recommendation lists

## Test plan
- [ ] Verify flow YAML parses correctly
- [ ] Run red-team prompt generation flow with the new default model

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined red team flow configuration by updating the default AI model and removing previously available model alternatives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->