### PR TITLE
docs: add JSONStructureBlock to transform blocks documentation

### DIFF
--- a/docs/blocks/transform-blocks.md
+++ b/docs/blocks/transform-blocks.md
@@ -25,6 +25,74 @@ Randomly samples values from list, set, or weighted dictionary columns. Use `num
 ### UniformColumnValueSetter
 Replaces all values in a column with a single statistical aggregate (mode, min, max, mean, or median) computed from the data. Modifies the column in-place, useful for data normalization, creating baseline comparisons, or extracting dominant values.
 
+### JSONStructureBlock
+Combines multiple columns into a single column containing a structured JSON object. Each input column becomes a field in the JSON output, using the column name as the field key.
+
+**Configuration:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `input_cols` | `list[str]` | — | Columns to include as JSON fields |
+| `output_cols` | `list[str]` | — | Single output column name (exactly one required) |
+| `ensure_json_serializable` | `bool` | `true` | Convert non-serializable values to strings |
+| `pretty_print` | `bool` | `false` | Format JSON with indentation |
+
+**YAML Example:**
+
+```yaml
+- block_type: "JSONStructureBlock"
+  block_config:
+    block_name: "combine_insights"
+    input_cols:
+      - "summary"
+      - "keywords"
+      - "entities"
+      - "sentiment"
+    output_cols:
+      - "structured_output"
+    ensure_json_serializable: true
+```
+
+**Python Example:**
+
+```python
+from sdg_hub.core.blocks.transform import JSONStructureBlock
+import pandas as pd
+
+block = JSONStructureBlock(
+    block_name="combine_results",
+    input_cols=["summary", "keywords", "sentiment"],
+    output_cols=["result_json"],
+    pretty_print=True,
+)
+
+dataset = pd.DataFrame({
+    "summary": ["AI adoption is accelerating across industries."],
+    "keywords": [["AI", "adoption", "industry"]],
+    "sentiment": ["positive"],
+})
+
+result = block(dataset)
+print(result["result_json"].iloc[0])
+```
+
+Output:
+
+```json
+{
+  "summary": "AI adoption is accelerating across industries.",
+  "keywords": ["AI", "adoption", "industry"],
+  "sentiment": "positive"
+}
+```
+
+**Behavior Notes:**
+- Missing input columns produce `null` values in the JSON output with a warning
+- Non-serializable values are converted to strings when `ensure_json_serializable` is enabled
+- Serialization errors return an empty JSON object (`{}`) rather than raising exceptions
+- Supports nested structures including lists, dictionaries, and `None` values
+- Handles unicode and emoji content correctly
+
 
 ## 🚀 Next Steps
 


### PR DESCRIPTION
## Summary

- Adds comprehensive documentation for `JSONStructureBlock` to the transform blocks page (`docs/blocks/transform-blocks.md`)
- Includes configuration table, YAML and Python usage examples, sample output, and behavior notes

Closes #442

## Test plan

- [ ] Verify markdown renders correctly on the docs site
- [ ] Confirm code examples are accurate against the source implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the new `JSONStructureBlock` transform block, which builds JSON-structured output columns from configured inputs.
  * Documented configuration parameters for controlling JSON serialization and output formatting.
  * Included usage examples and error handling specifications for missing or non-serializable values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->