### PR TITLE
feat(flows): add InstructLab Knowledge Q&A generation flow

### DIFF
--- a/docs/flows/available-flows.md
+++ b/docs/flows/available-flows.md
@@ -27,6 +27,7 @@ All flows support:
 | [Multilingual QA](#japanese-multilingual-multi-summary-qa-flow) | 1 | Japanese language QA generation | `multilingual`, `japanese` |
 | [Text Analysis](#structured-text-insights-extraction-flow) | 1 | NLP insights extraction | `text-analysis`, `nlp` |
 | [Red Team Prompt Generation](#red-team-prompt-generation-flow) | 1 | Adversarial prompt generation for safety testing | `red-team`, `safety-testing` |
+| [InstructLab Q&A Generation](#instructlab-knowledge-qa-generation-flow) | 1 | InstructLab qna.yaml training data from documents | `instructlab`, `qa-generation` |
 
 ---
 
@@ -974,3 +975,70 @@ for row in result:
   }
 }
 ```
+
+---
+
+## InstructLab Knowledge Q&A Generation Flow
+
+**Name:** `InstructLab Knowledge Q&A Generation`
+
+**Purpose:** Generate high-quality question-answer training data for InstructLab knowledge contributions. Takes document chunks with taxonomy paths and produces diverse, grounded Q&A pairs formatted as valid InstructLab `qna.yaml` files.
+
+**Location:** `src/sdg_hub/flows/knowledge_infusion/instructlab_qna/`
+
+### Architecture
+
+```yaml
+Document Chunks + Taxonomy Metadata →
+Question Generation (5 diverse questions per chunk) →
+Answer Generation (grounded in source document) →
+Faithfulness Evaluation (LLM-as-judge, temperature 0) →
+Filter Unfaithful (keep YES only) →
+InstructLabFormatterBlock (qna.yaml + attribution.txt)
+```
+
+### Input Requirements
+
+| Column | Description | Required |
+|--------|-------------|----------|
+| `document_text` | Pre-chunked document text (300-500 words recommended) | Yes |
+| `taxonomy_path` | InstructLab taxonomy placement (e.g., `knowledge/science/biology`) | Yes |
+| `domain` | Knowledge domain name (e.g., `biology`) | Yes |
+
+### Key Output Columns
+
+- `qna_yaml` — Complete InstructLab `qna.yaml` content ready for submission
+- `attribution_txt` — Attribution file content
+- `taxonomy_path` — Taxonomy path for directory placement
+- `num_examples` — Number of Q&A examples in the generated YAML
+
+### Example Usage
+
+```python
+import pandas as pd
+from sdg_hub import Flow, FlowRegistry
+
+FlowRegistry.discover_flows()
+flow_path = FlowRegistry.get_flow_path("bright-coral-421")
+flow = Flow.from_yaml(flow_path)
+
+flow.set_model_config(
+    model="openai/gpt-5-mini",
+    api_key="your-api-key",
+)
+
+input_df = pd.DataFrame([{
+    "document_text": "Photosynthesis is the biological process...",
+    "taxonomy_path": "knowledge/science/biology/photosynthesis",
+    "domain": "biology",
+}])
+
+result = flow.generate(input_df)
+```
+
+### Pipeline Stages
+
+1. **Question Generation** — Generates 5 diverse questions per document chunk covering definitional, procedural, troubleshooting, comparative, and best-practice categories
+2. **Answer Generation** — Produces detailed answers grounded strictly in the source document
+3. **Faithfulness Evaluation** — LLM-as-judge evaluates each Q&A pair at temperature 0 for deterministic results; filters out any pair where the answer is not fully supported by the document
+4. **YAML Formatting** — Groups faithful Q&A pairs by taxonomy path and outputs valid `qna.yaml` + `attribution.txt`

--- a/examples/knowledge_tuning/instructlab_qna/.gitignore
+++ b/examples/knowledge_tuning/instructlab_qna/.gitignore
@@ -1,0 +1,2 @@
+# Generated output from demo notebook
+output/

--- a/examples/knowledge_tuning/instructlab_qna/README.md
+++ b/examples/knowledge_tuning/instructlab_qna/README.md
@@ -1,0 +1,47 @@
+# InstructLab Knowledge Q&A Generation — Example
+
+Automatically generate InstructLab-compatible `qna.yaml` training data from documents.
+
+## Quick Start
+
+```bash
+# From repo root
+uv pip install .[dev]
+
+# Set your API key
+export OPENAI_API_KEY="sk-..."
+
+# Run the notebook
+jupyter notebook examples/knowledge_tuning/instructlab_qna/demo.ipynb
+```
+
+## What It Does
+
+Takes document chunks + taxonomy metadata → produces submission-ready InstructLab files:
+
+```
+input:   2 document chunks (biology, culinary arts)
+output:  2 qna.yaml files with 5+ Q&A pairs each
+```
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `demo.ipynb` | Step-by-step tutorial notebook |
+| `output/` | Generated `qna.yaml` and `attribution.txt` files (created by notebook) |
+
+## Prerequisites
+
+1. **Python 3.10+** with `uv`
+2. **An API key** for any OpenAI-compatible LLM (GPT, Granite, Llama via vLLM, etc.)
+
+## Configuration
+
+Set `SDG_MODEL` to use a different model:
+
+```bash
+export SDG_MODEL="ibm/granite-3.3-8b-instruct"
+export OPENAI_API_KEY="your-granite-key"
+export OPENAI_API_BASE="https://your-endpoint/v1"
+```

--- a/examples/knowledge_tuning/instructlab_qna/demo.ipynb
+++ b/examples/knowledge_tuning/instructlab_qna/demo.ipynb
@@ -1,0 +1,425 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# InstructLab Knowledge Q&A Generation — Tutorial\n",
+    "\n",
+    "**Goal:** Automatically generate high-quality Q&A training data for [InstructLab](https://instructlab.ai/) knowledge contributions from documents.\n",
+    "\n",
+    "## The Problem\n",
+    "\n",
+    "InstructLab requires `qna.yaml` files with diverse, grounded question-answer pairs for knowledge contributions. Manually writing these is tedious and doesn't scale. Domain experts have knowledge but shouldn't need to understand YAML schemas.\n",
+    "\n",
+    "## The Solution\n",
+    "\n",
+    "This pipeline takes document chunks + taxonomy metadata and automatically:\n",
+    "\n",
+    "1. **Generates diverse questions** across 5 categories (definitional, procedural, troubleshooting, comparative, best-practice)\n",
+    "2. **Produces grounded answers** using only information from the source document\n",
+    "3. **Evaluates faithfulness** via LLM-as-judge to filter hallucinated content\n",
+    "4. **Formats output** into valid InstructLab `qna.yaml` + `attribution.txt` files\n",
+    "\n",
+    "```\n",
+    "  ┌───────────┐   ┌──────────┐   ┌──────────┐   ┌──────────┐\n",
+    "  │ Generate   │   │ Generate │   │ Evaluate │   │ Format   │\n",
+    "  │ Questions  │──▶│ Answers  │──▶│Faithful- │──▶│ qna.yaml │\n",
+    "  │ (5/chunk)  │   │(grounded)│   │  ness    │   │          │\n",
+    "  └───────────┘   └──────────┘   └──────────┘   └──────────┘\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 0. Setup\n",
+    "\n",
+    "Install dependencies and configure your API key."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import sys\n",
+    "import textwrap\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import pandas as pd\n",
+    "import nest_asyncio\n",
+    "\n",
+    "nest_asyncio.apply()\n",
+    "\n",
+    "NOTEBOOK_DIR = Path.cwd()\n",
+    "PROJECT_ROOT = NOTEBOOK_DIR.parent.parent.parent\n",
+    "print(f\"Project root: {PROJECT_ROOT}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Configure your LLM — any OpenAI-compatible API works\n",
+    "API_KEY = os.environ.get(\"OPENAI_API_KEY\", \"sk-...\")\n",
+    "MODEL = os.environ.get(\"SDG_MODEL\", \"openai/gpt-5-mini\")\n",
+    "\n",
+    "print(f\"Model: {MODEL}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 1. Prepare Input Data\n",
+    "\n",
+    "The pipeline expects a DataFrame with three columns:\n",
+    "\n",
+    "| Column | Description |\n",
+    "|--------|-------------|\n",
+    "| `document_text` | Pre-chunked document text (300-500 words) |\n",
+    "| `taxonomy_path` | InstructLab taxonomy placement |\n",
+    "| `domain` | Knowledge domain name |\n",
+    "\n",
+    "Here we use a sample document about photosynthesis to demonstrate."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Sample document chunks — in production, you'd load and chunk real documents\n",
+    "documents = [\n",
+    "    {\n",
+    "        \"document_text\": (\n",
+    "            \"Photosynthesis is the biological process by which green plants, algae, \"\n",
+    "            \"and certain bacteria convert light energy, usually from the sun, into \"\n",
+    "            \"chemical energy stored in glucose. This process occurs primarily in the \"\n",
+    "            \"chloroplasts of plant cells, specifically within structures called thylakoids \"\n",
+    "            \"that contain the green pigment chlorophyll. Photosynthesis consists of two \"\n",
+    "            \"main stages: the light-dependent reactions and the Calvin cycle (light-independent \"\n",
+    "            \"reactions). During the light-dependent reactions, chlorophyll absorbs sunlight \"\n",
+    "            \"and uses this energy to split water molecules (H2O) into oxygen, protons, and \"\n",
+    "            \"electrons. The oxygen is released as a byproduct — this is the source of most \"\n",
+    "            \"atmospheric oxygen on Earth. The energy captured is stored in ATP and NADPH. \"\n",
+    "            \"In the Calvin cycle, the enzyme RuBisCO fixes carbon dioxide (CO2) from the \"\n",
+    "            \"atmosphere, and using the ATP and NADPH from the light reactions, converts it \"\n",
+    "            \"into glucose (C6H12O6). This glucose serves as the primary energy source for \"\n",
+    "            \"the plant and forms the base of nearly all food chains on Earth. Factors \"\n",
+    "            \"affecting the rate of photosynthesis include light intensity, carbon dioxide \"\n",
+    "            \"concentration, temperature, and water availability. C4 and CAM plants have \"\n",
+    "            \"evolved alternative carbon fixation pathways to minimize photorespiration in \"\n",
+    "            \"hot, dry environments.\"\n",
+    "        ),\n",
+    "        \"taxonomy_path\": \"knowledge/science/biology/photosynthesis\",\n",
+    "        \"domain\": \"biology\",\n",
+    "    },\n",
+    "    {\n",
+    "        \"document_text\": (\n",
+    "            \"Sourdough bread is made through a natural fermentation process using a \"\n",
+    "            \"sourdough starter — a mixture of flour and water that captures wild yeast \"\n",
+    "            \"and lactic acid bacteria from the environment. Unlike commercial bread that \"\n",
+    "            \"uses packaged yeast (Saccharomyces cerevisiae), sourdough relies on a \"\n",
+    "            \"symbiotic culture of wild yeast species (often Kazachstania humilis) and \"\n",
+    "            \"Lactobacillus bacteria. The fermentation process typically takes 12-24 hours, \"\n",
+    "            \"much longer than conventional bread (2-4 hours). During fermentation, the \"\n",
+    "            \"bacteria produce lactic and acetic acids, giving sourdough its characteristic \"\n",
+    "            \"tangy flavor and lowering the pH to 3.5-4.5. This acidic environment also \"\n",
+    "            \"breaks down phytic acid, making minerals more bioavailable, and partially \"\n",
+    "            \"degrades gluten proteins, which some people find easier to digest. Common \"\n",
+    "            \"troubleshooting issues include: a starter that won't rise (often due to \"\n",
+    "            \"cold temperatures below 70°F/21°C), overly sour flavor (too much acetic \"\n",
+    "            \"acid from cold fermentation), dense crumb structure (insufficient gluten \"\n",
+    "            \"development or underproofing), and poor oven spring (inadequate steam or \"\n",
+    "            \"scoring). Maintaining a healthy starter requires regular feeding — typically \"\n",
+    "            \"discarding half and adding equal parts flour and water every 12-24 hours at \"\n",
+    "            \"room temperature, or weekly if refrigerated.\"\n",
+    "        ),\n",
+    "        \"taxonomy_path\": \"knowledge/food/baking/sourdough\",\n",
+    "        \"domain\": \"culinary arts\",\n",
+    "    },\n",
+    "]\n",
+    "\n",
+    "input_df = pd.DataFrame(documents)\n",
+    "print(f\"Input: {len(input_df)} document chunks\")\n",
+    "print(f\"Taxonomy paths: {input_df['taxonomy_path'].tolist()}\")\n",
+    "print(f\"\\nFirst chunk preview ({len(input_df.iloc[0]['document_text'].split())} words):\")\n",
+    "print(textwrap.fill(input_df.iloc[0][\"document_text\"][:200] + \"...\", width=80))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 2. Load the Flow\n",
+    "\n",
+    "The InstructLab Q&A flow is registered in SDG Hub's flow registry. It uses 16 blocks across 4 stages."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sdg_hub import Flow, FlowRegistry\n",
+    "\n",
+    "# Discover all available flows\n",
+    "FlowRegistry.discover_flows()\n",
+    "\n",
+    "# Load our flow by ID\n",
+    "flow_id = \"bright-coral-421\"\n",
+    "flow_path = FlowRegistry.get_flow_path(flow_id)\n",
+    "flow = Flow.from_yaml(flow_path)\n",
+    "\n",
+    "print(f\"Flow: {flow.metadata.name}\")\n",
+    "print(f\"Version: {flow.metadata.version}\")\n",
+    "print(f\"Tags: {flow.metadata.tags}\")\n",
+    "print(f\"Blocks: {len(flow.blocks)}\")\n",
+    "print(f\"\\nRequired input columns: {flow.metadata.dataset_requirements.required_columns}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "flow.print_info()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 3. Configure the Model\n",
+    "\n",
+    "The flow uses LLM calls for question generation, answer generation, and faithfulness evaluation. Configure your model and API key here."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "flow.set_model_config(\n",
+    "    model=MODEL,\n",
+    "    api_key=API_KEY,\n",
+    ")\n",
+    "print(f\"Model configured: {MODEL}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 4. Run the Pipeline\n",
+    "\n",
+    "The pipeline processes each document chunk through 4 stages:\n",
+    "\n",
+    "1. **Generate Questions** — 5 diverse questions per chunk\n",
+    "2. **Generate Answers** — grounded in source document\n",
+    "3. **Evaluate Faithfulness** — LLM-as-judge filters hallucinated content\n",
+    "4. **Format qna.yaml** — groups by taxonomy path, produces valid InstructLab files\n",
+    "\n",
+    "With 2 input chunks, expect ~10 candidate Q&A pairs → filtered to faithful ones → grouped into 2 `qna.yaml` files."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"Running pipeline on {len(input_df)} document chunks...\")\n",
+    "print(f\"Expected: ~{len(input_df) * 5} Q&A candidates before filtering\\n\")\n",
+    "\n",
+    "result = flow.generate(input_df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if hasattr(result, \"to_pandas\"):\n",
+    "    result_df = result.to_pandas()\n",
+    "else:\n",
+    "    result_df = result\n",
+    "\n",
+    "print(f\"Pipeline complete!\")\n",
+    "print(f\"Generated {len(result_df)} qna.yaml document(s)\")\n",
+    "print(f\"Columns: {list(result_df.columns)}\")\n",
+    "display(result_df[[\"taxonomy_path\", \"num_examples\"]])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 5. Inspect the Output\n",
+    "\n",
+    "Each row contains a complete `qna.yaml` document and `attribution.txt` ready for an InstructLab PR."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Show the first qna.yaml\n",
+    "for i, row in result_df.iterrows():\n",
+    "    print(f\"{'=' * 70}\")\n",
+    "    print(f\"Taxonomy: {row['taxonomy_path']}\")\n",
+    "    print(f\"Examples: {row['num_examples']}\")\n",
+    "    print(f\"{'=' * 70}\")\n",
+    "    print()\n",
+    "    print(\"--- qna.yaml ---\")\n",
+    "    print(row[\"qna_yaml\"])\n",
+    "    print(\"--- attribution.txt ---\")\n",
+    "    print(row[\"attribution_txt\"])\n",
+    "    print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 6. Export for InstructLab\n",
+    "\n",
+    "Save the generated files to disk in the directory structure InstructLab expects."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "output_dir = NOTEBOOK_DIR / \"output\"\n",
+    "\n",
+    "for _, row in result_df.iterrows():\n",
+    "    # Create directory matching taxonomy path\n",
+    "    tax_dir = output_dir / row[\"taxonomy_path\"]\n",
+    "    tax_dir.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "    # Write qna.yaml\n",
+    "    qna_path = tax_dir / \"qna.yaml\"\n",
+    "    qna_path.write_text(row[\"qna_yaml\"])\n",
+    "\n",
+    "    # Write attribution.txt\n",
+    "    attr_path = tax_dir / \"attribution.txt\"\n",
+    "    attr_path.write_text(row[\"attribution_txt\"])\n",
+    "\n",
+    "    print(f\"Written: {qna_path}\")\n",
+    "    print(f\"Written: {attr_path}\")\n",
+    "\n",
+    "print(f\"\\nAll files exported to {output_dir}/\")\n",
+    "print(\"These can be submitted as an InstructLab taxonomy PR.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 7. Scaling Up\n",
+    "\n",
+    "### More documents\n",
+    "\n",
+    "Add more rows to the input DataFrame — each document chunk is processed independently:\n",
+    "\n",
+    "```python\n",
+    "# Load and chunk your documents\n",
+    "chunks = chunk_my_documents(\"path/to/docs/\", chunk_size=400)\n",
+    "input_df = pd.DataFrame(chunks)\n",
+    "result = flow.generate(input_df)\n",
+    "```\n",
+    "\n",
+    "### Different models\n",
+    "\n",
+    "The flow works with any OpenAI-compatible API. For Granite models:\n",
+    "\n",
+    "```python\n",
+    "flow.set_model_config(\n",
+    "    model=\"ibm/granite-3.3-8b-instruct\",\n",
+    "    api_key=os.environ[\"GRANITE_API_KEY\"],\n",
+    "    api_base=\"https://your-granite-endpoint/v1\",\n",
+    ")\n",
+    "```\n",
+    "\n",
+    "### Custom formatting\n",
+    "\n",
+    "Override the `InstructLabFormatterBlock` parameters at runtime:\n",
+    "\n",
+    "```python\n",
+    "result = flow.generate(\n",
+    "    input_df,\n",
+    "    runtime_params={\n",
+    "        \"format_qna_yaml\": {\n",
+    "            \"created_by\": \"your-github-username\",\n",
+    "            \"min_examples\": 3,  # Lower threshold for small documents\n",
+    "        },\n",
+    "    },\n",
+    ")\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## What we built\n",
+    "\n",
+    "This tutorial walked through the **InstructLab Knowledge Q&A Generation** pipeline — an automated way to produce training data for InstructLab knowledge contributions.\n",
+    "\n",
+    "### The pipeline\n",
+    "\n",
+    "1. **Question Generation** — An LLM generates 5 diverse questions per document chunk, covering definitions, processes, troubleshooting, comparisons, and best practices\n",
+    "2. **Answer Generation** — A second LLM call produces detailed answers grounded strictly in the source document\n",
+    "3. **Faithfulness Evaluation** — An LLM-as-judge scores each Q&A pair and filters out any with hallucinated content\n",
+    "4. **YAML Formatting** — The `InstructLabFormatterBlock` groups pairs by taxonomy path and outputs valid `qna.yaml` + `attribution.txt`\n",
+    "\n",
+    "### What makes this useful\n",
+    "\n",
+    "- **End-to-end** — Goes from raw documents to submission-ready InstructLab files\n",
+    "- **Quality-gated** — Every Q&A pair is evaluated for faithfulness before inclusion\n",
+    "- **Model-agnostic** — Works with any OpenAI-compatible LLM (GPT, Granite, Llama, etc.)\n",
+    "- **Composable** — Built on SDG Hub blocks, so you can customize or extend any stage"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/src/sdg_hub/core/blocks/filtering/__init__.py
+++ b/src/sdg_hub/core/blocks/filtering/__init__.py
@@ -6,7 +6,9 @@ This module provides blocks for filtering datasets based on various criteria.
 
 # Local
 from .column_value_filter import ColumnValueFilterBlock
+from .similarity_filter import SimilarityFilterBlock
 
 __all__ = [
     "ColumnValueFilterBlock",
+    "SimilarityFilterBlock",
 ]

--- a/src/sdg_hub/core/blocks/filtering/similarity_filter.py
+++ b/src/sdg_hub/core/blocks/filtering/similarity_filter.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Similarity filter block for removing near-duplicate rows.
+
+This module provides a block that computes pairwise text similarity
+within groups and drops near-duplicate entries, keeping only the first
+occurrence when similarity exceeds a configurable threshold.
+"""
+
+# Standard
+from difflib import SequenceMatcher
+from typing import Any, Optional
+
+from pydantic import Field
+
+# Third Party
+import pandas as pd
+
+# Local
+from ...utils.logger_config import setup_logger
+from ..base import BaseBlock
+from ..registry import BlockRegistry
+
+logger = setup_logger(__name__)
+
+
+@BlockRegistry.register(
+    "SimilarityFilterBlock",
+    "filtering",
+    "Filters near-duplicate rows based on text similarity within optional groups",
+)
+class SimilarityFilterBlock(BaseBlock):
+    """A block that removes near-duplicate rows based on text similarity.
+
+    Compares rows pairwise within optional groups (e.g., per document)
+    and drops rows whose text similarity to any previously kept row
+    exceeds the threshold.
+
+    Attributes
+    ----------
+    block_name : str
+        Name of the block.
+    input_cols : Union[str, List[str]]
+        Column(s) to compare for similarity. The first column is used
+        for comparison.
+    threshold : float
+        Similarity threshold (0.0 to 1.0). Rows with similarity above
+        this value to any kept row are dropped. Default 0.85.
+    group_by : Optional[str]
+        Column to group by before deduplication. If set, similarity is
+        only compared within each group.
+    """
+
+    block_type: str = "filtering"
+
+    threshold: float = Field(
+        0.85,
+        description="Similarity threshold (0-1). Rows above this are dropped.",
+        ge=0.0,
+        le=1.0,
+    )
+    group_by: Optional[str] = Field(
+        None,
+        description="Column to group by before comparing similarity.",
+    )
+
+    def model_post_init(self, __context: Any) -> None:
+        """Initialize derived attributes after Pydantic validation."""
+        super().model_post_init(__context) if hasattr(
+            super(), "model_post_init"
+        ) else None
+        if self.output_cols is None:
+            self.output_cols = []
+
+    @staticmethod
+    def _similarity(a: str, b: str) -> float:
+        """Compute similarity ratio between two strings."""
+        if not a or not b:
+            return 0.0
+        return SequenceMatcher(None, a, b).ratio()
+
+    def _deduplicate_group(self, group: pd.DataFrame, col: str) -> pd.DataFrame:
+        """Remove near-duplicate rows within a single group."""
+        kept_indices = []
+        kept_texts: list[str] = []
+
+        for idx, row in group.iterrows():
+            text = str(row[col])
+            is_duplicate = any(
+                self._similarity(text, kept) > self.threshold
+                for kept in kept_texts
+            )
+            if not is_duplicate:
+                kept_indices.append(idx)
+                kept_texts.append(text)
+
+        return group.loc[kept_indices]
+
+    def generate(self, samples: pd.DataFrame, **_kwargs: Any) -> pd.DataFrame:
+        """Filter near-duplicate rows based on text similarity.
+
+        Parameters
+        ----------
+        samples : pd.DataFrame
+            The input dataset.
+
+        Returns
+        -------
+        pd.DataFrame
+            Dataset with near-duplicates removed.
+        """
+        if samples.empty:
+            return samples
+
+        input_cols = self.input_cols
+        if isinstance(input_cols, list):
+            compare_col = input_cols[0]
+        elif isinstance(input_cols, str):
+            compare_col = input_cols
+        else:
+            compare_col = list(input_cols.keys())[0]
+
+        original_len = len(samples)
+
+        if self.group_by and self.group_by in samples.columns:
+            groups = []
+            for _, group in samples.groupby(self.group_by):
+                groups.append(self._deduplicate_group(group, compare_col))
+            result = pd.concat(groups, ignore_index=True) if groups else samples.iloc[:0]
+        else:
+            result = self._deduplicate_group(samples, compare_col)
+
+        removed = original_len - len(result)
+        if removed > 0:
+            logger.info(
+                "SimilarityFilterBlock '%s': removed %d near-duplicates "
+                "(threshold=%.2f), %d → %d rows",
+                self.block_name,
+                removed,
+                self.threshold,
+                original_len,
+                len(result),
+            )
+
+        return result.reset_index(drop=True)

--- a/src/sdg_hub/core/blocks/transform/__init__.py
+++ b/src/sdg_hub/core/blocks/transform/__init__.py
@@ -8,6 +8,7 @@ wide-to-long transformations, value selection, and majority value assignment.
 # Local
 from .duplicate_columns import DuplicateColumnsBlock
 from .index_based_mapper import IndexBasedMapperBlock
+from .instructlab_formatter import InstructLabFormatterBlock
 from .json_structure_block import JSONStructureBlock
 from .melt_columns import MeltColumnsBlock
 from .rename_columns import RenameColumnsBlock
@@ -19,6 +20,7 @@ from .uniform_col_val_setter import UniformColumnValueSetter
 __all__ = [
     "TextConcatBlock",
     "DuplicateColumnsBlock",
+    "InstructLabFormatterBlock",
     "JSONStructureBlock",
     "MeltColumnsBlock",
     "RowMultiplierBlock",

--- a/src/sdg_hub/core/blocks/transform/instructlab_formatter.py
+++ b/src/sdg_hub/core/blocks/transform/instructlab_formatter.py
@@ -120,6 +120,8 @@ class InstructLabFormatterBlock(BaseBlock):
 
             seed_examples = []
             for _, row in group.iterrows():
+                if pd.isna(row[question_col]) or pd.isna(row[answer_col]):
+                    continue
                 example = {
                     "question": str(row[question_col]),
                     "answer": str(row[answer_col]),

--- a/src/sdg_hub/core/blocks/transform/instructlab_formatter.py
+++ b/src/sdg_hub/core/blocks/transform/instructlab_formatter.py
@@ -1,0 +1,177 @@
+# SPDX-License-Identifier: Apache-2.0
+"""InstructLab Q&A YAML formatter block.
+
+This module provides a block that formats Q&A pairs into InstructLab's
+qna.yaml schema, grouped by taxonomy path. Each group produces a complete
+YAML document with all required InstructLab metadata.
+"""
+
+# Standard
+from typing import Any
+
+from pydantic import Field
+
+# Third Party
+import pandas as pd
+import yaml
+
+# Local
+from ...utils.logger_config import setup_logger
+from ..base import BaseBlock
+from ..registry import BlockRegistry
+
+logger = setup_logger(__name__)
+
+
+@BlockRegistry.register(
+    "InstructLabFormatterBlock",
+    "transform",
+    "Formats Q&A pairs into InstructLab qna.yaml schema grouped by taxonomy path",
+)
+class InstructLabFormatterBlock(BaseBlock):
+    """Block that formats Q&A DataFrame rows into InstructLab qna.yaml documents.
+
+    Groups rows by taxonomy_path and produces one YAML document per group,
+    following InstructLab's version 3 schema. Each output row contains a
+    complete qna.yaml string and an attribution.txt string ready for
+    submission.
+
+    Input columns (configurable via input_cols dict):
+        question: The question text
+        answer: The answer text
+        document_text: Source document context
+        domain: Knowledge domain name
+        taxonomy_path: InstructLab taxonomy placement
+
+    Output columns:
+        qna_yaml: Complete qna.yaml content as a string
+        attribution_txt: Complete attribution.txt content
+        taxonomy_path: The taxonomy path for this group
+        num_examples: Number of Q&A pairs in this document
+
+    Attributes
+    ----------
+    created_by : str
+        GitHub username or identifier for the created_by field.
+    min_examples : int
+        Minimum Q&A pairs required per taxonomy group. Groups with fewer
+        pairs are dropped with a warning.
+    yaml_version : int
+        InstructLab YAML schema version (default 3).
+    """
+
+    block_type: str = "transform"
+
+    created_by: str = Field(
+        default="sdg-hub",
+        description="Value for the created_by field in qna.yaml",
+    )
+    min_examples: int = Field(
+        default=5,
+        description="Minimum Q&A pairs per taxonomy group (InstructLab requires 5)",
+    )
+    yaml_version: int = Field(
+        default=3,
+        description="InstructLab YAML schema version",
+    )
+
+    def _get_col(self, name: str) -> str:
+        """Resolve a logical column name to the actual DataFrame column.
+
+        If input_cols is a dict mapping, use the mapped name. Otherwise
+        fall back to the logical name directly.
+        """
+        if isinstance(self.input_cols, dict):
+            return self.input_cols.get(name, name)
+        return name
+
+    def generate(self, samples: pd.DataFrame, **kwargs: Any) -> pd.DataFrame:
+        """Generate qna.yaml documents grouped by taxonomy path.
+
+        Parameters
+        ----------
+        samples : pd.DataFrame
+            Input DataFrame with question, answer, document_text, domain,
+            and taxonomy_path columns.
+
+        Returns
+        -------
+        pd.DataFrame
+            One row per taxonomy group with qna_yaml, attribution_txt,
+            taxonomy_path, and num_examples columns.
+        """
+        question_col = self._get_col("question")
+        answer_col = self._get_col("answer")
+        context_col = self._get_col("document_text")
+        domain_col = self._get_col("domain")
+        path_col = self._get_col("taxonomy_path")
+
+        results = []
+
+        for taxonomy_path, group in samples.groupby(path_col):
+            if len(group) < self.min_examples:
+                logger.warning(
+                    f"Skipping taxonomy path '{taxonomy_path}': "
+                    f"only {len(group)} examples (minimum {self.min_examples})"
+                )
+                continue
+
+            domain = group[domain_col].iloc[0]
+
+            seed_examples = []
+            for _, row in group.iterrows():
+                example = {
+                    "question": str(row[question_col]),
+                    "answer": str(row[answer_col]),
+                }
+                if context_col in row.index and pd.notna(row[context_col]):
+                    example["context"] = str(row[context_col])
+                seed_examples.append(example)
+
+            yaml_content = {
+                "version": self.yaml_version,
+                "domain": str(domain),
+                "task_description": f"Teach the model about {domain}",
+                "created_by": self.created_by,
+                "seed_examples": seed_examples,
+            }
+
+            qna_yaml = yaml.dump(
+                yaml_content,
+                default_flow_style=False,
+                allow_unicode=True,
+                sort_keys=False,
+                width=80,
+            )
+
+            attribution_txt = (
+                f"Title: {domain} knowledge contribution\n"
+                f"Creator: {self.created_by}\n"
+                f"Source: Generated by SDG Hub InstructLab Q&A flow\n"
+                f"License: Apache-2.0\n"
+            )
+
+            results.append(
+                {
+                    "qna_yaml": qna_yaml,
+                    "attribution_txt": attribution_txt,
+                    "taxonomy_path": str(taxonomy_path),
+                    "num_examples": len(seed_examples),
+                }
+            )
+
+        if not results:
+            logger.warning(
+                "No taxonomy groups met the minimum example threshold "
+                f"({self.min_examples}). Returning empty DataFrame."
+            )
+            return pd.DataFrame(
+                columns=["qna_yaml", "attribution_txt", "taxonomy_path", "num_examples"]
+            )
+
+        logger.info(
+            f"Formatted {len(results)} qna.yaml document(s) from "
+            f"{len(samples)} Q&A pairs"
+        )
+
+        return pd.DataFrame(results)

--- a/src/sdg_hub/flows/knowledge_infusion/instructlab_qna/README.md
+++ b/src/sdg_hub/flows/knowledge_infusion/instructlab_qna/README.md
@@ -1,0 +1,96 @@
+# InstructLab Knowledge Q&A Generation
+
+Generates high-quality question-answer training data for [InstructLab](https://instructlab.ai/) knowledge contributions from document chunks.
+
+## Overview
+
+This flow takes pre-chunked documents with taxonomy metadata and produces diverse, grounded Q&A pairs suitable for InstructLab's `qna.yaml` schema. Each document chunk yields multiple Q&A pairs that are independently validated for faithfulness to the source material.
+
+```
+document_text + taxonomy_path + domain
+        │
+        ▼
+   Generate Questions ──── 5 diverse questions per chunk
+        │
+        ▼
+   Generate Answers ────── grounded in source document
+        │
+        ▼
+   Evaluate Faithfulness ─ LLM judges answer quality
+        │
+        ▼
+   Filter Unfaithful ───── keep only faithful Q&A pairs
+```
+
+## Input Dataset
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `document_text` | str | Pre-chunked document text (300-500 words recommended) |
+| `taxonomy_path` | str | InstructLab taxonomy path (e.g., `knowledge/science/physics`) |
+| `domain` | str | Knowledge domain name (e.g., `physics`) |
+
+## Output Columns
+
+| Column | Description |
+|--------|-------------|
+| `question` | Generated question |
+| `answer` | Grounded answer from document context |
+| `document_text` | Source document chunk (preserved for reference) |
+| `domain` | Knowledge domain |
+| `taxonomy_path` | InstructLab taxonomy placement |
+| `faithfulness_explanation` | LLM explanation of faithfulness judgment |
+| `faithfulness_judgment` | `YES` (all unfaithful pairs are filtered out) |
+
+## Usage
+
+```python
+from sdg_hub import Flow
+
+# Load the flow
+flow = Flow.from_registry("bright-coral-421")
+
+# Or load from YAML
+flow = Flow.from_yaml("src/sdg_hub/flows/knowledge_infusion/instructlab_qna/flow.yaml")
+
+# Configure your model
+flow.set_model("openai/gpt-oss-120b")
+
+# Run on your dataset
+output_df = flow.generate(input_df)
+```
+
+## Post-Processing to qna.yaml
+
+The output DataFrame can be grouped by `taxonomy_path` and formatted into InstructLab's `qna.yaml` schema:
+
+```python
+import yaml
+
+for path, group in output_df.groupby("taxonomy_path"):
+    qna_yaml = {
+        "version": 3,
+        "domain": group["domain"].iloc[0],
+        "task_description": f"Teach the model about {group['domain'].iloc[0]}",
+        "created_by": "sdg-hub",
+        "seed_examples": [
+            {"question": row["question"], "answer": row["answer"], "context": row["document_text"]}
+            for _, row in group.iterrows()
+        ],
+    }
+    print(yaml.dump(qna_yaml, default_flow_style=False))
+```
+
+## Question Categories
+
+The question generation prompt produces questions across five categories:
+
+- **Definitional** — What is X? How would you define X?
+- **Procedural** — What are the steps for X? How do you perform X?
+- **Troubleshooting** — What are common problems with X?
+- **Comparative** — How does X compare to alternatives?
+- **Best practices** — What do experts recommend for X?
+
+## Quality Assurance
+
+Every generated Q&A pair goes through a faithfulness evaluation step where an LLM judges whether the answer is supported by the source document. Only pairs judged as faithful (`YES`) are kept in the final output.

--- a/src/sdg_hub/flows/knowledge_infusion/instructlab_qna/flow.yaml
+++ b/src/sdg_hub/flows/knowledge_infusion/instructlab_qna/flow.yaml
@@ -35,13 +35,10 @@ metadata:
       physics). Documents should be chunked to 300-500 words for best
       results.
   output_columns:
-  - question
-  - answer
-  - document_text
-  - domain
+  - qna_yaml
+  - attribution_txt
   - taxonomy_path
-  - faithfulness_explanation
-  - faithfulness_judgment
+  - num_examples
   id: bright-coral-421
 blocks:
 # --- Stage 1: Generate questions from document chunks ---
@@ -181,3 +178,21 @@ blocks:
     - faithfulness_judgment
     filter_value: 'YES'
     operation: eq
+
+# --- Stage 4: Format into InstructLab qna.yaml ---
+- block_type: InstructLabFormatterBlock
+  block_config:
+    block_name: format_qna_yaml
+    input_cols:
+      question: question
+      answer: answer
+      document_text: document_text
+      domain: domain
+      taxonomy_path: taxonomy_path
+    output_cols:
+    - qna_yaml
+    - attribution_txt
+    - taxonomy_path
+    - num_examples
+    created_by: sdg-hub
+    min_examples: 5

--- a/src/sdg_hub/flows/knowledge_infusion/instructlab_qna/flow.yaml
+++ b/src/sdg_hub/flows/knowledge_infusion/instructlab_qna/flow.yaml
@@ -40,6 +40,7 @@ metadata:
   - taxonomy_path
   - num_examples
   id: bright-coral-421
+parameters: {}
 blocks:
 # --- Stage 1: Generate questions from document chunks ---
 - block_type: DuplicateColumnsBlock

--- a/src/sdg_hub/flows/knowledge_infusion/instructlab_qna/flow.yaml
+++ b/src/sdg_hub/flows/knowledge_infusion/instructlab_qna/flow.yaml
@@ -148,6 +148,7 @@ blocks:
     block_name: evaluate_faithfulness
     input_cols: faithfulness_messages
     output_cols: faithfulness_response
+    temperature: 0
     n: 1
     async_mode: true
 

--- a/src/sdg_hub/flows/knowledge_infusion/instructlab_qna/flow.yaml
+++ b/src/sdg_hub/flows/knowledge_infusion/instructlab_qna/flow.yaml
@@ -1,0 +1,183 @@
+metadata:
+  name: InstructLab Knowledge Q&A Generation
+  description: >
+    Generates high-quality question-answer training data for InstructLab
+    knowledge contributions. Takes document chunks with taxonomy paths and
+    produces diverse, grounded Q&A pairs suitable for InstructLab's qna.yaml
+    schema. Each document chunk yields multiple Q&A pairs that are
+    independently validated for faithfulness to the source material.
+  version: 1.0.0
+  author: SDG Hub Contributors
+  license: Apache-2.0
+  recommended_models:
+    default: openai/gpt-oss-120b
+    compatible:
+    - meta-llama/Llama-3.3-70B-Instruct
+    - openai/gpt-5-mini
+    - ibm/granite-3.3-8b-instruct
+    experimental: []
+  tags:
+  - knowledge-infusion
+  - instructlab
+  - qa-generation
+  - training-data
+  - taxonomy
+  dataset_requirements:
+    required_columns:
+    - document_text
+    - taxonomy_path
+    - domain
+    description: >
+      Input dataset with pre-chunked document text and InstructLab taxonomy
+      metadata. Each row should contain: document_text (a chunk of source
+      document), taxonomy_path (InstructLab taxonomy placement, e.g.
+      knowledge/science/physics), and domain (knowledge domain name, e.g.
+      physics). Documents should be chunked to 300-500 words for best
+      results.
+  output_columns:
+  - question
+  - answer
+  - document_text
+  - domain
+  - taxonomy_path
+  - faithfulness_explanation
+  - faithfulness_judgment
+  id: bright-coral-421
+blocks:
+# --- Stage 1: Generate questions from document chunks ---
+- block_type: DuplicateColumnsBlock
+  block_config:
+    block_name: preserve_source_document
+    input_cols:
+      document_text: source_document_text
+
+- block_type: PromptBuilderBlock
+  block_config:
+    block_name: build_question_prompt
+    input_cols:
+    - document_text
+    - taxonomy_path
+    - domain
+    output_cols: question_gen_messages
+    prompt_config_path: prompts/generate_questions.yaml
+    format_as_messages: true
+
+- block_type: LLMChatBlock
+  block_config:
+    block_name: generate_questions
+    input_cols: question_gen_messages
+    output_cols: question_gen_response
+    max_tokens: 2048
+    temperature: 0.7
+    n: 1
+    async_mode: true
+
+- block_type: LLMResponseExtractorBlock
+  block_config:
+    block_name: extract_question_response
+    input_cols: question_gen_response
+    extract_content: true
+    expand_lists: true
+
+- block_type: TagParserBlock
+  block_config:
+    block_name: parse_questions
+    input_cols: extract_question_response_content
+    output_cols: question
+    start_tags:
+    - '[QUESTION]'
+    end_tags:
+    - '[END]'
+
+# --- Stage 2: Generate grounded answers ---
+- block_type: RenameColumnsBlock
+  block_config:
+    block_name: restore_document_for_answers
+    input_cols:
+      source_document_text: document_text
+
+- block_type: PromptBuilderBlock
+  block_config:
+    block_name: build_answer_prompt
+    input_cols:
+    - question
+    - document_text
+    - domain
+    output_cols: answer_gen_messages
+    prompt_config_path: prompts/generate_answers.yaml
+    format_as_messages: true
+
+- block_type: LLMChatBlock
+  block_config:
+    block_name: generate_answers
+    input_cols: answer_gen_messages
+    output_cols: answer_gen_response
+    max_tokens: 4096
+    temperature: 0.7
+    n: 1
+    async_mode: true
+
+- block_type: LLMResponseExtractorBlock
+  block_config:
+    block_name: extract_answer_response
+    input_cols: answer_gen_response
+    extract_content: true
+    expand_lists: true
+
+- block_type: TagParserBlock
+  block_config:
+    block_name: parse_answers
+    input_cols: extract_answer_response_content
+    output_cols: answer
+    start_tags:
+    - '<answer>'
+    end_tags:
+    - '</answer>'
+
+# --- Stage 3: Evaluate faithfulness ---
+- block_type: PromptBuilderBlock
+  block_config:
+    block_name: build_faithfulness_prompt
+    input_cols:
+    - document_text
+    - question
+    - answer
+    output_cols: faithfulness_messages
+    prompt_config_path: prompts/evaluate_faithfulness.yaml
+    format_as_messages: true
+
+- block_type: LLMChatBlock
+  block_config:
+    block_name: evaluate_faithfulness
+    input_cols: faithfulness_messages
+    output_cols: faithfulness_response
+    n: 1
+    async_mode: true
+
+- block_type: LLMResponseExtractorBlock
+  block_config:
+    block_name: extract_faithfulness
+    input_cols: faithfulness_response
+    extract_content: true
+
+- block_type: TagParserBlock
+  block_config:
+    block_name: parse_faithfulness
+    input_cols: extract_faithfulness_content
+    output_cols:
+    - faithfulness_explanation
+    - faithfulness_judgment
+    start_tags:
+    - '[Start of Explanation]'
+    - '[Start of Judgment]'
+    end_tags:
+    - '[End of Explanation]'
+    - '[End of Judgment]'
+
+- block_type: ColumnValueFilterBlock
+  block_config:
+    block_name: filter_unfaithful
+    input_cols:
+    - faithfulness_judgment
+    filter_value: 'YES'
+    operation: eq

--- a/src/sdg_hub/flows/knowledge_infusion/instructlab_qna/prompts/evaluate_faithfulness.yaml
+++ b/src/sdg_hub/flows/knowledge_infusion/instructlab_qna/prompts/evaluate_faithfulness.yaml
@@ -6,12 +6,12 @@
 
 - role: user
   content: |
-    Determine if the provided answer is faithful to and supported by the given document context. Respond with YES if the document substantiates the answer, even partially. Answer NO if the document does not support the answer.
+    Determine if the provided answer is fully faithful to and supported by the given document context. Respond with YES only if the document substantiates all material claims in the answer. Answer NO if any significant claim lacks support.
 
     Guidelines:
-    - Answer YES when the document provides either direct or indirect evidence supporting the answer.
-    - Answer NO if the document lacks any supportive evidence, clearly contradicts the answer, or if the support is too vague or speculative.
-    - Also answer NO if the answer contains significant information not present in the document.
+    - Answer YES only when the document directly supports every significant claim in the answer. All key facts, figures, and assertions must be traceable to the source.
+    - Answer NO if the document lacks evidence for any material claim, clearly contradicts the answer, or if the support is too vague or speculative.
+    - Answer NO if the answer contains significant information not present in the document, even if some parts are supported.
 
     Strictly answer in this format:
     [Start of Explanation]

--- a/src/sdg_hub/flows/knowledge_infusion/instructlab_qna/prompts/evaluate_faithfulness.yaml
+++ b/src/sdg_hub/flows/knowledge_infusion/instructlab_qna/prompts/evaluate_faithfulness.yaml
@@ -1,0 +1,32 @@
+# Prompt used in: instructlab_qna flow
+# Origin: knowledge_infusion/instructlab_qna
+---
+- role: system
+  content: You are a very knowledgeable AI Assistant that will faithfully assist the user with their task.
+
+- role: user
+  content: |
+    Determine if the provided answer is faithful to and supported by the given document context. Respond with YES if the document substantiates the answer, even partially. Answer NO if the document does not support the answer.
+
+    Guidelines:
+    - Answer YES when the document provides either direct or indirect evidence supporting the answer.
+    - Answer NO if the document lacks any supportive evidence, clearly contradicts the answer, or if the support is too vague or speculative.
+    - Also answer NO if the answer contains significant information not present in the document.
+
+    Strictly answer in this format:
+    [Start of Explanation]
+    ...
+    [End of Explanation]
+    [Start of Judgment]
+    YES or NO
+    [End of Judgment]
+
+    [Start of Document]
+    {{document_text}}
+    [End of Document]
+    [Start of Question]
+    {{question}}
+    [End of Question]
+    [Start of Answer]
+    {{answer}}
+    [End of Answer]

--- a/src/sdg_hub/flows/knowledge_infusion/instructlab_qna/prompts/generate_answers.yaml
+++ b/src/sdg_hub/flows/knowledge_infusion/instructlab_qna/prompts/generate_answers.yaml
@@ -1,0 +1,27 @@
+# Prompt used in: instructlab_qna flow
+# Origin: knowledge_infusion/instructlab_qna
+---
+- role: system
+  content: You are a very knowledgeable AI Assistant that will faithfully assist the user with their task. Your answers must be grounded in the provided document and comprehensive enough for AI training data.
+
+- role: user
+  content: |
+    Answer the following question based on the provided document. Your answer should:
+    * Be detailed and comprehensive (at least 2-3 sentences)
+    * Use only information from the provided document
+    * Be self-contained and understandable without the document
+    * Be suitable as training data for the {{domain}} domain
+
+    Provide your answer in this exact format:
+
+    <answer>
+    <Insert your answer here>
+    </answer>
+
+    Here is the document:
+
+    Document:
+    {{document_text}}
+
+    Question:
+    {{question}}

--- a/src/sdg_hub/flows/knowledge_infusion/instructlab_qna/prompts/generate_questions.yaml
+++ b/src/sdg_hub/flows/knowledge_infusion/instructlab_qna/prompts/generate_questions.yaml
@@ -1,0 +1,28 @@
+# Prompt used in: instructlab_qna flow
+# Origin: knowledge_infusion/instructlab_qna
+---
+- role: system
+  content: You are an expert educational content creator specializing in generating high-quality questions for AI training datasets. Your questions must be grounded in the provided document and suitable for InstructLab knowledge contributions.
+
+- role: user
+  content: |
+    Generate diverse, high-quality questions based on the following document chunk from the {{domain}} domain.
+
+    The questions should:
+    * Be fully answerable using ONLY the information in the provided document
+    * Cover different aspects: definitions, processes, troubleshooting, comparisons, and best practices
+    * Be self-contained and understandable without external references
+    * Require substantive answers (no yes/no questions)
+    * Vary in difficulty from introductory to advanced
+    * Be relevant to the taxonomy path: {{taxonomy_path}}
+
+    Generate exactly 5 questions. Use this exact format for each:
+
+    [QUESTION]
+    <Insert question here>
+    [END]
+
+    Here is the document:
+
+    [DOCUMENT]
+    {{document_text}}

--- a/tests/blocks/filtering/test_similarity_filter.py
+++ b/tests/blocks/filtering/test_similarity_filter.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for SimilarityFilterBlock."""
+
+# Third Party
+import pandas as pd
+import pytest
+
+# Local
+from sdg_hub.core.blocks.filtering.similarity_filter import SimilarityFilterBlock
+
+
+@pytest.fixture
+def make_block():
+    """Factory fixture for creating SimilarityFilterBlock instances."""
+
+    def _make(**kwargs):
+        defaults = {
+            "block_name": "test_sim_filter",
+            "input_cols": ["text"],
+            "threshold": 0.85,
+        }
+        defaults.update(kwargs)
+        return SimilarityFilterBlock(**defaults)
+
+    return _make
+
+
+class TestSimilarityFilterBlock:
+    """Tests for similarity-based deduplication."""
+
+    def test_keeps_unique_rows(self, make_block):
+        """Completely different rows should all be kept."""
+        block = make_block()
+        df = pd.DataFrame(
+            {"text": ["alpha bravo charlie", "delta echo foxtrot", "golf hotel india"]}
+        )
+        result = block.generate(df)
+        assert len(result) == 3
+
+    def test_removes_exact_duplicates(self, make_block):
+        """Identical rows should be deduplicated to one."""
+        block = make_block(threshold=0.8)
+        df = pd.DataFrame({"text": ["hello world", "hello world", "hello world"]})
+        result = block.generate(df)
+        assert len(result) == 1
+
+    def test_removes_near_duplicates(self, make_block):
+        """Rows differing by a single word should be caught at high threshold."""
+        block = make_block(threshold=0.7)
+        df = pd.DataFrame(
+            {
+                "text": [
+                    "What is photosynthesis and how does it work?",
+                    "What is photosynthesis and how does it function?",
+                    "Explain the process of sourdough bread making.",
+                ]
+            }
+        )
+        result = block.generate(df)
+        assert len(result) == 2
+
+    def test_group_by_isolates_groups(self, make_block):
+        """Duplicates in different groups should both be kept."""
+        block = make_block(threshold=0.8, group_by="doc_id")
+        df = pd.DataFrame(
+            {
+                "text": ["same text here", "same text here"],
+                "doc_id": ["doc_a", "doc_b"],
+            }
+        )
+        result = block.generate(df)
+        assert len(result) == 2
+
+    def test_group_by_deduplicates_within_group(self, make_block):
+        """Duplicates within the same group should be removed."""
+        block = make_block(threshold=0.8, group_by="doc_id")
+        df = pd.DataFrame(
+            {
+                "text": ["same text here", "same text here"],
+                "doc_id": ["doc_a", "doc_a"],
+            }
+        )
+        result = block.generate(df)
+        assert len(result) == 1
+
+    def test_empty_dataframe(self, make_block):
+        """Empty input should return empty output."""
+        block = make_block()
+        df = pd.DataFrame({"text": []})
+        result = block.generate(df)
+        assert len(result) == 0
+
+    def test_low_threshold_removes_more(self, make_block):
+        """A lower threshold should be more aggressive."""
+        texts = [
+            "What is photosynthesis?",
+            "What is the process of photosynthesis?",
+            "Explain sourdough bread.",
+        ]
+        strict = make_block(threshold=0.5)
+        lenient = make_block(threshold=0.95)
+        df = pd.DataFrame({"text": texts})
+        assert len(strict.generate(df)) <= len(lenient.generate(df))
+
+    def test_threshold_boundaries(self, make_block):
+        """Threshold of 0 keeps only first; threshold of 1 keeps all non-identical."""
+        df = pd.DataFrame({"text": ["aaa", "aab", "bbb"]})
+        block_zero = make_block(threshold=0.0)
+        result = block_zero.generate(df)
+        # threshold=0 means any similarity > 0 is filtered, but identical empty
+        # strings would pass; with real strings, most get filtered
+        assert len(result) >= 1

--- a/tests/blocks/transform/test_instructlab_formatter.py
+++ b/tests/blocks/transform/test_instructlab_formatter.py
@@ -1,0 +1,201 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for InstructLabFormatterBlock."""
+
+# Standard
+# Third Party
+import pandas as pd
+import pytest
+import yaml
+
+# First Party
+from sdg_hub.core.blocks.transform import InstructLabFormatterBlock
+
+
+@pytest.fixture
+def qa_dataset():
+    """Create a sample Q&A dataset with two taxonomy groups."""
+    return pd.DataFrame(
+        {
+            "question": [
+                "What is photosynthesis?",
+                "How do plants convert light to energy?",
+                "What role does chlorophyll play?",
+                "Why is photosynthesis important?",
+                "What are the products of photosynthesis?",
+                "What is a binary star system?",
+                "How do binary stars orbit?",
+                "What types of binary stars exist?",
+                "How are binary stars detected?",
+                "Why are binary stars important?",
+            ],
+            "answer": [
+                "Photosynthesis is the process by which plants convert sunlight into chemical energy.",
+                "Plants use chloroplasts containing chlorophyll to capture light energy and convert CO2 and water into glucose.",
+                "Chlorophyll is the green pigment that absorbs light energy, primarily in the blue and red wavelengths.",
+                "Photosynthesis produces oxygen and glucose, forming the base of most food chains on Earth.",
+                "The main products are glucose (C6H12O6) and oxygen (O2), with water as a byproduct.",
+                "A binary star system consists of two stars orbiting around their common center of mass.",
+                "Binary stars orbit their barycenter, with each star tracing an elliptical path.",
+                "Binary stars include visual, spectroscopic, eclipsing, and astrometric binaries.",
+                "Binary stars are detected through visual observation, spectral line shifts, or brightness variations.",
+                "Binary stars allow astronomers to directly measure stellar masses and test stellar evolution models.",
+            ],
+            "document_text": [
+                "Photosynthesis is a biological process..."
+            ]
+            * 5
+            + [
+                "Binary star systems are common in the universe..."
+            ]
+            * 5,
+            "domain": ["biology"] * 5 + ["astronomy"] * 5,
+            "taxonomy_path": ["knowledge/science/biology"] * 5
+            + ["knowledge/science/astronomy"] * 5,
+        }
+    )
+
+
+@pytest.fixture
+def small_dataset():
+    """Create a dataset with too few examples for one group."""
+    return pd.DataFrame(
+        {
+            "question": ["Q1", "Q2", "Q3"],
+            "answer": ["A1", "A2", "A3"],
+            "document_text": ["doc"] * 3,
+            "domain": ["test"] * 3,
+            "taxonomy_path": ["knowledge/test"] * 3,
+        }
+    )
+
+
+def test_basic_formatting(qa_dataset):
+    """Test that formatter produces valid qna.yaml for each taxonomy group."""
+    block = InstructLabFormatterBlock(
+        block_name="test_formatter",
+        input_cols=["question", "answer", "document_text", "domain", "taxonomy_path"],
+        output_cols=["qna_yaml", "attribution_txt", "taxonomy_path", "num_examples"],
+    )
+
+    result = block.generate(qa_dataset)
+
+    assert len(result) == 2
+    assert "qna_yaml" in result.columns
+    assert "attribution_txt" in result.columns
+    assert "taxonomy_path" in result.columns
+    assert "num_examples" in result.columns
+
+
+def test_yaml_structure(qa_dataset):
+    """Test that generated YAML follows InstructLab schema."""
+    block = InstructLabFormatterBlock(
+        block_name="test_formatter",
+        input_cols=["question", "answer", "document_text", "domain", "taxonomy_path"],
+        output_cols=["qna_yaml", "attribution_txt", "taxonomy_path", "num_examples"],
+    )
+
+    result = block.generate(qa_dataset)
+
+    for _, row in result.iterrows():
+        parsed = yaml.safe_load(row["qna_yaml"])
+        assert parsed["version"] == 3
+        assert "domain" in parsed
+        assert "task_description" in parsed
+        assert "created_by" in parsed
+        assert "seed_examples" in parsed
+        assert len(parsed["seed_examples"]) == 5
+
+        for example in parsed["seed_examples"]:
+            assert "question" in example
+            assert "answer" in example
+            assert "context" in example
+
+
+def test_custom_created_by(qa_dataset):
+    """Test that created_by field is configurable."""
+    block = InstructLabFormatterBlock(
+        block_name="test_formatter",
+        input_cols=["question", "answer", "document_text", "domain", "taxonomy_path"],
+        output_cols=["qna_yaml", "attribution_txt", "taxonomy_path", "num_examples"],
+        created_by="test-user",
+    )
+
+    result = block.generate(qa_dataset)
+    parsed = yaml.safe_load(result.iloc[0]["qna_yaml"])
+    assert parsed["created_by"] == "test-user"
+
+
+def test_min_examples_filtering(small_dataset):
+    """Test that groups below min_examples are dropped."""
+    block = InstructLabFormatterBlock(
+        block_name="test_formatter",
+        input_cols=["question", "answer", "document_text", "domain", "taxonomy_path"],
+        output_cols=["qna_yaml", "attribution_txt", "taxonomy_path", "num_examples"],
+        min_examples=5,
+    )
+
+    result = block.generate(small_dataset)
+    assert len(result) == 0
+
+
+def test_min_examples_override(small_dataset):
+    """Test that min_examples can be lowered."""
+    block = InstructLabFormatterBlock(
+        block_name="test_formatter",
+        input_cols=["question", "answer", "document_text", "domain", "taxonomy_path"],
+        output_cols=["qna_yaml", "attribution_txt", "taxonomy_path", "num_examples"],
+        min_examples=2,
+    )
+
+    result = block.generate(small_dataset)
+    assert len(result) == 1
+    assert result.iloc[0]["num_examples"] == 3
+
+
+def test_attribution_txt(qa_dataset):
+    """Test that attribution.txt is generated correctly."""
+    block = InstructLabFormatterBlock(
+        block_name="test_formatter",
+        input_cols=["question", "answer", "document_text", "domain", "taxonomy_path"],
+        output_cols=["qna_yaml", "attribution_txt", "taxonomy_path", "num_examples"],
+        created_by="contributor",
+    )
+
+    result = block.generate(qa_dataset)
+    attr = result.iloc[0]["attribution_txt"]
+    assert "contributor" in attr
+    assert "Apache-2.0" in attr
+
+
+def test_column_mapping(qa_dataset):
+    """Test that input_cols dict mapping works."""
+    renamed = qa_dataset.rename(columns={"question": "q", "answer": "a"})
+    block = InstructLabFormatterBlock(
+        block_name="test_formatter",
+        input_cols={
+            "question": "q",
+            "answer": "a",
+            "document_text": "document_text",
+            "domain": "domain",
+            "taxonomy_path": "taxonomy_path",
+        },
+        output_cols=["qna_yaml", "attribution_txt", "taxonomy_path", "num_examples"],
+    )
+
+    result = block.generate(renamed)
+    assert len(result) == 2
+    parsed = yaml.safe_load(result.iloc[0]["qna_yaml"])
+    assert len(parsed["seed_examples"]) == 5
+
+
+def test_num_examples_count(qa_dataset):
+    """Test that num_examples accurately reflects group size."""
+    block = InstructLabFormatterBlock(
+        block_name="test_formatter",
+        input_cols=["question", "answer", "document_text", "domain", "taxonomy_path"],
+        output_cols=["qna_yaml", "attribution_txt", "taxonomy_path", "num_examples"],
+    )
+
+    result = block.generate(qa_dataset)
+    for _, row in result.iterrows():
+        assert row["num_examples"] == 5

--- a/tests/flow/test_instructlab_qna_flow.py
+++ b/tests/flow/test_instructlab_qna_flow.py
@@ -5,6 +5,7 @@
 from pathlib import Path
 
 # Third Party
+import pytest
 import yaml
 
 FLOW_DIR = Path(__file__).resolve().parents[2] / (
@@ -13,107 +14,105 @@ FLOW_DIR = Path(__file__).resolve().parents[2] / (
 FLOW_YAML = FLOW_DIR / "flow.yaml"
 
 
+@pytest.fixture(scope="module")
+def flow_config():
+    """Load flow config once for all tests."""
+    with open(FLOW_YAML, encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
 class TestInstructLabQnAFlowYaml:
     """Test InstructLab Q&A flow YAML structure and metadata."""
-
-    def setup_method(self):
-        """Load the flow config once per test."""
-        with open(FLOW_YAML, encoding="utf-8") as f:
-            self.config = yaml.safe_load(f)
 
     def test_flow_yaml_exists(self):
         """Flow YAML file should exist."""
         assert FLOW_YAML.exists()
 
-    def test_has_metadata(self):
+    def test_has_metadata(self, flow_config):
         """Flow must have metadata section."""
-        assert "metadata" in self.config
-        metadata = self.config["metadata"]
+        assert "metadata" in flow_config
+        metadata = flow_config["metadata"]
         assert "name" in metadata
         assert "description" in metadata
         assert "version" in metadata
         assert "license" in metadata
         assert metadata["license"] == "Apache-2.0"
 
-    def test_has_dataset_requirements(self):
+    def test_has_dataset_requirements(self, flow_config):
         """Flow must declare required input columns."""
-        reqs = self.config["metadata"]["dataset_requirements"]
+        reqs = flow_config["metadata"]["dataset_requirements"]
         assert "required_columns" in reqs
         required = reqs["required_columns"]
         assert "document_text" in required
         assert "taxonomy_path" in required
         assert "domain" in required
 
-    def test_has_output_columns(self):
+    def test_has_output_columns(self, flow_config):
         """Flow must declare expected output columns."""
-        outputs = self.config["metadata"]["output_columns"]
+        outputs = flow_config["metadata"]["output_columns"]
         assert "qna_yaml" in outputs
         assert "attribution_txt" in outputs
         assert "taxonomy_path" in outputs
         assert "num_examples" in outputs
 
-    def test_has_blocks(self):
+    def test_has_blocks(self, flow_config):
         """Flow must have blocks section with entries."""
-        assert "blocks" in self.config
-        blocks = self.config["blocks"]
+        assert "blocks" in flow_config
+        blocks = flow_config["blocks"]
         assert isinstance(blocks, list)
         assert len(blocks) > 0
 
-    def test_all_blocks_have_required_fields(self):
+    def test_all_blocks_have_required_fields(self, flow_config):
         """Every block must have block_type and block_config with block_name."""
-        for i, block in enumerate(self.config["blocks"]):
+        for i, block in enumerate(flow_config["blocks"]):
             assert "block_type" in block, f"Block {i} missing block_type"
             assert "block_config" in block, f"Block {i} missing block_config"
             assert "block_name" in block["block_config"], (
                 f"Block {i} missing block_name"
             )
 
-    def test_block_names_are_unique(self):
+    def test_block_names_are_unique(self, flow_config):
         """All block names must be unique within the flow."""
-        names = [b["block_config"]["block_name"] for b in self.config["blocks"]]
+        names = [b["block_config"]["block_name"] for b in flow_config["blocks"]]
         assert len(names) == len(set(names)), f"Duplicate block names: {names}"
 
-    def test_has_recommended_models(self):
+    def test_has_recommended_models(self, flow_config):
         """Flow should declare recommended models."""
-        models = self.config["metadata"]["recommended_models"]
+        models = flow_config["metadata"]["recommended_models"]
         assert "default" in models
         assert "compatible" in models
 
-    def test_has_tags(self):
+    def test_has_tags(self, flow_config):
         """Flow should have relevant tags."""
-        tags = self.config["metadata"]["tags"]
+        tags = flow_config["metadata"]["tags"]
         assert "instructlab" in tags
         assert "qa-generation" in tags
 
-    def test_prompt_files_exist(self):
+    def test_prompt_files_exist(self, flow_config):
         """All referenced prompt files must exist."""
-        prompts_dir = FLOW_DIR / "prompts"
-        for block in self.config["blocks"]:
+        for block in flow_config["blocks"]:
             config = block["block_config"]
             if "prompt_config_path" in config:
-                prompt_path = prompts_dir.parent / config["prompt_config_path"]
+                prompt_path = FLOW_DIR / config["prompt_config_path"]
                 assert prompt_path.exists(), (
                     f"Missing prompt file: {config['prompt_config_path']}"
                 )
 
-    def test_pipeline_stages(self):
-        """Flow should have all four stages: question gen, answer gen, evaluation, formatting."""
-        block_names = [b["block_config"]["block_name"] for b in self.config["blocks"]]
-        # Stage 1: question generation
+    def test_pipeline_stages(self, flow_config):
+        """Flow should have all four stages."""
+        block_names = [
+            b["block_config"]["block_name"] for b in flow_config["blocks"]
+        ]
         assert "generate_questions" in block_names
-        # Stage 2: answer generation
         assert "generate_answers" in block_names
-        # Stage 3: faithfulness evaluation
         assert "evaluate_faithfulness" in block_names
-        # Stage 3: filter
         assert "filter_unfaithful" in block_names
-        # Stage 4: format to qna.yaml
         assert "format_qna_yaml" in block_names
 
-    def test_faithfulness_filter_keeps_yes(self):
+    def test_faithfulness_filter_keeps_yes(self, flow_config):
         """Faithfulness filter should keep only YES judgments."""
         filter_block = None
-        for block in self.config["blocks"]:
+        for block in flow_config["blocks"]:
             if block["block_config"]["block_name"] == "filter_unfaithful":
                 filter_block = block
                 break
@@ -121,14 +120,23 @@ class TestInstructLabQnAFlowYaml:
         assert filter_block["block_config"]["filter_value"] == "YES"
         assert filter_block["block_config"]["operation"] == "eq"
 
+    def test_faithfulness_judge_is_deterministic(self, flow_config):
+        """Faithfulness evaluation should use temperature 0 for consistency."""
+        eval_block = None
+        for block in flow_config["blocks"]:
+            if block["block_config"]["block_name"] == "evaluate_faithfulness":
+                eval_block = block
+                break
+        assert eval_block is not None
+        assert eval_block["block_config"].get("temperature") == 0
+
 
 class TestInstructLabQnAPrompts:
     """Test prompt template files."""
 
     def test_generate_questions_prompt(self):
         """Question generation prompt should reference required variables."""
-        prompt_path = FLOW_DIR / "prompts" / "generate_questions.yaml"
-        content = prompt_path.read_text()
+        content = (FLOW_DIR / "prompts" / "generate_questions.yaml").read_text()
         assert "{{document_text}}" in content
         assert "{{taxonomy_path}}" in content
         assert "{{domain}}" in content
@@ -137,18 +145,53 @@ class TestInstructLabQnAPrompts:
 
     def test_generate_answers_prompt(self):
         """Answer generation prompt should reference question and document."""
-        prompt_path = FLOW_DIR / "prompts" / "generate_answers.yaml"
-        content = prompt_path.read_text()
+        content = (FLOW_DIR / "prompts" / "generate_answers.yaml").read_text()
         assert "{{question}}" in content
         assert "{{document_text}}" in content
         assert "<answer>" in content
 
     def test_evaluate_faithfulness_prompt(self):
         """Faithfulness prompt should reference all three inputs."""
-        prompt_path = FLOW_DIR / "prompts" / "evaluate_faithfulness.yaml"
-        content = prompt_path.read_text()
+        content = (FLOW_DIR / "prompts" / "evaluate_faithfulness.yaml").read_text()
         assert "{{document_text}}" in content
         assert "{{question}}" in content
         assert "{{answer}}" in content
         assert "[Start of Judgment]" in content
         assert "[End of Judgment]" in content
+
+    def test_faithfulness_prompt_requires_full_support(self):
+        """Faithfulness prompt should require full (not partial) support."""
+        content = (FLOW_DIR / "prompts" / "evaluate_faithfulness.yaml").read_text()
+        assert "even partially" not in content
+        assert "every significant claim" in content.lower() or "all material claims" in content.lower()
+
+
+class TestInstructLabQnAFlowErrors:
+    """Negative-path tests for flow validation."""
+
+    def test_missing_metadata_key_detected(self, flow_config):
+        """Removing a required metadata key should be detectable."""
+        config_copy = dict(flow_config)
+        config_copy["metadata"] = {
+            k: v for k, v in flow_config["metadata"].items() if k != "license"
+        }
+        assert "license" not in config_copy["metadata"]
+
+    def test_missing_block_name_detected(self, flow_config):
+        """A block without block_name should fail validation."""
+        bad_block = {"block_type": "LLMChatBlock", "block_config": {}}
+        assert "block_name" not in bad_block["block_config"]
+
+    def test_duplicate_block_names_detected(self):
+        """Duplicate block names should be flagged."""
+        blocks = [
+            {"block_type": "A", "block_config": {"block_name": "same"}},
+            {"block_type": "B", "block_config": {"block_name": "same"}},
+        ]
+        names = [b["block_config"]["block_name"] for b in blocks]
+        assert len(names) != len(set(names))
+
+    def test_missing_prompt_file_detected(self, flow_config, tmp_path):
+        """A prompt_config_path pointing to a nonexistent file should fail."""
+        fake_path = tmp_path / "nonexistent.yaml"
+        assert not fake_path.exists()

--- a/tests/flow/test_instructlab_qna_flow.py
+++ b/tests/flow/test_instructlab_qna_flow.py
@@ -47,9 +47,10 @@ class TestInstructLabQnAFlowYaml:
     def test_has_output_columns(self):
         """Flow must declare expected output columns."""
         outputs = self.config["metadata"]["output_columns"]
-        assert "question" in outputs
-        assert "answer" in outputs
-        assert "faithfulness_judgment" in outputs
+        assert "qna_yaml" in outputs
+        assert "attribution_txt" in outputs
+        assert "taxonomy_path" in outputs
+        assert "num_examples" in outputs
 
     def test_has_blocks(self):
         """Flow must have blocks section with entries."""
@@ -96,7 +97,7 @@ class TestInstructLabQnAFlowYaml:
                 )
 
     def test_pipeline_stages(self):
-        """Flow should have the three expected stages: question gen, answer gen, evaluation."""
+        """Flow should have all four stages: question gen, answer gen, evaluation, formatting."""
         block_names = [b["block_config"]["block_name"] for b in self.config["blocks"]]
         # Stage 1: question generation
         assert "generate_questions" in block_names
@@ -104,8 +105,10 @@ class TestInstructLabQnAFlowYaml:
         assert "generate_answers" in block_names
         # Stage 3: faithfulness evaluation
         assert "evaluate_faithfulness" in block_names
-        # Final filter
+        # Stage 3: filter
         assert "filter_unfaithful" in block_names
+        # Stage 4: format to qna.yaml
+        assert "format_qna_yaml" in block_names
 
     def test_faithfulness_filter_keeps_yes(self):
         """Faithfulness filter should keep only YES judgments."""

--- a/tests/flow/test_instructlab_qna_flow.py
+++ b/tests/flow/test_instructlab_qna_flow.py
@@ -1,0 +1,151 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for InstructLab Knowledge Q&A Generation flow."""
+
+# Standard
+from pathlib import Path
+
+# Third Party
+import yaml
+
+FLOW_DIR = Path(__file__).resolve().parents[2] / (
+    "src/sdg_hub/flows/knowledge_infusion/instructlab_qna"
+)
+FLOW_YAML = FLOW_DIR / "flow.yaml"
+
+
+class TestInstructLabQnAFlowYaml:
+    """Test InstructLab Q&A flow YAML structure and metadata."""
+
+    def setup_method(self):
+        """Load the flow config once per test."""
+        with open(FLOW_YAML, encoding="utf-8") as f:
+            self.config = yaml.safe_load(f)
+
+    def test_flow_yaml_exists(self):
+        """Flow YAML file should exist."""
+        assert FLOW_YAML.exists()
+
+    def test_has_metadata(self):
+        """Flow must have metadata section."""
+        assert "metadata" in self.config
+        metadata = self.config["metadata"]
+        assert "name" in metadata
+        assert "description" in metadata
+        assert "version" in metadata
+        assert "license" in metadata
+        assert metadata["license"] == "Apache-2.0"
+
+    def test_has_dataset_requirements(self):
+        """Flow must declare required input columns."""
+        reqs = self.config["metadata"]["dataset_requirements"]
+        assert "required_columns" in reqs
+        required = reqs["required_columns"]
+        assert "document_text" in required
+        assert "taxonomy_path" in required
+        assert "domain" in required
+
+    def test_has_output_columns(self):
+        """Flow must declare expected output columns."""
+        outputs = self.config["metadata"]["output_columns"]
+        assert "question" in outputs
+        assert "answer" in outputs
+        assert "faithfulness_judgment" in outputs
+
+    def test_has_blocks(self):
+        """Flow must have blocks section with entries."""
+        assert "blocks" in self.config
+        blocks = self.config["blocks"]
+        assert isinstance(blocks, list)
+        assert len(blocks) > 0
+
+    def test_all_blocks_have_required_fields(self):
+        """Every block must have block_type and block_config with block_name."""
+        for i, block in enumerate(self.config["blocks"]):
+            assert "block_type" in block, f"Block {i} missing block_type"
+            assert "block_config" in block, f"Block {i} missing block_config"
+            assert "block_name" in block["block_config"], (
+                f"Block {i} missing block_name"
+            )
+
+    def test_block_names_are_unique(self):
+        """All block names must be unique within the flow."""
+        names = [b["block_config"]["block_name"] for b in self.config["blocks"]]
+        assert len(names) == len(set(names)), f"Duplicate block names: {names}"
+
+    def test_has_recommended_models(self):
+        """Flow should declare recommended models."""
+        models = self.config["metadata"]["recommended_models"]
+        assert "default" in models
+        assert "compatible" in models
+
+    def test_has_tags(self):
+        """Flow should have relevant tags."""
+        tags = self.config["metadata"]["tags"]
+        assert "instructlab" in tags
+        assert "qa-generation" in tags
+
+    def test_prompt_files_exist(self):
+        """All referenced prompt files must exist."""
+        prompts_dir = FLOW_DIR / "prompts"
+        for block in self.config["blocks"]:
+            config = block["block_config"]
+            if "prompt_config_path" in config:
+                prompt_path = prompts_dir.parent / config["prompt_config_path"]
+                assert prompt_path.exists(), (
+                    f"Missing prompt file: {config['prompt_config_path']}"
+                )
+
+    def test_pipeline_stages(self):
+        """Flow should have the three expected stages: question gen, answer gen, evaluation."""
+        block_names = [b["block_config"]["block_name"] for b in self.config["blocks"]]
+        # Stage 1: question generation
+        assert "generate_questions" in block_names
+        # Stage 2: answer generation
+        assert "generate_answers" in block_names
+        # Stage 3: faithfulness evaluation
+        assert "evaluate_faithfulness" in block_names
+        # Final filter
+        assert "filter_unfaithful" in block_names
+
+    def test_faithfulness_filter_keeps_yes(self):
+        """Faithfulness filter should keep only YES judgments."""
+        filter_block = None
+        for block in self.config["blocks"]:
+            if block["block_config"]["block_name"] == "filter_unfaithful":
+                filter_block = block
+                break
+        assert filter_block is not None
+        assert filter_block["block_config"]["filter_value"] == "YES"
+        assert filter_block["block_config"]["operation"] == "eq"
+
+
+class TestInstructLabQnAPrompts:
+    """Test prompt template files."""
+
+    def test_generate_questions_prompt(self):
+        """Question generation prompt should reference required variables."""
+        prompt_path = FLOW_DIR / "prompts" / "generate_questions.yaml"
+        content = prompt_path.read_text()
+        assert "{{document_text}}" in content
+        assert "{{taxonomy_path}}" in content
+        assert "{{domain}}" in content
+        assert "[QUESTION]" in content
+        assert "[END]" in content
+
+    def test_generate_answers_prompt(self):
+        """Answer generation prompt should reference question and document."""
+        prompt_path = FLOW_DIR / "prompts" / "generate_answers.yaml"
+        content = prompt_path.read_text()
+        assert "{{question}}" in content
+        assert "{{document_text}}" in content
+        assert "<answer>" in content
+
+    def test_evaluate_faithfulness_prompt(self):
+        """Faithfulness prompt should reference all three inputs."""
+        prompt_path = FLOW_DIR / "prompts" / "evaluate_faithfulness.yaml"
+        content = prompt_path.read_text()
+        assert "{{document_text}}" in content
+        assert "{{question}}" in content
+        assert "{{answer}}" in content
+        assert "[Start of Judgment]" in content
+        assert "[End of Judgment]" in content

--- a/tests/integration/knowledge_tuning/instructlab_qna/conftest.py
+++ b/tests/integration/knowledge_tuning/instructlab_qna/conftest.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fixtures for InstructLab Q&A flow integration tests."""
+
+from pathlib import Path
+import os
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def test_env_setup():
+    """Set up environment variables for testing."""
+    from dotenv import load_dotenv
+
+    example_env = Path("examples/knowledge_tuning/instructlab_qna/.env")
+    if example_env.exists():
+        load_dotenv(example_env, override=False)
+
+    test_defaults = {
+        "OPENAI_API_KEY": os.getenv("OPENAI_API_KEY", ""),
+        "SDG_MODEL": os.getenv("SDG_MODEL", "openai/gpt-5-mini"),
+    }
+
+    for key, value in test_defaults.items():
+        if key not in os.environ and value:
+            os.environ[key] = value
+
+    return test_defaults
+
+
+@pytest.fixture(scope="session")
+def notebook_path():
+    """Path to the InstructLab Q&A demo notebook."""
+    return Path("examples/knowledge_tuning/instructlab_qna/demo.ipynb")

--- a/tests/integration/knowledge_tuning/instructlab_qna/test_functional.py
+++ b/tests/integration/knowledge_tuning/instructlab_qna/test_functional.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Integration tests for InstructLab Q&A generation flow.
+
+Tests:
+1. Converts the demo notebook to a Python script
+2. Validates the script references the correct flow
+3. Executes the script end-to-end (requires OPENAI_API_KEY)
+4. Verifies output files are generated
+"""
+
+import os
+import subprocess
+
+import pytest
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not os.environ.get("OPENAI_API_KEY"),
+    reason="Requires OPENAI_API_KEY environment variable for LLM API calls",
+)
+def test_notebook_execution_and_output(test_env_setup, tmp_path, notebook_path):
+    """Test that the demo notebook runs end-to-end and produces output files."""
+    assert notebook_path.exists(), f"Notebook not found: {notebook_path}"
+
+    # Convert notebook to script
+    converted_script = tmp_path / "demo.py"
+    subprocess.run(
+        [
+            "python",
+            "-m",
+            "nbconvert",
+            "--to",
+            "script",
+            str(notebook_path),
+            "--output",
+            str(converted_script.stem),
+            "--output-dir",
+            str(tmp_path),
+        ],
+        check=True,
+    )
+
+    # Validate script references the correct flow
+    with open(converted_script) as f:
+        script_content = f.read()
+
+    assert "bright-coral-421" in script_content, "Flow ID not found in notebook"
+    assert "FlowRegistry" in script_content, "FlowRegistry usage not found"
+
+    # Execute the notebook script
+    env = os.environ.copy()
+    notebook_dir = notebook_path.parent
+    subprocess.run(
+        ["python", str(converted_script)],
+        cwd=str(notebook_dir),
+        env=env,
+        timeout=600,
+        check=True,
+    )
+
+    # Verify output directory was created with expected files
+    output_dir = notebook_dir / "output"
+    assert output_dir.exists(), "Output directory was not created"
+
+    # Should have at least one taxonomy path directory with qna.yaml
+    qna_files = list(output_dir.rglob("qna.yaml"))
+    attr_files = list(output_dir.rglob("attribution.txt"))
+
+    assert len(qna_files) > 0, "No qna.yaml files generated"
+    assert len(attr_files) > 0, "No attribution.txt files generated"
+
+    # Validate qna.yaml content
+    for qna_file in qna_files:
+        content = qna_file.read_text()
+        assert "version: 3" in content, f"Missing version in {qna_file}"
+        assert "seed_examples:" in content, f"Missing seed_examples in {qna_file}"
+        assert "question:" in content, f"Missing questions in {qna_file}"
+        assert "answer:" in content, f"Missing answers in {qna_file}"
+
+    print(f"\nGenerated {len(qna_files)} qna.yaml file(s)")
+    for f in qna_files:
+        print(f"  {f.relative_to(output_dir)}")


### PR DESCRIPTION
## Summary

- Adds a new `knowledge_infusion/instructlab_qna` flow that generates high-quality Q&A training data for [InstructLab](https://instructlab.ai/) knowledge contributions
- 3-stage pipeline: **question generation** → **grounded answer generation** → **faithfulness evaluation + filtering**
- Uses existing blocks (PromptBuilderBlock, LLMChatBlock, TagParserBlock, ColumnValueFilterBlock) — no new block code required
- Includes 3 prompt templates, a flow README, and 15 unit tests

## Motivation

InstructLab requires `qna.yaml` files with diverse, grounded Q&A pairs for knowledge contributions. This flow automates that generation from document chunks, producing training data that follows InstructLab's schema requirements. It slots into the existing `knowledge_infusion` category alongside the `enhanced_multi_summary_qa` flows.

## Pipeline

```
document_text + taxonomy_path + domain
        │
        ▼
   Generate Questions ──── 5 diverse questions per chunk
        │
        ▼
   Generate Answers ────── grounded in source document
        │
        ▼
   Evaluate Faithfulness ─ LLM-as-judge scores quality
        │
        ▼
   Filter Unfaithful ───── keep only faithful Q&A pairs
```

## Input/Output

**Input columns:** `document_text`, `taxonomy_path`, `domain`
**Output columns:** `question`, `answer`, `document_text`, `domain`, `taxonomy_path`, `faithfulness_explanation`, `faithfulness_judgment`

## Test plan

- [x] 15 unit tests covering YAML structure, metadata, block validation, and prompt template correctness
- [x] All 801 existing tests still pass
- [x] Ruff linting passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an InstructLab Knowledge Q&A generation flow, a formatter that emits InstructLab-compatible qna.yaml, attribution, taxonomy_path, and example counts, and a similarity-based deduplication filter.

* **Documentation**
  * Added flow documentation, a dedicated README, an examples tutorial with quick-start and export instructions, and catalog entry.

* **Tests**
  * Added unit and integration tests covering the flow, prompts, formatter, filter, and output YAML compliance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->