### PR TITLE
Pin litellm<=1.82.6 to mitigate security issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "datasets>=4.0.0",
     "httpx>=0.25.0,<1.0.0",
     "jinja2",
-    "litellm>=1.73.0,<2.0.0",         # raising cap since tests run without errors related to 'backoff' cap back to <1.75.0 if errors surface
+    "litellm>=1.73.0,<=1.82.6",       # capped due to security vulnerabilities in newer versions (ref: https://github.com/BerriAI/litellm/issues/24518)
     "mcp>=1.8.0,<2.0.0",              # Model Context Protocol for MCP agent block (1.8.0+ for streamablehttp_client)
     "rich",
     "pandas",

--- a/uv.lock
+++ b/uv.lock
@@ -5570,7 +5570,7 @@ requires-dist = [
     { name = "ipykernel", marker = "extra == 'examples'" },
     { name = "jinja2" },
     { name = "langchain-text-splitters", marker = "extra == 'examples'" },
-    { name = "litellm", specifier = ">=1.73.0,<2.0.0" },
+    { name = "litellm", specifier = ">=1.73.0,<=1.82.6" },
     { name = "matplotlib", marker = "extra == 'examples'" },
     { name = "mcp", specifier = ">=1.8.0,<2.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },


### PR DESCRIPTION
## Summary

- Pin `litellm<=1.82.6` (last known safe version) to mitigate security issues
- `litellm` 1.82.7 and 1.82.8 contain a malicious `.pth` file that automatically executes a credential-stealing script when Python starts
- Ref: https://github.com/BerriAI/litellm/issues/24518

## Changes

- `pyproject.toml`: Update litellm specifier from `>=1.73.0,<2.0.0` to `>=1.73.0,<=1.82.6`
- `uv.lock`: Update specifier to match

## Test plan

- [x] Existing unit tests (760 passed)
- [x] Existing integration test passes 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency version constraints to enhance stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->