### PR TITLE
feat(connectors): add LangGraph agent connector

### DIFF
--- a/src/sdg_hub/core/blocks/agent/agent_block.py
+++ b/src/sdg_hub/core/blocks/agent/agent_block.py
@@ -121,6 +121,13 @@ class AgentBlock(BaseBlock):
         description="Maximum concurrent requests in async mode",
         gt=0,
     )
+    connector_kwargs: dict[str, Any] = Field(
+        default_factory=dict,
+        description=(
+            "Extra keyword arguments passed to the connector constructor. "
+            "Use for framework-specific settings like assistant_id for LangGraph."
+        ),
+    )
 
     # Private attributes
     _connector: Optional[BaseAgentConnector] = PrivateAttr(default=None)
@@ -143,6 +150,7 @@ class AgentBlock(BaseBlock):
             self.agent_api_key,
             self.timeout,
             self.max_retries,
+            tuple(sorted(self.connector_kwargs.items())),
         )
         if self._connector is None or self._connector_config_key != config_key:
             connector_class = ConnectorRegistry.get(self.agent_framework)
@@ -152,7 +160,7 @@ class AgentBlock(BaseBlock):
                 timeout=self.timeout,
                 max_retries=self.max_retries,
             )
-            self._connector = connector_class(config=config)
+            self._connector = connector_class(config=config, **self.connector_kwargs)
             self._connector_config_key = config_key
         return self._connector
 

--- a/src/sdg_hub/core/blocks/agent/agent_block.py
+++ b/src/sdg_hub/core/blocks/agent/agent_block.py
@@ -160,7 +160,14 @@ class AgentBlock(BaseBlock):
                 timeout=self.timeout,
                 max_retries=self.max_retries,
             )
-            self._connector = connector_class(config=config, **self.connector_kwargs)
+            try:
+                self._connector = connector_class(
+                    config=config, **self.connector_kwargs
+                )
+            except TypeError as e:
+                raise ConnectorError(
+                    f"Invalid connector_kwargs for '{self.agent_framework}': {e}"
+                ) from e
             self._connector_config_key = config_key
         return self._connector
 

--- a/src/sdg_hub/core/blocks/agent/agent_block.py
+++ b/src/sdg_hub/core/blocks/agent/agent_block.py
@@ -3,9 +3,10 @@
 
 from typing import Any, Optional
 import asyncio
+import json
 import uuid
 
-from pydantic import Field, PrivateAttr
+from pydantic import Field, PrivateAttr, ValidationError
 from tqdm import tqdm
 import pandas as pd
 
@@ -150,7 +151,7 @@ class AgentBlock(BaseBlock):
             self.agent_api_key,
             self.timeout,
             self.max_retries,
-            tuple(sorted(self.connector_kwargs.items())),
+            json.dumps(self.connector_kwargs, sort_keys=True, default=str),
         )
         if self._connector is None or self._connector_config_key != config_key:
             connector_class = ConnectorRegistry.get(self.agent_framework)
@@ -164,7 +165,7 @@ class AgentBlock(BaseBlock):
                 self._connector = connector_class(
                     config=config, **self.connector_kwargs
                 )
-            except TypeError as e:
+            except (TypeError, ValidationError) as e:
                 raise ConnectorError(
                     f"Invalid connector_kwargs for '{self.agent_framework}': {e}"
                 ) from e

--- a/src/sdg_hub/core/connectors/__init__.py
+++ b/src/sdg_hub/core/connectors/__init__.py
@@ -23,7 +23,7 @@ Example
 """
 
 # Import agent module to register connectors
-from .agent import BaseAgentConnector, LangflowConnector
+from .agent import BaseAgentConnector, LangflowConnector, LangGraphConnector
 from .base import BaseConnector, ConnectorConfig
 from .exceptions import ConnectorError, ConnectorHTTPError
 from .http import HttpClient
@@ -36,6 +36,7 @@ __all__ = [
     # Agent connectors
     "BaseAgentConnector",
     "LangflowConnector",
+    "LangGraphConnector",
     # Registry
     "ConnectorRegistry",
     # HTTP utilities

--- a/src/sdg_hub/core/connectors/agent/__init__.py
+++ b/src/sdg_hub/core/connectors/agent/__init__.py
@@ -3,8 +3,10 @@
 
 from .base import BaseAgentConnector
 from .langflow import LangflowConnector
+from .langgraph import LangGraphConnector
 
 __all__ = [
     "BaseAgentConnector",
     "LangflowConnector",
+    "LangGraphConnector",
 ]

--- a/src/sdg_hub/core/connectors/agent/langgraph.py
+++ b/src/sdg_hub/core/connectors/agent/langgraph.py
@@ -29,8 +29,9 @@ class LangGraphConnector(BaseAgentConnector):
     1. Creates a thread via ``POST {base_url}/threads``
     2. Runs the agent via ``POST {base_url}/threads/{thread_id}/runs/wait``
 
-    The ``session_id`` from :class:`AgentBlock` maps to the LangGraph
-    ``thread_id``, so rows sharing a session share conversation history.
+    Each call creates a new LangGraph thread. The ``session_id`` is
+    stored as thread metadata for traceability but does not cause
+    thread reuse -- each request starts a fresh conversation.
 
     Parameters
     ----------
@@ -55,6 +56,7 @@ class LangGraphConnector(BaseAgentConnector):
 
     assistant_id: str = Field(
         default="agent",
+        min_length=1,
         description="The assistant ID or graph name to run.",
     )
 
@@ -88,13 +90,24 @@ class LangGraphConnector(BaseAgentConnector):
         messages : list[dict]
             Messages in standard format.
         session_id : str
-            Session identifier (used as thread_id).
+            Session identifier. Not used in the run payload; included
+            for interface compatibility with ``BaseAgentConnector``.
 
         Returns
         -------
         dict
             LangGraph ``/runs/wait`` request payload.
+
+        Raises
+        ------
+        ConnectorError
+            If messages list is empty.
         """
+        if not messages:
+            raise ConnectorError(
+                "Cannot send empty messages list to LangGraph. "
+                "Expected at least one message with role and content."
+            )
         return {
             "assistant_id": self.assistant_id,
             "input": {"messages": messages},
@@ -125,6 +138,17 @@ class LangGraphConnector(BaseAgentConnector):
         if not isinstance(response, dict):
             raise ConnectorError(
                 f"Expected dict response, got {type(response).__name__}"
+            )
+        if not response:
+            raise ConnectorError(
+                "LangGraph API returned an empty response. "
+                "Verify the agent graph is configured correctly."
+            )
+        if "messages" not in response:
+            logger.warning(
+                "LangGraph response has no 'messages' key. "
+                f"Available keys: {list(response.keys())}. "
+                "This may indicate an API error or misconfigured graph."
             )
 
         return response

--- a/src/sdg_hub/core/connectors/agent/langgraph.py
+++ b/src/sdg_hub/core/connectors/agent/langgraph.py
@@ -180,3 +180,100 @@ class LangGraphConnector(BaseAgentConnector):
         logger.debug(f"Received response from {run_url}")
 
         return self.parse_response(raw_response)
+
+    # ------------------------------------------------------------------
+    # Response field extraction
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def extract_text(cls, response: dict[str, Any]) -> str | None:
+        """Extract text from the last AI message in LangGraph state.
+
+        Parameters
+        ----------
+        response : dict
+            LangGraph final graph state.
+
+        Returns
+        -------
+        str or None
+            Content of the last AI message, or None if not found.
+        """
+        messages = response.get("messages")
+        if not messages or not isinstance(messages, list):
+            return None
+
+        for msg in reversed(messages):
+            if not isinstance(msg, dict):
+                continue
+            role = msg.get("type") or msg.get("role", "")
+            if role in ("ai", "assistant"):
+                content = msg.get("content")
+                if content is None:
+                    logger.warning("AI message content is None, using empty string")
+                    return ""
+                return str(content)
+
+        return None
+
+    @classmethod
+    def extract_session_id(cls, response: dict[str, Any]) -> str | None:
+        """Extract session ID from a LangGraph response.
+
+        LangGraph uses thread-based state; there is no top-level
+        ``session_id`` in the run response.
+
+        Parameters
+        ----------
+        response : dict
+            LangGraph final graph state.
+
+        Returns
+        -------
+        None
+            Always returns None for LangGraph.
+        """
+        return None
+
+    @classmethod
+    def extract_tool_trace(
+        cls, response: dict[str, Any]
+    ) -> list[dict[str, Any]] | None:
+        """Extract tool call trace from LangGraph messages.
+
+        Collects AI messages with ``tool_calls`` and tool response
+        messages into a structured trace.
+
+        Parameters
+        ----------
+        response : dict
+            LangGraph final graph state.
+
+        Returns
+        -------
+        list[dict] or None
+            List of tool-related message dicts, or None if none found.
+        """
+        messages = response.get("messages")
+        if not messages or not isinstance(messages, list):
+            return None
+
+        tool_entries: list[dict[str, Any]] = []
+        for msg in messages:
+            if not isinstance(msg, dict):
+                continue
+            role = msg.get("type") or msg.get("role", "")
+            if role in ("ai", "assistant") and msg.get("tool_calls"):
+                tool_entries.append(
+                    {"type": "tool_use", "tool_calls": msg["tool_calls"]}
+                )
+            elif role == "tool":
+                tool_entries.append(
+                    {
+                        "type": "tool_result",
+                        "name": msg.get("name", ""),
+                        "content": msg.get("content", ""),
+                    }
+                )
+
+        return tool_entries if tool_entries else None

--- a/src/sdg_hub/core/connectors/agent/langgraph.py
+++ b/src/sdg_hub/core/connectors/agent/langgraph.py
@@ -1,0 +1,182 @@
+# SPDX-License-Identifier: Apache-2.0
+"""LangGraph agent framework connector."""
+
+from typing import Any
+
+from pydantic import Field
+
+from ...utils.logger_config import setup_logger
+from ..exceptions import ConnectorError
+from ..registry import ConnectorRegistry
+from .base import BaseAgentConnector
+
+logger = setup_logger(__name__)
+
+
+@ConnectorRegistry.register("langgraph")
+class LangGraphConnector(BaseAgentConnector):
+    """Connector for LangGraph agent framework.
+
+    LangGraph is a framework for building stateful, multi-actor applications
+    with LLMs. This connector communicates with any HTTP endpoint that
+    implements the LangGraph Platform API (thread and run management).
+    Common deployment options include ``langgraph dev`` for local
+    development, the LangGraph Platform for managed hosting, or
+    self-hosted setups behind FastAPI / Docker on any cloud provider.
+
+    The connector uses thread-based runs:
+
+    1. Creates a thread via ``POST {base_url}/threads``
+    2. Runs the agent via ``POST {base_url}/threads/{thread_id}/runs/wait``
+
+    The ``session_id`` from :class:`AgentBlock` maps to the LangGraph
+    ``thread_id``, so rows sharing a session share conversation history.
+
+    Parameters
+    ----------
+    assistant_id : str
+        The assistant ID or graph name to run. Defaults to ``"agent"``,
+        which is the standard default for LangGraph deployments.
+
+    Example
+    -------
+    >>> from sdg_hub.core.connectors import ConnectorConfig, LangGraphConnector
+    >>>
+    >>> config = ConnectorConfig(
+    ...     url="http://localhost:2024",
+    ...     api_key="your-api-key",
+    ... )
+    >>> connector = LangGraphConnector(config=config)
+    >>> response = connector.send(
+    ...     messages=[{"role": "user", "content": "Hello!"}],
+    ...     session_id="session-123",
+    ... )
+    """
+
+    assistant_id: str = Field(
+        default="agent",
+        description="The assistant ID or graph name to run.",
+    )
+
+    def _build_headers(self) -> dict[str, str]:
+        """Build headers for LangGraph API.
+
+        LangGraph / LangSmith deployments use ``x-api-key`` for authentication.
+
+        Returns
+        -------
+        dict[str, str]
+            HTTP headers.
+        """
+        headers = {"Content-Type": "application/json"}
+        if self.config.api_key:
+            headers["x-api-key"] = self.config.api_key
+        return headers
+
+    def build_request(
+        self,
+        messages: list[dict[str, Any]],
+        session_id: str,
+    ) -> dict[str, Any]:
+        """Build LangGraph run request payload.
+
+        Formats messages into the LangGraph input structure with the
+        configured ``assistant_id``.
+
+        Parameters
+        ----------
+        messages : list[dict]
+            Messages in standard format.
+        session_id : str
+            Session identifier (used as thread_id).
+
+        Returns
+        -------
+        dict
+            LangGraph ``/runs/wait`` request payload.
+        """
+        return {
+            "assistant_id": self.assistant_id,
+            "input": {"messages": messages},
+        }
+
+    def parse_response(self, response: dict[str, Any]) -> dict[str, Any]:
+        """Parse LangGraph response.
+
+        LangGraph returns the final graph state as a dict. For chat agents
+        this typically contains a ``messages`` list with the full
+        conversation history.
+
+        Parameters
+        ----------
+        response : dict
+            Raw response from LangGraph API (final graph state).
+
+        Returns
+        -------
+        dict
+            Validated response dict.
+
+        Raises
+        ------
+        ConnectorError
+            If response is not a valid dict.
+        """
+        if not isinstance(response, dict):
+            raise ConnectorError(
+                f"Expected dict response, got {type(response).__name__}"
+            )
+
+        return response
+
+    async def _send_async(
+        self,
+        messages: list[dict[str, Any]],
+        session_id: str,
+    ) -> dict[str, Any]:
+        """Send request to LangGraph API using thread-based runs.
+
+        Creates a thread and then executes a run on it. The ``session_id``
+        is stored as thread metadata for traceability.
+
+        Parameters
+        ----------
+        messages : list[dict]
+            Messages to send to the agent.
+        session_id : str
+            Session identifier, stored as thread metadata.
+
+        Returns
+        -------
+        dict
+            Parsed response from the agent (final graph state).
+        """
+        if not self.config.url:
+            raise ConnectorError("No URL configured for connector")
+
+        http_client = self._get_http_client()
+        headers = self._build_headers()
+        base_url = self.config.url.rstrip("/")
+
+        # Step 1: Create a thread
+        logger.debug(f"Creating thread at {base_url}/threads")
+        thread_response = await http_client.post(
+            url=f"{base_url}/threads",
+            payload={"metadata": {"session_id": session_id}},
+            headers=headers,
+        )
+        thread_id = thread_response["thread_id"]
+        logger.debug(f"Created thread {thread_id}")
+
+        # Step 2: Run agent on the thread
+        request = self.build_request(messages, session_id)
+        run_url = f"{base_url}/threads/{thread_id}/runs/wait"
+        logger.debug(f"Sending run request to {run_url}")
+        raw_response = await http_client.post(
+            url=run_url,
+            payload=request,
+            headers=headers,
+        )
+        logger.debug(f"Received response from {run_url}")
+
+        return self.parse_response(raw_response)

--- a/src/sdg_hub/core/connectors/agent/langgraph.py
+++ b/src/sdg_hub/core/connectors/agent/langgraph.py
@@ -165,7 +165,9 @@ class LangGraphConnector(BaseAgentConnector):
             payload={"metadata": {"session_id": session_id}},
             headers=headers,
         )
-        thread_id = thread_response["thread_id"]
+        thread_id = thread_response.get("thread_id")
+        if not thread_id:
+            raise ConnectorError("LangGraph /threads response missing 'thread_id'")
         logger.debug(f"Created thread {thread_id}")
 
         # Step 2: Run agent on the thread

--- a/tests/connectors/agent/test_langgraph.py
+++ b/tests/connectors/agent/test_langgraph.py
@@ -1,0 +1,171 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for LangGraphConnector."""
+
+from unittest.mock import AsyncMock, patch
+
+from sdg_hub.core.connectors.agent.langgraph import LangGraphConnector
+from sdg_hub.core.connectors.base import ConnectorConfig
+from sdg_hub.core.connectors.exceptions import ConnectorError
+from sdg_hub.core.connectors.registry import ConnectorRegistry
+import pytest
+
+
+class TestLangGraphConnector:
+    """Test LangGraphConnector."""
+
+    def test_registered_in_registry(self):
+        """Test connector is registered."""
+        assert ConnectorRegistry.get("langgraph") == LangGraphConnector
+
+    def test_build_headers_with_api_key(self):
+        """Test LangGraph uses x-api-key header."""
+        connector = LangGraphConnector(
+            config=ConnectorConfig(url="http://test", api_key="secret")
+        )
+        headers = connector._build_headers()
+        assert headers["x-api-key"] == "secret"
+        assert "Authorization" not in headers
+
+    def test_build_headers_without_api_key(self):
+        """Test headers without API key."""
+        connector = LangGraphConnector(config=ConnectorConfig(url="http://test"))
+        assert connector._build_headers() == {"Content-Type": "application/json"}
+
+    def test_build_request(self):
+        """Test request building with default assistant_id."""
+        connector = LangGraphConnector(config=ConnectorConfig(url="http://test"))
+
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi"},
+            {"role": "user", "content": "What is 2+2?"},
+        ]
+        request = connector.build_request(messages, "session-1")
+
+        assert request == {
+            "assistant_id": "agent",
+            "input": {"messages": messages},
+        }
+
+    def test_build_request_custom_assistant_id(self):
+        """Test request building with custom assistant_id."""
+        connector = LangGraphConnector(
+            config=ConnectorConfig(url="http://test"),
+            assistant_id="my-graph",
+        )
+
+        messages = [{"role": "user", "content": "Hello"}]
+        request = connector.build_request(messages, "session-1")
+
+        assert request["assistant_id"] == "my-graph"
+
+    def test_parse_response_valid(self):
+        """Test response parsing returns raw dict."""
+        connector = LangGraphConnector(config=ConnectorConfig(url="http://test"))
+
+        response = {
+            "messages": [
+                {"type": "human", "content": "Hello"},
+                {"type": "ai", "content": "Hi there!"},
+            ]
+        }
+        assert connector.parse_response(response) == response
+
+    def test_parse_response_non_dict_raises_error(self):
+        """Test non-dict response raises error."""
+        connector = LangGraphConnector(config=ConnectorConfig(url="http://test"))
+
+        with pytest.raises(ConnectorError, match="Expected dict"):
+            connector.parse_response(["not", "a", "dict"])
+
+    @pytest.mark.asyncio
+    async def test_send_async_no_url_raises_error(self):
+        """Test error when no URL configured."""
+        connector = LangGraphConnector(config=ConnectorConfig())
+        with pytest.raises(ConnectorError, match="No URL configured"):
+            await connector._send_async(
+                [{"role": "user", "content": "hi"}], "session-1"
+            )
+
+    @pytest.mark.asyncio
+    async def test_send_async_full_flow(self):
+        """Test _send_async creates thread then runs agent."""
+        connector = LangGraphConnector(
+            config=ConnectorConfig(url="http://localhost:2024")
+        )
+
+        mock_client = AsyncMock()
+        # First call: POST /threads -> returns thread_id
+        # Second call: POST /threads/{id}/runs/wait -> returns graph state
+        mock_client.post.side_effect = [
+            {"thread_id": "thread-abc-123"},
+            {
+                "messages": [
+                    {"type": "human", "content": "Hello"},
+                    {"type": "ai", "content": "Hi there!"},
+                ]
+            },
+        ]
+
+        with patch.object(connector, "_get_http_client", return_value=mock_client):
+            result = await connector._send_async(
+                [{"role": "user", "content": "Hello"}], "session-1"
+            )
+
+        # Verify thread creation call
+        thread_call = mock_client.post.call_args_list[0]
+        assert thread_call[1]["url"] == "http://localhost:2024/threads"
+        assert thread_call[1]["payload"]["metadata"]["session_id"] == "session-1"
+
+        # Verify run call
+        run_call = mock_client.post.call_args_list[1]
+        assert (
+            run_call[1]["url"]
+            == "http://localhost:2024/threads/thread-abc-123/runs/wait"
+        )
+        assert run_call[1]["payload"]["assistant_id"] == "agent"
+        assert run_call[1]["payload"]["input"]["messages"] == [
+            {"role": "user", "content": "Hello"}
+        ]
+
+        # Verify response
+        assert result["messages"][1]["content"] == "Hi there!"
+
+    @pytest.mark.asyncio
+    async def test_send_async_strips_trailing_slash(self):
+        """Test that trailing slashes in URL are handled."""
+        connector = LangGraphConnector(
+            config=ConnectorConfig(url="http://localhost:2024/")
+        )
+
+        mock_client = AsyncMock()
+        mock_client.post.side_effect = [
+            {"thread_id": "thread-1"},
+            {"messages": [{"type": "ai", "content": "ok"}]},
+        ]
+
+        with patch.object(connector, "_get_http_client", return_value=mock_client):
+            await connector._send_async([{"role": "user", "content": "test"}], "s1")
+
+        thread_url = mock_client.post.call_args_list[0][1]["url"]
+        assert thread_url == "http://localhost:2024/threads"
+
+    @pytest.mark.asyncio
+    async def test_send_async_custom_assistant_id(self):
+        """Test _send_async uses custom assistant_id."""
+        connector = LangGraphConnector(
+            config=ConnectorConfig(url="http://localhost:2024"),
+            assistant_id="my-custom-graph",
+        )
+
+        mock_client = AsyncMock()
+        mock_client.post.side_effect = [
+            {"thread_id": "thread-1"},
+            {"messages": [{"type": "ai", "content": "response"}]},
+        ]
+
+        with patch.object(connector, "_get_http_client", return_value=mock_client):
+            await connector._send_async([{"role": "user", "content": "test"}], "s1")
+
+        run_payload = mock_client.post.call_args_list[1][1]["payload"]
+        assert run_payload["assistant_id"] == "my-custom-graph"

--- a/tests/connectors/agent/test_langgraph.py
+++ b/tests/connectors/agent/test_langgraph.py
@@ -3,11 +3,12 @@
 
 from unittest.mock import AsyncMock, patch
 
+import pytest
+
 from sdg_hub.core.connectors.agent.langgraph import LangGraphConnector
 from sdg_hub.core.connectors.base import ConnectorConfig
 from sdg_hub.core.connectors.exceptions import ConnectorError
 from sdg_hub.core.connectors.registry import ConnectorRegistry
-import pytest
 
 
 class TestLangGraphConnector:
@@ -169,3 +170,90 @@ class TestLangGraphConnector:
 
         run_payload = mock_client.post.call_args_list[1][1]["payload"]
         assert run_payload["assistant_id"] == "my-custom-graph"
+
+
+class TestLangGraphExtractText:
+    """Test LangGraphConnector.extract_text class method."""
+
+    def test_success(self):
+        response = {
+            "messages": [
+                {"type": "human", "content": "Hello"},
+                {"type": "ai", "content": "Hi there!"},
+            ]
+        }
+        assert LangGraphConnector.extract_text(response) == "Hi there!"
+
+    def test_role_key_fallback(self):
+        """Test extraction works with 'role' key instead of 'type'."""
+        response = {
+            "messages": [
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hi!"},
+            ]
+        }
+        assert LangGraphConnector.extract_text(response) == "Hi!"
+
+    def test_none_content_returns_empty_string(self):
+        response = {"messages": [{"type": "ai", "content": None}]}
+        assert LangGraphConnector.extract_text(response) == ""
+
+    def test_no_ai_message_returns_none(self):
+        response = {"messages": [{"type": "human", "content": "Hello"}]}
+        assert LangGraphConnector.extract_text(response) is None
+
+    def test_no_messages_returns_none(self):
+        assert LangGraphConnector.extract_text({}) is None
+        assert LangGraphConnector.extract_text({"messages": []}) is None
+        assert LangGraphConnector.extract_text({"other": "data"}) is None
+
+
+class TestLangGraphExtractSessionId:
+    """Test LangGraphConnector.extract_session_id class method."""
+
+    def test_always_returns_none(self):
+        """LangGraph uses thread-based state, no session_id in response."""
+        response = {
+            "messages": [{"type": "ai", "content": "Hi"}],
+            "session_id": "some-id",
+        }
+        assert LangGraphConnector.extract_session_id(response) is None
+
+
+class TestLangGraphExtractToolTrace:
+    """Test LangGraphConnector.extract_tool_trace class method."""
+
+    def test_success(self):
+        response = {
+            "messages": [
+                {"type": "human", "content": "What is the weather?"},
+                {
+                    "type": "ai",
+                    "content": "",
+                    "tool_calls": [
+                        {"name": "get_weather", "args": {"city": "NYC"}, "id": "c1"}
+                    ],
+                },
+                {"type": "tool", "name": "get_weather", "content": '{"temp": 72}'},
+                {"type": "ai", "content": "It's 72°F in NYC."},
+            ]
+        }
+        trace = LangGraphConnector.extract_tool_trace(response)
+        assert trace is not None
+        assert len(trace) == 2
+        assert trace[0]["type"] == "tool_use"
+        assert trace[0]["tool_calls"][0]["name"] == "get_weather"
+        assert trace[1]["type"] == "tool_result"
+        assert trace[1]["name"] == "get_weather"
+
+    def test_no_tool_calls_returns_none(self):
+        response = {
+            "messages": [
+                {"type": "human", "content": "Hello"},
+                {"type": "ai", "content": "Hi!"},
+            ]
+        }
+        assert LangGraphConnector.extract_tool_trace(response) is None
+
+    def test_no_messages_returns_none(self):
+        assert LangGraphConnector.extract_tool_trace({}) is None


### PR DESCRIPTION
## Summary

Adds a `LangGraphConnector` to the agent connector registry, enabling sdg_hub flows to use deployed LangGraph agents via the existing `AgentBlock`.

- **New connector** (`src/sdg_hub/core/connectors/agent/langgraph.py`): Registered as `"langgraph"`, uses thread-based runs (`POST /threads` → `POST /threads/{id}/runs/wait`), `x-api-key` auth, configurable `assistant_id` (default `"agent"`)
- **Extraction classmethods** on `LangGraphConnector`: `extract_text` (last AI message), `extract_session_id` (returns None — LangGraph uses thread-based state), `extract_tool_trace` (messages with `tool_calls` + tool responses), following the pattern from #663
- **`connector_kwargs` on `AgentBlock`**: Generic dict field for passing framework-specific config (e.g., `assistant_id`) through YAML flows
- **20 unit tests** covering connector registration, headers, request/response building, full async flow, and all three extraction classmethods

No changes to `AgentResponseExtractorBlock` — extraction is handled automatically via the connector registry (#663).

## Usage

```python
# Python
block = AgentBlock(
    block_name="my_agent",
    agent_framework="langgraph",
    agent_url="http://localhost:2024",
    connector_kwargs={"assistant_id": "my-graph"},
    input_cols={"messages": "question"},
    output_cols=["agent_response"],
)
```

```yaml
# YAML flow
- block_type: AgentBlock
  block_config:
    agent_framework: langgraph
    agent_url: http://localhost:2024
    connector_kwargs:
      assistant_id: my-graph
    input_cols:
      messages: question
    output_cols:
      - agent_response
```

## Test plan

- [x] 20 unit tests pass (`uv run pytest tests/connectors/agent/test_langgraph.py`)
- [x] Full test suite (858 tests) passes
- [x] Integration tested against live LangGraph dev server with MCP weather agent (connector, AgentBlock sync/async, extractor text + tool trace)
- [x] Ruff lint + format clean, pre-commit hooks pass
- [ ] CI checks

Closes #660

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a LangGraph connector for thread-based agent workflows with configurable assistant IDs and optional API-key support.
  * Agent blocks can accept custom connector parameters so connector creation and caching respect extra options.
* **Tests**
  * Added tests for headers, request/response handling, async thread flow, assistant ID behavior, and tool-call tracing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->