### PR TITLE
docs(agent): clarify connector-driven extraction docs

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -206,6 +206,37 @@ class TestMyNewBlock:
   - Comprehensive operator support
   - Good performance on large datasets
 
+## 🔌 Contributing Agent Connectors
+
+When adding a new agent framework connector under `src/sdg_hub/core/connectors/agent/`, implement runtime request/response support and extraction hooks used by `AgentResponseExtractorBlock`.
+
+### Connector requirements
+
+1. Register the connector with `@ConnectorRegistry.register("framework_name")`.
+2. Implement instance methods for runtime execution:
+   - `build_request(...)`
+   - `parse_response(...)`
+3. Implement class methods for response extraction:
+   - `extract_text(response)`
+   - `extract_session_id(response)`
+   - `extract_tool_trace(response)`
+
+`AgentResponseExtractorBlock` resolves the connector class from `agent_framework` and delegates extraction to these class methods, so new frameworks can add extraction support without changing block code.
+
+```python
+@ConnectorRegistry.register("myframework")
+class MyFrameworkConnector(BaseAgentConnector):
+    def build_request(self, **kwargs):
+        ...
+
+    def parse_response(self, response):
+        return response
+
+    @classmethod
+    def extract_text(cls, response):
+        return None
+```
+
 
 ## 🌊 Contributing Flows
 

--- a/docs/flows/available-flows.md
+++ b/docs/flows/available-flows.md
@@ -61,7 +61,7 @@ Response Completeness Filter
 - `question` - Grounded user question designed to require multi-tool execution
 - `target_tools` - Intended tool sequence for solving the question
 - `extract_agent_text_text` - Expert trajectory conversation text
-- `extract_agent_text_tool_trace` - Structured tool-use trace extracted from Langflow `content_blocks`
+- `extract_agent_text_tool_trace` - Structured tool-use trace extracted by the configured agent connector (Langflow uses `content_blocks`)
 - `completeness_rating` - Response quality rating used by final filtering
 
 ### Runtime Requirements
@@ -69,6 +69,7 @@ Response Completeness Filter
 - This flow includes both LLM and agent blocks, so configure both before calling `generate()`.
 - Use `flow.set_model_config(...)` for LLM blocks.
 - Use `flow.set_agent_config(...)` for agent connector settings such as `agent_framework`, `agent_url`, and `agent_api_key`.
+- Response field extraction (text, session ID, tool trace) is connector-driven, so behavior follows the selected `agent_framework`.
 
 ### Example Usage
 


### PR DESCRIPTION
Document that agent response field extraction is now delegated to connector implementations and add contributor guidance for implementing connector extraction hooks.

Docs-Update-PR: 663
Docs-Update-Head-SHA: 5af69e2411ea6972aa99114b1bd6a313f707c7c7
Made-with: Cursor