### PR TITLE
feat(filtering): add SimilarityFilterBlock for near-duplicate removal

### DIFF
--- a/src/sdg_hub/core/blocks/__init__.py
+++ b/src/sdg_hub/core/blocks/__init__.py
@@ -6,7 +6,7 @@ This package provides various block implementations for data generation, process
 # Local
 from .agent import AgentBlock
 from .base import BaseBlock
-from .filtering import ColumnValueFilterBlock
+from .filtering import ColumnValueFilterBlock, SimilarityFilterBlock
 from .llm import (
     LLMChatBlock,
     LLMResponseExtractorBlock,
@@ -28,6 +28,7 @@ __all__ = [
     "BaseBlock",
     "BlockRegistry",
     "ColumnValueFilterBlock",
+    "SimilarityFilterBlock",
     "DuplicateColumnsBlock",
     "IndexBasedMapperBlock",
     "JSONParserBlock",

--- a/src/sdg_hub/core/blocks/filtering/__init__.py
+++ b/src/sdg_hub/core/blocks/filtering/__init__.py
@@ -6,7 +6,9 @@ This module provides blocks for filtering datasets based on various criteria.
 
 # Local
 from .column_value_filter import ColumnValueFilterBlock
+from .similarity_filter import SimilarityFilterBlock
 
 __all__ = [
     "ColumnValueFilterBlock",
+    "SimilarityFilterBlock",
 ]

--- a/src/sdg_hub/core/blocks/filtering/similarity_filter.py
+++ b/src/sdg_hub/core/blocks/filtering/similarity_filter.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Similarity filter block for removing near-duplicate rows.
+
+This module provides a block that computes pairwise text similarity
+within groups and drops near-duplicate entries, keeping only the first
+occurrence when similarity exceeds a configurable threshold.
+"""
+
+# Standard
+from difflib import SequenceMatcher
+from typing import Any, Optional
+
+from pydantic import Field
+
+# Third Party
+import pandas as pd
+
+# Local
+from ...utils.logger_config import setup_logger
+from ..base import BaseBlock
+from ..registry import BlockRegistry
+
+logger = setup_logger(__name__)
+
+
+@BlockRegistry.register(
+    "SimilarityFilterBlock",
+    "filtering",
+    "Filters near-duplicate rows based on text similarity within optional groups",
+)
+class SimilarityFilterBlock(BaseBlock):
+    """A block that removes near-duplicate rows based on text similarity.
+
+    Compares rows pairwise within optional groups (e.g., per document)
+    and drops rows whose text similarity to any previously kept row
+    exceeds the threshold.
+
+    Attributes
+    ----------
+    block_name : str
+        Name of the block.
+    input_cols : Union[str, List[str]]
+        Column(s) to compare for similarity. The first column is used
+        for comparison.
+    threshold : float
+        Similarity threshold (0.0 to 1.0). Rows with similarity above
+        this value to any kept row are dropped. Default 0.85.
+    group_by : Optional[str]
+        Column to group by before deduplication. If set, similarity is
+        only compared within each group.
+    """
+
+    block_type: str = "filtering"
+
+    threshold: float = Field(
+        0.85,
+        description="Similarity threshold (0-1). Rows above this are dropped.",
+        ge=0.0,
+        le=1.0,
+    )
+    group_by: Optional[str] = Field(
+        None,
+        description="Column to group by before comparing similarity.",
+    )
+
+    def model_post_init(self, __context: Any) -> None:
+        """Initialize derived attributes after Pydantic validation."""
+        super().model_post_init(__context) if hasattr(
+            super(), "model_post_init"
+        ) else None
+        if self.output_cols is None:
+            self.output_cols = []
+
+    @staticmethod
+    def _similarity(a: str, b: str) -> float:
+        """Compute similarity ratio between two strings."""
+        if not a or not b:
+            return 0.0
+        return SequenceMatcher(None, a, b).ratio()
+
+    def _deduplicate_group(self, group: pd.DataFrame, col: str) -> pd.DataFrame:
+        """Remove near-duplicate rows within a single group."""
+        kept_indices = []
+        kept_texts: list[str] = []
+
+        for idx, row in group.iterrows():
+            text = str(row[col])
+            is_duplicate = any(
+                self._similarity(text, kept) > self.threshold
+                for kept in kept_texts
+            )
+            if not is_duplicate:
+                kept_indices.append(idx)
+                kept_texts.append(text)
+
+        return group.loc[kept_indices]
+
+    def generate(self, samples: pd.DataFrame, **_kwargs: Any) -> pd.DataFrame:
+        """Filter near-duplicate rows based on text similarity.
+
+        Parameters
+        ----------
+        samples : pd.DataFrame
+            The input dataset.
+
+        Returns
+        -------
+        pd.DataFrame
+            Dataset with near-duplicates removed.
+        """
+        if samples.empty:
+            return samples
+
+        input_cols = self.input_cols
+        if isinstance(input_cols, list):
+            compare_col = input_cols[0]
+        elif isinstance(input_cols, str):
+            compare_col = input_cols
+        else:
+            compare_col = list(input_cols.keys())[0]
+
+        original_len = len(samples)
+
+        if self.group_by and self.group_by in samples.columns:
+            groups = []
+            for _, group in samples.groupby(self.group_by):
+                groups.append(self._deduplicate_group(group, compare_col))
+            result = pd.concat(groups, ignore_index=True) if groups else samples.iloc[:0]
+        else:
+            result = self._deduplicate_group(samples, compare_col)
+
+        removed = original_len - len(result)
+        if removed > 0:
+            logger.info(
+                "SimilarityFilterBlock '%s': removed %d near-duplicates "
+                "(threshold=%.2f), %d → %d rows",
+                self.block_name,
+                removed,
+                self.threshold,
+                original_len,
+                len(result),
+            )
+
+        return result.reset_index(drop=True)

--- a/src/sdg_hub/core/blocks/filtering/similarity_filter.py
+++ b/src/sdg_hub/core/blocks/filtering/similarity_filter.py
@@ -8,7 +8,7 @@ occurrence when similarity exceeds a configurable threshold.
 
 # Standard
 from difflib import SequenceMatcher
-from typing import Any, Optional
+from typing import Any, Optional, cast
 
 from pydantic import Field
 
@@ -79,15 +79,19 @@ class SimilarityFilterBlock(BaseBlock):
         return SequenceMatcher(None, a, b).ratio()
 
     def _deduplicate_group(self, group: pd.DataFrame, col: str) -> pd.DataFrame:
-        """Remove near-duplicate rows within a single group."""
+        """Remove near-duplicate rows within a single group.
+
+        Note: This uses O(n*k) comparisons where n is the group size and k is
+        the number of kept rows.  For very large groups consider pre-sharding
+        or approximate methods (e.g. MinHash).
+        """
         kept_indices = []
         kept_texts: list[str] = []
 
         for idx, row in group.iterrows():
             text = str(row[col])
             is_duplicate = any(
-                self._similarity(text, kept) > self.threshold
-                for kept in kept_texts
+                self._similarity(text, kept) > self.threshold for kept in kept_texts
             )
             if not is_duplicate:
                 kept_indices.append(idx)
@@ -111,21 +115,26 @@ class SimilarityFilterBlock(BaseBlock):
         if samples.empty:
             return samples
 
-        input_cols = self.input_cols
-        if isinstance(input_cols, list):
-            compare_col = input_cols[0]
-        elif isinstance(input_cols, str):
-            compare_col = input_cols
-        else:
-            compare_col = list(input_cols.keys())[0]
+        input_cols = cast(list[str], self.input_cols)
+        compare_col = input_cols[0]
 
         original_len = len(samples)
+
+        if self.group_by and self.group_by not in samples.columns:
+            logger.warning(
+                "SimilarityFilterBlock '%s': group_by column '%s' not found, "
+                "applying global deduplication",
+                self.block_name,
+                self.group_by,
+            )
 
         if self.group_by and self.group_by in samples.columns:
             groups = []
             for _, group in samples.groupby(self.group_by):
                 groups.append(self._deduplicate_group(group, compare_col))
-            result = pd.concat(groups, ignore_index=True) if groups else samples.iloc[:0]
+            result = (
+                pd.concat(groups, ignore_index=True) if groups else samples.iloc[:0]
+            )
         else:
             result = self._deduplicate_group(samples, compare_col)
 

--- a/src/sdg_hub/core/blocks/filtering/similarity_filter.py
+++ b/src/sdg_hub/core/blocks/filtering/similarity_filter.py
@@ -1,16 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 """Similarity filter block for removing near-duplicate rows.
 
-This module provides a block that computes pairwise text similarity
-within groups and drops near-duplicate entries, keeping only the first
-occurrence when similarity exceeds a configurable threshold.
+This module provides a block that performs greedy sequential deduplication
+based on text similarity, comparing each row against previously retained
+rows and dropping entries whose similarity exceeds a configurable threshold.
 """
 
 # Standard
 from difflib import SequenceMatcher
 from typing import Any, Optional, cast
 
-from pydantic import Field
+from pydantic import Field, field_validator
 
 # Third Party
 import pandas as pd
@@ -31,9 +31,9 @@ logger = setup_logger(__name__)
 class SimilarityFilterBlock(BaseBlock):
     """A block that removes near-duplicate rows based on text similarity.
 
-    Compares rows pairwise within optional groups (e.g., per document)
-    and drops rows whose text similarity to any previously kept row
-    exceeds the threshold.
+    Performs greedy sequential deduplication within optional groups
+    (e.g., per document). Each row is compared against previously
+    retained rows and dropped if similarity exceeds the threshold.
 
     Attributes
     ----------
@@ -63,17 +63,25 @@ class SimilarityFilterBlock(BaseBlock):
         description="Column to group by before comparing similarity.",
     )
 
+    @field_validator("input_cols", mode="after")
+    @classmethod
+    def validate_input_cols_not_empty(cls, v: list[str]) -> list[str]:
+        """Validate that we have at least one input column."""
+        if not v or len(v) == 0:
+            raise ValueError("SimilarityFilterBlock requires at least one input column")
+        return v
+
     def model_post_init(self, __context: Any) -> None:
         """Initialize derived attributes after Pydantic validation."""
-        super().model_post_init(__context) if hasattr(
-            super(), "model_post_init"
-        ) else None
+        super().model_post_init(__context)
         if self.output_cols is None:
             self.output_cols = []
 
     @staticmethod
     def _similarity(a: str, b: str) -> float:
         """Compute similarity ratio between two strings."""
+        if not a and not b:
+            return 1.0
         if not a or not b:
             return 0.0
         return SequenceMatcher(None, a, b).ratio()
@@ -130,7 +138,7 @@ class SimilarityFilterBlock(BaseBlock):
 
         if self.group_by and self.group_by in samples.columns:
             groups = []
-            for _, group in samples.groupby(self.group_by):
+            for _, group in samples.groupby(self.group_by, dropna=False):
                 groups.append(self._deduplicate_group(group, compare_col))
             result = (
                 pd.concat(groups, ignore_index=True) if groups else samples.iloc[:0]
@@ -148,6 +156,14 @@ class SimilarityFilterBlock(BaseBlock):
                 self.threshold,
                 original_len,
                 len(result),
+            )
+        else:
+            logger.info(
+                "SimilarityFilterBlock '%s': no near-duplicates found "
+                "(threshold=%.2f, %d rows examined)",
+                self.block_name,
+                self.threshold,
+                original_len,
             )
 
         return result.reset_index(drop=True)

--- a/tests/blocks/filtering/test_similarity_filter.py
+++ b/tests/blocks/filtering/test_similarity_filter.py
@@ -199,6 +199,19 @@ class TestSimilarityFilterBlock:
         # Both None rows become "None" string — second is a duplicate
         assert len(result) == 2
 
+    def test_uses_first_input_col_only(self, make_block):
+        """When multiple input_cols given, only the first is used for comparison."""
+        block = make_block(input_cols=["text", "other"])
+        df = pd.DataFrame(
+            {
+                "text": ["hello", "hello"],
+                "other": ["world", "universe"],
+            }
+        )
+        result = block(df)
+        # Should deduplicate based on "text" only
+        assert len(result) == 1
+
     def test_single_row_dataframe(self, make_block):
         """A single-row DataFrame should pass through unchanged."""
         block = make_block()

--- a/tests/blocks/filtering/test_similarity_filter.py
+++ b/tests/blocks/filtering/test_similarity_filter.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for SimilarityFilterBlock."""
+
+# Third Party
+import pandas as pd
+import pytest
+
+# Local
+from sdg_hub.core.blocks.filtering.similarity_filter import SimilarityFilterBlock
+
+
+@pytest.fixture
+def make_block():
+    """Factory fixture for creating SimilarityFilterBlock instances."""
+
+    def _make(**kwargs):
+        defaults = {
+            "block_name": "test_sim_filter",
+            "input_cols": ["text"],
+            "threshold": 0.85,
+        }
+        defaults.update(kwargs)
+        return SimilarityFilterBlock(**defaults)
+
+    return _make
+
+
+class TestSimilarityFilterBlock:
+    """Tests for similarity-based deduplication."""
+
+    def test_keeps_unique_rows(self, make_block):
+        """Completely different rows should all be kept."""
+        block = make_block()
+        df = pd.DataFrame(
+            {"text": ["alpha bravo charlie", "delta echo foxtrot", "golf hotel india"]}
+        )
+        result = block.generate(df)
+        assert len(result) == 3
+
+    def test_removes_exact_duplicates(self, make_block):
+        """Identical rows should be deduplicated to one."""
+        block = make_block(threshold=0.8)
+        df = pd.DataFrame({"text": ["hello world", "hello world", "hello world"]})
+        result = block.generate(df)
+        assert len(result) == 1
+
+    def test_removes_near_duplicates(self, make_block):
+        """Rows differing by a single word should be caught at high threshold."""
+        block = make_block(threshold=0.7)
+        df = pd.DataFrame(
+            {
+                "text": [
+                    "What is photosynthesis and how does it work?",
+                    "What is photosynthesis and how does it function?",
+                    "Explain the process of sourdough bread making.",
+                ]
+            }
+        )
+        result = block.generate(df)
+        assert len(result) == 2
+
+    def test_group_by_isolates_groups(self, make_block):
+        """Duplicates in different groups should both be kept."""
+        block = make_block(threshold=0.8, group_by="doc_id")
+        df = pd.DataFrame(
+            {
+                "text": ["same text here", "same text here"],
+                "doc_id": ["doc_a", "doc_b"],
+            }
+        )
+        result = block.generate(df)
+        assert len(result) == 2
+
+    def test_group_by_deduplicates_within_group(self, make_block):
+        """Duplicates within the same group should be removed."""
+        block = make_block(threshold=0.8, group_by="doc_id")
+        df = pd.DataFrame(
+            {
+                "text": ["same text here", "same text here"],
+                "doc_id": ["doc_a", "doc_a"],
+            }
+        )
+        result = block.generate(df)
+        assert len(result) == 1
+
+    def test_empty_dataframe(self, make_block):
+        """Empty input should return empty output."""
+        block = make_block()
+        df = pd.DataFrame({"text": []})
+        result = block.generate(df)
+        assert len(result) == 0
+
+    def test_low_threshold_removes_more(self, make_block):
+        """A lower threshold should be more aggressive."""
+        texts = [
+            "What is photosynthesis?",
+            "What is the process of photosynthesis?",
+            "Explain sourdough bread.",
+        ]
+        strict = make_block(threshold=0.5)
+        lenient = make_block(threshold=0.95)
+        df = pd.DataFrame({"text": texts})
+        assert len(strict.generate(df)) <= len(lenient.generate(df))
+
+    def test_threshold_boundaries(self, make_block):
+        """Threshold of 0 keeps only first; threshold of 1 keeps all non-identical."""
+        df = pd.DataFrame({"text": ["aaa", "aab", "bbb"]})
+        block_zero = make_block(threshold=0.0)
+        result = block_zero.generate(df)
+        # threshold=0 means any similarity > 0 is filtered, but identical empty
+        # strings would pass; with real strings, most get filtered
+        assert len(result) >= 1

--- a/tests/blocks/filtering/test_similarity_filter.py
+++ b/tests/blocks/filtering/test_similarity_filter.py
@@ -2,11 +2,13 @@
 """Tests for SimilarityFilterBlock."""
 
 # Third Party
+import numpy as np
 import pandas as pd
 import pytest
 
 # Local
 from sdg_hub.core.blocks.filtering.similarity_filter import SimilarityFilterBlock
+from sdg_hub.core.utils.error_handling import EmptyDatasetError, MissingColumnError
 
 
 @pytest.fixture
@@ -34,14 +36,14 @@ class TestSimilarityFilterBlock:
         df = pd.DataFrame(
             {"text": ["alpha bravo charlie", "delta echo foxtrot", "golf hotel india"]}
         )
-        result = block.generate(df)
+        result = block(df)
         assert len(result) == 3
 
     def test_removes_exact_duplicates(self, make_block):
         """Identical rows should be deduplicated to one."""
         block = make_block(threshold=0.8)
         df = pd.DataFrame({"text": ["hello world", "hello world", "hello world"]})
-        result = block.generate(df)
+        result = block(df)
         assert len(result) == 1
 
     def test_removes_near_duplicates(self, make_block):
@@ -56,7 +58,7 @@ class TestSimilarityFilterBlock:
                 ]
             }
         )
-        result = block.generate(df)
+        result = block(df)
         assert len(result) == 2
 
     def test_group_by_isolates_groups(self, make_block):
@@ -68,7 +70,7 @@ class TestSimilarityFilterBlock:
                 "doc_id": ["doc_a", "doc_b"],
             }
         )
-        result = block.generate(df)
+        result = block(df)
         assert len(result) == 2
 
     def test_group_by_deduplicates_within_group(self, make_block):
@@ -80,15 +82,15 @@ class TestSimilarityFilterBlock:
                 "doc_id": ["doc_a", "doc_a"],
             }
         )
-        result = block.generate(df)
+        result = block(df)
         assert len(result) == 1
 
     def test_empty_dataframe(self, make_block):
-        """Empty input should return empty output."""
+        """Empty input should raise EmptyDatasetError via __call__."""
         block = make_block()
         df = pd.DataFrame({"text": []})
-        result = block.generate(df)
-        assert len(result) == 0
+        with pytest.raises(EmptyDatasetError):
+            block(df)
 
     def test_low_threshold_removes_more(self, make_block):
         """A lower threshold should be more aggressive."""
@@ -100,22 +102,22 @@ class TestSimilarityFilterBlock:
         strict = make_block(threshold=0.5)
         lenient = make_block(threshold=0.95)
         df = pd.DataFrame({"text": texts})
-        assert len(strict.generate(df)) <= len(lenient.generate(df))
+        assert len(strict(df)) <= len(lenient(df))
 
     def test_threshold_boundaries(self, make_block):
         """Threshold of 0 filters any row with non-zero similarity to kept rows."""
         df = pd.DataFrame({"text": ["aaa", "aaa!", "bbb"]})
         block_zero = make_block(threshold=0.0)
-        result = block_zero.generate(df)
+        result = block_zero(df)
         # "aaa" kept, "aaa!" filtered (similarity > 0), "bbb" kept (similarity = 0)
         assert len(result) == 2
 
     def test_missing_column_raises_error(self, make_block):
-        """Should raise KeyError when input column is missing."""
+        """Should raise MissingColumnError when input column is missing."""
         block = make_block(input_cols=["nonexistent"])
         df = pd.DataFrame({"other_col": ["a", "b"]})
-        with pytest.raises(KeyError):
-            block.generate(df)
+        with pytest.raises(MissingColumnError):
+            block(df)
 
     def test_invalid_threshold_rejected(self):
         """Threshold outside 0-1 should be rejected by Pydantic."""
@@ -130,6 +132,77 @@ class TestSimilarityFilterBlock:
         """When group_by column is missing, should warn and deduplicate globally."""
         block = make_block(threshold=0.8, group_by="missing_col")
         df = pd.DataFrame({"text": ["hello world", "hello world", "different"]})
-        result = block.generate(df)
+        result = block(df)
         assert len(result) == 2
         assert "group_by column 'missing_col' not found" in caplog.text
+
+    def test_empty_input_cols_rejected(self):
+        """Empty input_cols should be rejected by validator."""
+        with pytest.raises(ValueError, match="at least one input column"):
+            SimilarityFilterBlock(
+                block_name="test",
+                input_cols=[],
+            )
+
+    def test_empty_string_duplicates_filtered(self, make_block):
+        """Two empty strings should be treated as identical and deduplicated."""
+        block = make_block(threshold=0.8)
+        df = pd.DataFrame({"text": ["", "", "actual content"]})
+        result = block(df)
+        assert len(result) == 2
+
+    def test_nan_in_group_by_column_preserved(self, make_block):
+        """Rows with NaN in group_by column should not be silently dropped."""
+        block = make_block(threshold=0.8, group_by="doc_id")
+        df = pd.DataFrame(
+            {
+                "text": ["hello world", "different text", "unique stuff"],
+                "doc_id": ["doc_a", np.nan, "doc_b"],
+            }
+        )
+        result = block(df)
+        # All rows are unique, so all 3 should be kept (including NaN group)
+        assert len(result) == 3
+
+    def test_first_occurrence_retained(self, make_block):
+        """When duplicates are found, the first occurrence should be kept."""
+        block = make_block(threshold=0.8)
+        df = pd.DataFrame(
+            {
+                "text": ["hello world", "hello world!", "completely different"],
+                "id": [1, 2, 3],
+            }
+        )
+        result = block(df)
+        # First row (id=1) should be kept, second (id=2) filtered
+        assert len(result) == 2
+        assert list(result["id"]) == [1, 3]
+
+    def test_threshold_one_keeps_all_non_identical(self, make_block):
+        """Threshold=1.0 should keep everything since similarity > 1.0 is impossible."""
+        block = make_block(threshold=1.0)
+        df = pd.DataFrame({"text": ["aaa", "aab", "aaa"]})
+        result = block(df)
+        # Only exact duplicates have ratio=1.0, but > 1.0 is impossible,
+        # so even exact dupes are kept
+        assert len(result) == 3
+
+    def test_none_in_comparison_column(self, make_block):
+        """None values in the comparison column become 'None' strings.
+
+        Rows with None are coerced via str() to the literal 'None',
+        so multiple None rows are treated as duplicates of each other.
+        """
+        block = make_block(threshold=0.8)
+        df = pd.DataFrame({"text": [None, None, "actual content"]})
+        result = block(df)
+        # Both None rows become "None" string — second is a duplicate
+        assert len(result) == 2
+
+    def test_single_row_dataframe(self, make_block):
+        """A single-row DataFrame should pass through unchanged."""
+        block = make_block()
+        df = pd.DataFrame({"text": ["only row"]})
+        result = block(df)
+        assert len(result) == 1
+        assert result["text"].iloc[0] == "only row"

--- a/tests/blocks/filtering/test_similarity_filter.py
+++ b/tests/blocks/filtering/test_similarity_filter.py
@@ -103,10 +103,33 @@ class TestSimilarityFilterBlock:
         assert len(strict.generate(df)) <= len(lenient.generate(df))
 
     def test_threshold_boundaries(self, make_block):
-        """Threshold of 0 keeps only first; threshold of 1 keeps all non-identical."""
-        df = pd.DataFrame({"text": ["aaa", "aab", "bbb"]})
+        """Threshold of 0 filters any row with non-zero similarity to kept rows."""
+        df = pd.DataFrame({"text": ["aaa", "aaa!", "bbb"]})
         block_zero = make_block(threshold=0.0)
         result = block_zero.generate(df)
-        # threshold=0 means any similarity > 0 is filtered, but identical empty
-        # strings would pass; with real strings, most get filtered
-        assert len(result) >= 1
+        # "aaa" kept, "aaa!" filtered (similarity > 0), "bbb" kept (similarity = 0)
+        assert len(result) == 2
+
+    def test_missing_column_raises_error(self, make_block):
+        """Should raise KeyError when input column is missing."""
+        block = make_block(input_cols=["nonexistent"])
+        df = pd.DataFrame({"other_col": ["a", "b"]})
+        with pytest.raises(KeyError):
+            block.generate(df)
+
+    def test_invalid_threshold_rejected(self):
+        """Threshold outside 0-1 should be rejected by Pydantic."""
+        with pytest.raises(ValueError):
+            SimilarityFilterBlock(
+                block_name="test",
+                input_cols=["text"],
+                threshold=1.5,
+            )
+
+    def test_group_by_missing_column_warns(self, make_block, caplog):
+        """When group_by column is missing, should warn and deduplicate globally."""
+        block = make_block(threshold=0.8, group_by="missing_col")
+        df = pd.DataFrame({"text": ["hello world", "hello world", "different"]})
+        result = block.generate(df)
+        assert len(result) == 2
+        assert "group_by column 'missing_col' not found" in caplog.text


### PR DESCRIPTION
## Summary

Adds a standalone `SimilarityFilterBlock` to `core/blocks/filtering/` that removes near-duplicate rows from a DataFrame based on text similarity.

This is a follow-up to #652, where this block was originally part of a larger InstructLab Q&A pipeline PR. Per the [maintainer feedback](https://github.com/Red-Hat-AI-Innovation-Team/sdg_hub/pull/652#issuecomment-4184277191):

> *"the SimilarityFilterBlock is genuinely useful and framework-agnostic. We'd welcome a separate PR for that block on its own (with its tests). It's a clean addition to core/blocks/filtering/ that benefits all users."*

This PR contains **only** the similarity filter block and its tests — no InstructLab pipeline, no qna.yaml references, no flow YAML, no formatter block.

## Design

The block follows the existing `ColumnValueFilterBlock` pattern:

- Inherits from `BaseBlock` (Pydantic)
- Registered via `@BlockRegistry.register("SimilarityFilterBlock", "filtering", ...)`
- Operates on `pd.DataFrame` input/output
- Uses `difflib.SequenceMatcher` for similarity — **zero new dependencies**

### Parameters

| Parameter | Type | Default | Description |
|-----------|------|---------|-------------|
| `input_cols` | `str \| list[str]` | required | Column(s) to compare for similarity (first column is used) |
| `threshold` | `float` | `0.85` | Similarity ratio (0.0–1.0). Rows above this vs any kept row are dropped |
| `group_by` | `str \| None` | `None` | If set, deduplication is scoped within groups of this column |

### Algorithm

1. Extract the comparison column from `input_cols`
2. If `group_by` is set and column exists, group by that column
3. Within each group (or globally), iterate rows and compare against kept rows using `SequenceMatcher.ratio()`
4. Drop rows exceeding the similarity threshold
5. Return filtered DataFrame with reset index

## Files Changed

| File | Change |
|------|--------|
| `src/sdg_hub/core/blocks/filtering/similarity_filter.py` | New block (144 lines) |
| `src/sdg_hub/core/blocks/filtering/__init__.py` | Added export |
| `tests/blocks/filtering/test_similarity_filter.py` | 8 unit tests |

## Usage Example

```python
from sdg_hub.core.blocks.filtering import SimilarityFilterBlock

block = SimilarityFilterBlock(
    block_name="deduplicate_questions",
    input_cols=["question"],
    threshold=0.85,
    group_by="document_id",  # optional
)
filtered_df = block.generate(df)
```

In flow YAML:
```yaml
- block_type: SimilarityFilterBlock
  block_name: deduplicate_questions
  input_cols:
    - question
  threshold: 0.85
  group_by: document_id
```

## Test Plan

- [x] 8 unit tests covering:
  - Unique rows preserved
  - Exact duplicates removed
  - Near-duplicates caught at threshold
  - `group_by` isolates groups correctly
  - `group_by` deduplicates within same group
  - Empty DataFrame returns empty
  - Lower threshold is more aggressive than higher
  - Threshold boundary behavior (0.0)
- [x] No changes to existing code beyond the `__init__.py` export

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a similarity-based filtering block to identify and remove duplicate or near-duplicate records.
  * Configurable similarity threshold (0–1) and optional group-by mode to deduplicate within specified groups; preserves first occurrence and returns a reindexed result.

* **Tests**
  * Added comprehensive tests covering unique rows, exact/near duplicates, group-by isolation, empty inputs, threshold boundaries, validation and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->