### PR TITLE
test(agent-config): improve coverage for agent_config and message_for…

### DIFF
--- a/tests/flow/test_agent_config.py
+++ b/tests/flow/test_agent_config.py
@@ -1,0 +1,217 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for agent_config.py and serialization.py agent-config paths.
+
+Covers the uncovered branches identified in issue #646:
+- The extra=="allow" branch in set_agent_config()
+- reset_agent_config() edge cases
+- from_yaml sets flow._agent_config_set based on agent block presence
+"""
+
+from unittest.mock import Mock, patch
+import logging
+
+from sdg_hub import Flow, FlowMetadata
+from sdg_hub.core.flow.metadata import RecommendedModels
+import pytest
+import yaml
+
+from tests.flow.conftest import MockBlock
+
+
+@pytest.fixture()
+def test_metadata():
+    """Create sample FlowMetadata for agent config tests."""
+    return FlowMetadata(
+        name="Test Flow",
+        description="A test flow",
+        version="1.0.0",
+        author="Test Author",
+        recommended_models=RecommendedModels(
+            default="test-model", compatible=["alt-model"], experimental=[]
+        ),
+        tags=["test"],
+    )
+
+
+def _build_flow_yaml(name, description, block_type, block_name):
+    """Build a flow YAML config dict with the given block definition."""
+    return {
+        "metadata": {
+            "name": name,
+            "description": description,
+            "version": "1.0.0",
+            "recommended_models": {
+                "default": "test-model",
+                "compatible": [],
+                "experimental": [],
+            },
+        },
+        "blocks": [
+            {
+                "block_type": block_type,
+                "block_config": {
+                    "block_name": block_name,
+                    "input_cols": "input",
+                    "output_cols": "output",
+                },
+            }
+        ],
+    }
+
+
+def _create_mock_block(name="test_block"):
+    """Create a MockBlock with default input/output columns."""
+    return MockBlock(block_name=name, input_cols=["input"], output_cols=["output"])
+
+
+def _create_mock_agent_block(name="agent_block"):
+    """Create a MockBlock configured as an agent block with block_type='agent'.
+
+    Uses setattr for agent attributes rather than Pydantic field declarations.
+    This mirrors how test_base.py's create_mock_agent_block works and is
+    sufficient for the hasattr-based checks in set_agent_config(). If the
+    production code switches to model_fields introspection, these helpers
+    would need to be updated to use declared Pydantic fields instead.
+    """
+    block = MockBlock(block_name=name, input_cols=["input"], output_cols=["output"])
+    block.block_type = "agent"
+    block.agent_framework = "langflow"
+    block.agent_url = "http://localhost:7860"
+    block.agent_api_key = None
+    return block
+
+
+class TestAgentConfigCoverage:
+    """Tests targeting uncovered branches in agent_config.py."""
+
+    # --- Gap 1: extra == "allow" branch in set_agent_config ---
+
+    def test_set_agent_config_extra_allow_branch(self, test_metadata):
+        """Passing an unknown kwarg triggers the elif extra=='allow' branch."""
+        agent_block = _create_mock_agent_block("agent1")
+        flow = Flow(blocks=[agent_block], metadata=test_metadata)
+
+        assert (
+            agent_block.model_config.get("extra") == "allow"
+        ), "Precondition: block must allow extra fields for this branch"
+        assert not hasattr(agent_block, "custom_timeout")
+
+        flow.set_agent_config(
+            agent_url="http://new:7860",
+            custom_timeout=60,
+        )
+
+        # agent_url hit the hasattr branch (already exists)
+        assert flow.blocks[0].agent_url == "http://new:7860"
+        # custom_timeout hit the elif extra=="allow" branch
+        assert flow.blocks[0].custom_timeout == 60
+
+    def test_set_agent_config_extra_allow_sensitive_redaction(
+        self, test_metadata, caplog
+    ):
+        """Sensitive params via the extra=='allow' branch are redacted in logs."""
+        agent_block = _create_mock_agent_block("agent1")
+        flow = Flow(blocks=[agent_block], metadata=test_metadata)
+
+        assert (
+            agent_block.model_config.get("extra") == "allow"
+        ), "Precondition: block must allow extra fields for this branch"
+        assert not hasattr(agent_block, "secret")
+
+        with caplog.at_level(logging.DEBUG, logger="sdg_hub.core.flow.agent_config"):
+            flow.set_agent_config(
+                agent_url="http://new:7860",
+                secret="super-secret-value",
+            )
+
+        assert flow.blocks[0].secret == "super-secret-value"
+
+        # The secret value must not appear in any log message
+        all_log_text = " ".join(record.message for record in caplog.records)
+        assert "super-secret-value" not in all_log_text
+        # Verify redaction actually happened (not just silent skip)
+        assert "secret set (redacted)" in all_log_text
+
+    # --- Gap 2: reset_agent_config() edge cases ---
+
+    def test_reset_agent_config_no_agent_blocks(self, test_metadata):
+        """Reset on a flow with no agent blocks is a silent no-op."""
+        regular_block = _create_mock_block("regular")
+        flow = Flow(blocks=[regular_block], metadata=test_metadata)
+
+        assert flow.is_agent_config_set()
+
+        flow.reset_agent_config()
+
+        # Should still report as set (no agent blocks = nothing to reset)
+        assert flow.is_agent_config_set()
+
+    def test_reset_agent_config_never_configured(self, test_metadata):
+        """Reset on a flow with agent blocks that was never configured."""
+        agent_block = _create_mock_agent_block("agent1")
+        flow = Flow(blocks=[agent_block], metadata=test_metadata)
+
+        assert not flow.is_agent_config_set()
+
+        flow.reset_agent_config()
+
+        # Should remain not set
+        assert not flow.is_agent_config_set()
+
+    # --- Gap 3: from_yaml sets flow._agent_config_set based on agent blocks ---
+
+    def test_from_yaml_with_agent_blocks_sets_flag_false(self, tmp_path):
+        """Loading a YAML with agent blocks sets flow._agent_config_set=False."""
+        flow_config = _build_flow_yaml(
+            "Agent Flow", "Flow with agent block", "AgentBlock", "my_agent"
+        )
+
+        yaml_path = tmp_path / "agent_flow.yaml"
+        with open(yaml_path, "w") as f:
+            yaml.dump(flow_config, f)
+
+        with patch("sdg_hub.core.flow.serialization.BlockRegistry._get") as mock_get:
+            mock_block_class = Mock()
+            mock_instance = _create_mock_agent_block("my_agent")
+            mock_block_class.return_value = mock_instance
+            mock_get.return_value = mock_block_class
+
+            flow = Flow.from_yaml(str(yaml_path))
+
+            mock_get.assert_called_once_with("AgentBlock")
+            mock_block_class.assert_called_once()
+            kwargs = mock_block_class.call_args.kwargs
+            assert kwargs["block_name"] == "my_agent"
+            assert kwargs["input_cols"] == "input"
+            assert kwargs["output_cols"] == "output"
+
+        assert flow._agent_config_set is False
+        assert not flow.is_agent_config_set()
+
+    def test_from_yaml_without_agent_blocks_sets_flag_true(self, tmp_path):
+        """Loading a YAML with only regular blocks sets flow._agent_config_set=True."""
+        flow_config = _build_flow_yaml(
+            "Regular Flow", "Flow without agent blocks", "MockBlock", "regular_block"
+        )
+
+        yaml_path = tmp_path / "regular_flow.yaml"
+        with open(yaml_path, "w") as f:
+            yaml.dump(flow_config, f)
+
+        with patch("sdg_hub.core.flow.serialization.BlockRegistry._get") as mock_get:
+            mock_block_class = Mock()
+            mock_instance = _create_mock_block("regular_block")
+            mock_block_class.return_value = mock_instance
+            mock_get.return_value = mock_block_class
+
+            flow = Flow.from_yaml(str(yaml_path))
+
+            mock_get.assert_called_once_with("MockBlock")
+            mock_block_class.assert_called_once()
+            kwargs = mock_block_class.call_args.kwargs
+            assert kwargs["block_name"] == "regular_block"
+            assert kwargs["input_cols"] == "input"
+            assert kwargs["output_cols"] == "output"
+
+        assert flow._agent_config_set is True
+        assert flow.is_agent_config_set()

--- a/tests/utils/test_message_formatter.py
+++ b/tests/utils/test_message_formatter.py
@@ -129,3 +129,81 @@ class TestToolTraceToMessages:
         ]
         msgs = tool_trace_to_messages(trace, SAMPLE_TOOL_LIST)
         assert msgs[2]["content"] == ""
+
+    # --- Edge cases for malformed traces (issue #646) ---
+
+    def test_missing_type_field(self):
+        """A step with no 'type' key is silently skipped."""
+        trace = [{"text": "hello"}]
+        msgs = tool_trace_to_messages(trace, SAMPLE_TOOL_LIST)
+        # Only the system message should be present
+        assert len(msgs) == 1
+        assert msgs[0]["role"] == "system"
+
+    def test_empty_content_list(self):
+        """Empty content list is falsy, so the entire output dict is JSON-serialized."""
+        trace = [
+            {
+                "type": "tool_use",
+                "name": "search_products",
+                "tool_input": {},
+                "output": {"content": []},
+            },
+        ]
+        msgs = tool_trace_to_messages(trace, SAMPLE_TOOL_LIST)
+        # Empty content list is falsy, so falls through to json.dumps(output)
+        assert json.loads(msgs[2]["content"]) == {"content": []}
+
+    def test_missing_header_field(self):
+        """A text step with no 'header' key defaults to assistant message."""
+        trace = [{"type": "text", "text": "no header here"}]
+        msgs = tool_trace_to_messages(trace, SAMPLE_TOOL_LIST)
+        assert len(msgs) == 2
+        assert msgs[1] == {"role": "assistant", "content": "no header here"}
+
+    def test_missing_text_in_content_item(self):
+        """Content item without 'text' key returns empty string."""
+        trace = [
+            {
+                "type": "tool_use",
+                "name": "search_products",
+                "tool_input": {},
+                "output": {"content": [{"type": "text"}]},
+            },
+        ]
+        msgs = tool_trace_to_messages(trace, SAMPLE_TOOL_LIST)
+        assert msgs[2]["content"] == ""
+
+    def test_non_list_content_field(self):
+        """Non-list content field falls through to structuredContent path."""
+        trace = [
+            {
+                "type": "tool_use",
+                "name": "search_products",
+                "tool_input": {},
+                "output": {"content": "not a list"},
+            },
+        ]
+        msgs = tool_trace_to_messages(trace, SAMPLE_TOOL_LIST)
+        # isinstance("not a list", list) is False, so falls through
+        assert json.loads(msgs[2]["content"]) == {"content": "not a list"}
+
+    def test_unknown_type_value(self):
+        """A step with an unrecognized type value is silently skipped."""
+        trace = [{"type": "image", "url": "http://example.com/img.png"}]
+        msgs = tool_trace_to_messages(trace, SAMPLE_TOOL_LIST)
+        assert len(msgs) == 1
+        assert msgs[0]["role"] == "system"
+
+    def test_numeric_tool_output(self):
+        """Non-dict, non-string, non-None output is JSON-serialized."""
+        trace = [
+            {
+                "type": "tool_use",
+                "name": "search_products",
+                "tool_input": {},
+                "output": 42,
+            },
+        ]
+        msgs = tool_trace_to_messages(trace, SAMPLE_TOOL_LIST)
+        assert msgs[2]["content"] == "42"


### PR DESCRIPTION
## Summary

Closes #646

Adds 11 tests covering the uncovered code paths flagged by codecov on PR #628:

- agent_config.py : the `extra == "allow"` branch in `set_agent_config()`, sensitive param redaction within that branch, `reset_agent_config()` edge cases (no agent blocks, never configured)

- serialization.py: flow loading with agent blocks sets `_agent_config_set = False`, flow loading without agent blocks sets `_agent_config_set = True`

- message_formatter.py: malformed trace edge cases (missing `type` field, empty `contents` list, missing `header` field, missing `text` in content item, non-list `content` field)


## Test plan
- [x] All 11 new tests pass locally
- [x] Full test suite passes (797 tests, 0 failures)
- [x] ruff lint clean
- [x] ruff format clean
- [x] Pre-commit hooks pass (ruff, ruff-format, conventional-pre-commit)
- [x] No production code changes — tests only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for agent-configuration workflows: added scenarios for setting, resetting, and detecting agent config, YAML-loading edge cases, and verification that sensitive values are redacted from logs.
  * Added unit tests for message formatting to handle malformed tool traces, missing or empty fields, non-list or unexpected content types, and numeric or edge-case outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->