### PR TITLE
feat(blocks): add max_completion_tokens support to LLMChatBlock

### DIFF
--- a/src/sdg_hub/core/blocks/llm/llm_chat_block.py
+++ b/src/sdg_hub/core/blocks/llm/llm_chat_block.py
@@ -329,10 +329,10 @@ class LLMChatBlock(BaseBlock):
         if self.max_completion_tokens is not None:
             completion_kwargs["max_completion_tokens"] = self.max_completion_tokens
 
-        # Apply non-block-field overrides (flow params + unknown LiteLLM params)
-        # BaseBlock already handles block field overrides by modifying instance
-        # attributes, but LiteLLM params that happen to also be model fields
-        # (like max_completion_tokens) need to pass through as well.
+        # Apply non-block-field overrides (flow params + unknown LiteLLM params).
+        # max_completion_tokens must also pass through here: when generate()
+        # is called directly (not via __call__), BaseBlock doesn't apply the
+        # setattr override, so self.max_completion_tokens stays None.
         litellm_passthrough_fields = {"max_completion_tokens"}
         non_block_overrides = {
             k: v

--- a/src/sdg_hub/core/blocks/llm/llm_chat_block.py
+++ b/src/sdg_hub/core/blocks/llm/llm_chat_block.py
@@ -124,6 +124,11 @@ class LLMChatBlock(BaseBlock):
     drop_params: bool = Field(
         True, description="Whether to drop unsupported parameters to prevent API errors"
     )
+    max_completion_tokens: Optional[int] = Field(
+        None,
+        description="Maximum completion tokens (used by newer models like GPT-5 "
+        "instead of max_tokens). When set, max_tokens is automatically excluded.",
+    )
 
     # All LiteLLM completion parameters can be passed via extra="allow"
     # Common examples: temperature, max_tokens, top_p, frequency_penalty,
@@ -320,12 +325,27 @@ class LLMChatBlock(BaseBlock):
         if self.num_retries is not None:
             completion_kwargs["num_retries"] = self.num_retries
 
-        # Apply only non-block-field overrides (flow params + unknown LiteLLM params)
-        # BaseBlock already handles block field overrides by modifying instance attributes
+        # Add max_completion_tokens if set (for models like GPT-5, o1, o3)
+        if self.max_completion_tokens is not None:
+            completion_kwargs["max_completion_tokens"] = self.max_completion_tokens
+
+        # Apply non-block-field overrides (flow params + unknown LiteLLM params)
+        # BaseBlock already handles block field overrides by modifying instance
+        # attributes, but LiteLLM params that happen to also be model fields
+        # (like max_completion_tokens) need to pass through as well.
+        litellm_passthrough_fields = {"max_completion_tokens"}
         non_block_overrides = {
-            k: v for k, v in overrides.items() if k not in self.__class__.model_fields
+            k: v
+            for k, v in overrides.items()
+            if k not in self.__class__.model_fields or k in litellm_passthrough_fields
         }
         completion_kwargs.update(non_block_overrides)
+
+        # When max_completion_tokens is set, drop max_tokens to avoid
+        # API errors with models that only support max_completion_tokens
+        # (e.g., GPT-5, o1, o3)
+        if completion_kwargs.get("max_completion_tokens") is not None:
+            completion_kwargs.pop("max_tokens", None)
 
         # Ensure drop_params is set to handle unknown parameters gracefully
         completion_kwargs["drop_params"] = self.drop_params

--- a/tests/blocks/llm/test_llm_chat_block.py
+++ b/tests/blocks/llm/test_llm_chat_block.py
@@ -1048,6 +1048,97 @@ class TestMultipleResponses:
         assert "row 100" in error_msg  # Should find the error in the last row
         assert "missing required 'content' field" in error_msg
 
+
+class TestMaxCompletionTokens:
+    """Test max_completion_tokens support for newer models (GPT-5, o1, o3)."""
+
+    def test_max_completion_tokens_field(self):
+        """Test that max_completion_tokens is an explicit field."""
+        block = LLMChatBlock(
+            block_name="test_mct",
+            input_cols="messages",
+            output_cols="response",
+            model="openai/gpt-5",
+            max_completion_tokens=1024,
+        )
+        assert block.max_completion_tokens == 1024
+
+    def test_max_completion_tokens_passed_to_litellm(
+        self, mock_litellm_completion, sample_dataset
+    ):
+        """Test that max_completion_tokens is passed through to LiteLLM."""
+        block = LLMChatBlock(
+            block_name="test_mct",
+            input_cols="messages",
+            output_cols="response",
+            model="openai/gpt-5",
+            api_key="test-key",
+            max_completion_tokens=1024,
+        )
+
+        block.generate(sample_dataset)
+
+        call_kwargs = mock_litellm_completion.call_args[1]
+        assert call_kwargs["max_completion_tokens"] == 1024
+
+    def test_max_completion_tokens_drops_max_tokens(
+        self, mock_litellm_completion, sample_dataset
+    ):
+        """Test that max_tokens is dropped when max_completion_tokens is set."""
+        block = LLMChatBlock(
+            block_name="test_mct",
+            input_cols="messages",
+            output_cols="response",
+            model="openai/gpt-5",
+            api_key="test-key",
+            max_tokens=500,
+            max_completion_tokens=1024,
+        )
+
+        block.generate(sample_dataset)
+
+        call_kwargs = mock_litellm_completion.call_args[1]
+        assert call_kwargs["max_completion_tokens"] == 1024
+        assert "max_tokens" not in call_kwargs
+
+    def test_max_tokens_still_works_without_max_completion_tokens(
+        self, mock_litellm_completion, sample_dataset
+    ):
+        """Test that max_tokens works normally when max_completion_tokens is not set."""
+        block = LLMChatBlock(
+            block_name="test_mt",
+            input_cols="messages",
+            output_cols="response",
+            model="openai/gpt-4",
+            api_key="test-key",
+            max_tokens=500,
+        )
+
+        block.generate(sample_dataset)
+
+        call_kwargs = mock_litellm_completion.call_args[1]
+        assert call_kwargs["max_tokens"] == 500
+        assert "max_completion_tokens" not in call_kwargs
+
+    def test_max_completion_tokens_runtime_override(
+        self, mock_litellm_completion, sample_dataset
+    ):
+        """Test that max_completion_tokens can be set via runtime params."""
+        block = LLMChatBlock(
+            block_name="test_mct_override",
+            input_cols="messages",
+            output_cols="response",
+            model="openai/gpt-5",
+            api_key="test-key",
+            max_tokens=500,
+        )
+
+        block.generate(sample_dataset, max_completion_tokens=2048)
+
+        call_kwargs = mock_litellm_completion.call_args[1]
+        assert call_kwargs["max_completion_tokens"] == 2048
+        assert "max_tokens" not in call_kwargs
+
     def test_validation_with_complex_conversation(self):
         """Test validation with complex multi-turn conversations."""
         valid_data = [

--- a/tests/blocks/llm/test_llm_chat_block.py
+++ b/tests/blocks/llm/test_llm_chat_block.py
@@ -555,6 +555,47 @@ class TestLLMChatBlockValidation:
         # Should not raise any exception
         block._validate_custom(dataset)
 
+    def test_validation_with_complex_conversation(self):
+        """Test validation with complex multi-turn conversations."""
+        valid_data = [
+            {
+                "messages": [
+                    {"role": "system", "content": "You are a helpful assistant."},
+                    {"role": "user", "content": "Hello, how are you?"},
+                    {
+                        "role": "assistant",
+                        "content": "I'm doing well, thank you! How can I help you today?",
+                    },
+                    {"role": "user", "content": "Can you help me with Python?"},
+                    {
+                        "role": "assistant",
+                        "content": "Absolutely! I'd be happy to help with Python. What specific question do you have?",
+                    },
+                ]
+            },
+            {
+                "messages": [
+                    {"role": "user", "content": "What's the weather like?"},
+                    {
+                        "role": "assistant",
+                        "content": "I don't have access to real-time weather data.",
+                    },
+                    {"role": "user", "content": "That's okay, thanks!"},
+                ]
+            },
+        ]
+        dataset = pd.DataFrame(valid_data)
+
+        block = LLMChatBlock(
+            block_name="test_validation",
+            input_cols="messages",
+            output_cols="response",
+            model="openai/gpt-3.5-turbo",
+        )
+
+        # Should not raise any exception
+        block._validate_custom(dataset)
+
 
 class TestMultipleResponses:
     """Test multiple response generation (n > 1)."""
@@ -1138,44 +1179,3 @@ class TestMaxCompletionTokens:
         call_kwargs = mock_litellm_completion.call_args[1]
         assert call_kwargs["max_completion_tokens"] == 2048
         assert "max_tokens" not in call_kwargs
-
-    def test_validation_with_complex_conversation(self):
-        """Test validation with complex multi-turn conversations."""
-        valid_data = [
-            {
-                "messages": [
-                    {"role": "system", "content": "You are a helpful assistant."},
-                    {"role": "user", "content": "Hello, how are you?"},
-                    {
-                        "role": "assistant",
-                        "content": "I'm doing well, thank you! How can I help you today?",
-                    },
-                    {"role": "user", "content": "Can you help me with Python?"},
-                    {
-                        "role": "assistant",
-                        "content": "Absolutely! I'd be happy to help with Python. What specific question do you have?",
-                    },
-                ]
-            },
-            {
-                "messages": [
-                    {"role": "user", "content": "What's the weather like?"},
-                    {
-                        "role": "assistant",
-                        "content": "I don't have access to real-time weather data.",
-                    },
-                    {"role": "user", "content": "That's okay, thanks!"},
-                ]
-            },
-        ]
-        dataset = pd.DataFrame(valid_data)
-
-        block = LLMChatBlock(
-            block_name="test_validation",
-            input_cols="messages",
-            output_cols="response",
-            model="openai/gpt-3.5-turbo",
-        )
-
-        # Should not raise any exception
-        block._validate_custom(dataset)


### PR DESCRIPTION
## Summary

- Adds explicit `max_completion_tokens` field to `LLMChatBlock` for newer models (GPT-5, o1, o3) that use it instead of `max_tokens`
- When `max_completion_tokens` is set, `max_tokens` is automatically excluded from completion kwargs to prevent `BadRequestError`
- Works via YAML config, init-time, or runtime params
- Existing flows using `max_tokens` with older models are unaffected

**YAML usage:**
```yaml
- block_type: "LLMChatBlock"
  block_config:
    block_name: "gen_question"
    input_cols: "messages"
    output_cols: "response"
    max_completion_tokens: 1024  # For GPT-5, o1, o3
```

Closes #526

## Test plan

- [x] 5 new tests in `TestMaxCompletionTokens`:
  - Field exists and is settable
  - Passed through to LiteLLM completion
  - Drops `max_tokens` when both are set
  - `max_tokens` still works alone (backward compat)
  - Works via runtime override
- [x] All 41 LLM chat block tests pass
- [x] Full test suite (765 tests) passes
- [x] Ruff lint and format checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)