### PR TITLE
refactor(config): extract shared apply_config_to_blocks helper to ded…

### DIFF
--- a/src/sdg_hub/core/flow/agent_config.py
+++ b/src/sdg_hub/core/flow/agent_config.py
@@ -5,6 +5,7 @@
 from typing import TYPE_CHECKING, Any, Optional
 
 # Local
+from ..utils.config_helpers import apply_config_to_blocks
 from ..utils.logger_config import setup_logger
 
 if TYPE_CHECKING:
@@ -172,68 +173,16 @@ def set_agent_config(
             f"{sorted(target_block_names)}"
         )
 
-    # Sensitive parameter names that should not be logged
     sensitive_params = {"agent_api_key", "api_key", "token", "password", "secret"}
 
-    # Apply configuration to target blocks
-    modified_count = 0
-    for block in flow.blocks:
-        if block.block_name in target_block_names:
-            block_modified = False
-            for param_name, param_value in config_params.items():
-                if hasattr(block, param_name):
-                    setattr(block, param_name, param_value)
-                    block_modified = True
-                    # Don't log sensitive values
-                    if param_name in sensitive_params:
-                        logger.debug(
-                            f"Block '{block.block_name}': {param_name} set (redacted)"
-                        )
-                    else:
-                        logger.debug(
-                            f"Block '{block.block_name}': {param_name} "
-                            f"set to '{param_value}'"
-                        )
-                # check if allow extra
-                elif block.model_config.get("extra") == "allow":
-                    setattr(block, param_name, param_value)
-                    block_modified = True
-                    if param_name in sensitive_params:
-                        logger.debug(
-                            f"Block '{block.block_name}': {param_name} set (redacted)"
-                        )
-                    else:
-                        logger.debug(
-                            f"Block '{block.block_name}': {param_name} "
-                            f"set to '{param_value}'"
-                        )
-                else:
-                    logger.warning(
-                        f"Block '{block.block_name}' ({block.__class__.__name__}) "
-                        f"does not have attribute '{param_name}' - skipping"
-                    )
-
-            if block_modified:
-                modified_count += 1
+    modified_count = apply_config_to_blocks(
+        flow.blocks,
+        target_block_names,
+        config_params,
+        sensitive_params,
+        "agent",
+        logger,
+    )
 
     if modified_count > 0:
-        # Enhanced logging showing what was configured
-        param_summary = []
-        for param_name, param_value in config_params.items():
-            if param_name in sensitive_params:
-                param_summary.append(f"{param_name}: (redacted)")
-            else:
-                param_summary.append(f"{param_name}: '{param_value}'")
-
-        logger.info(
-            f"Successfully configured {modified_count} agent blocks with: "
-            f"{', '.join(param_summary)}"
-        )
-        logger.info(f"Configured blocks: {sorted(target_block_names)}")
-
-        # Mark that agent configuration has been set
         flow._agent_config_set = True
-    else:
-        logger.warning(
-            "No blocks were modified - check block names or agent block detection"
-        )

--- a/src/sdg_hub/core/flow/model_config.py
+++ b/src/sdg_hub/core/flow/model_config.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, Optional
 from pydantic import SecretStr
 
 # Local
+from ..utils.config_helpers import apply_config_to_blocks
 from ..utils.logger_config import setup_logger
 
 if TYPE_CHECKING:
@@ -243,68 +244,16 @@ def set_model_config(
             f"Auto-detected {len(target_block_names)} LLM blocks for configuration: {sorted(target_block_names)}"
         )
 
-    # Sensitive parameter names that should not be logged
     sensitive_params = {"api_key", "token", "password", "secret"}
 
-    # Apply configuration to target blocks
-    modified_count = 0
-    for block in flow.blocks:
-        if block.block_name in target_block_names:
-            block_modified = False
-            for param_name, param_value in config_params.items():
-                if hasattr(block, param_name):
-                    setattr(block, param_name, param_value)
-                    block_modified = True
-                    # Don't log sensitive values
-                    if param_name in sensitive_params:
-                        logger.debug(
-                            f"Block '{block.block_name}': {param_name} set (redacted)"
-                        )
-                    else:
-                        logger.debug(
-                            f"Block '{block.block_name}': {param_name} "
-                            f"set to '{param_value}'"
-                        )
-                # check if allow extra
-                elif block.model_config.get("extra") == "allow":
-                    setattr(block, param_name, param_value)
-                    block_modified = True
-                    if param_name in sensitive_params:
-                        logger.debug(
-                            f"Block '{block.block_name}': {param_name} set (redacted)"
-                        )
-                    else:
-                        logger.debug(
-                            f"Block '{block.block_name}': {param_name} "
-                            f"set to '{param_value}'"
-                        )
-                else:
-                    logger.warning(
-                        f"Block '{block.block_name}' ({block.__class__.__name__}) "
-                        f"does not have attribute '{param_name}' - skipping"
-                    )
-
-            if block_modified:
-                modified_count += 1
+    modified_count = apply_config_to_blocks(
+        flow.blocks,
+        target_block_names,
+        config_params,
+        sensitive_params,
+        "LLM",
+        logger,
+    )
 
     if modified_count > 0:
-        # Enhanced logging showing what was configured
-        # Apply same redaction rules as per-block logging
-        param_summary = []
-        for param_name, param_value in config_params.items():
-            if param_name in sensitive_params:
-                param_summary.append(f"{param_name}: (redacted)")
-            else:
-                param_summary.append(f"{param_name}: '{param_value}'")
-
-        logger.info(
-            f"Successfully configured {modified_count} LLM blocks with: {', '.join(param_summary)}"
-        )
-        logger.info(f"Configured blocks: {sorted(target_block_names)}")
-
-        # Mark that model configuration has been set
         flow._model_config_set = True
-    else:
-        logger.warning(
-            "No blocks were modified - check block names or LLM block detection"
-        )

--- a/src/sdg_hub/core/utils/config_helpers.py
+++ b/src/sdg_hub/core/utils/config_helpers.py
@@ -5,12 +5,15 @@ Used by model_config.py and agent_config.py to avoid duplicating the
 hasattr / extra=="allow" / warning logic and sensitive-param redaction.
 """
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 import logging
+
+if TYPE_CHECKING:
+    from ..blocks.base import BaseBlock
 
 
 def apply_config_to_blocks(
-    blocks: list,
+    blocks: "list[BaseBlock]",
     target_block_names: set[str],
     config_params: dict[str, Any],
     sensitive_params: set[str],

--- a/src/sdg_hub/core/utils/config_helpers.py
+++ b/src/sdg_hub/core/utils/config_helpers.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared helpers for applying configuration parameters to flow blocks.
+
+Used by model_config.py and agent_config.py to avoid duplicating the
+hasattr / extra=="allow" / warning logic and sensitive-param redaction.
+"""
+
+from typing import Any
+import logging
+
+
+def apply_config_to_blocks(
+    blocks: list,
+    target_block_names: set[str],
+    config_params: dict[str, Any],
+    sensitive_params: set[str],
+    config_label: str,
+    block_logger: logging.Logger,
+) -> int:
+    """Apply configuration parameters to targeted blocks.
+
+    Iterates over blocks, matches by name, and sets each config parameter
+    using hasattr/setattr with a fallback to Pydantic's extra=="allow".
+    Sensitive parameters are redacted in log output.
+
+    Parameters
+    ----------
+    blocks : list
+        The flow's block list (flow.blocks).
+    target_block_names : set[str]
+        Block names to apply configuration to.
+    config_params : dict[str, Any]
+        Parameter name-value pairs to set on each target block.
+    sensitive_params : set[str]
+        Parameter names whose values should be redacted in logs.
+    config_label : str
+        Human-readable label for log messages (e.g., "LLM", "agent").
+    block_logger : logging.Logger
+        Logger instance to use for all log output.
+
+    Returns
+    -------
+    int
+        Number of blocks that were modified.
+    """
+    modified_count = 0
+    for block in blocks:
+        if block.block_name not in target_block_names:
+            continue
+
+        block_modified = False
+        for param_name, param_value in config_params.items():
+            if hasattr(block, param_name):
+                setattr(block, param_name, param_value)
+                block_modified = True
+            elif block.model_config.get("extra") == "allow":
+                setattr(block, param_name, param_value)
+                block_modified = True
+            else:
+                block_logger.warning(
+                    f"Block '{block.block_name}' ({block.__class__.__name__}) "
+                    f"does not have attribute '{param_name}' - skipping"
+                )
+                continue
+
+            if param_name in sensitive_params:
+                block_logger.debug(
+                    f"Block '{block.block_name}': {param_name} set (redacted)"
+                )
+            else:
+                block_logger.debug(
+                    f"Block '{block.block_name}': {param_name} set to '{param_value}'"
+                )
+
+        if block_modified:
+            modified_count += 1
+
+    if modified_count > 0:
+        param_summary = []
+        for param_name, param_value in config_params.items():
+            if param_name in sensitive_params:
+                param_summary.append(f"{param_name}: (redacted)")
+            else:
+                param_summary.append(f"{param_name}: '{param_value}'")
+
+        block_logger.info(
+            f"Successfully configured {modified_count} {config_label} "
+            f"blocks with: {', '.join(param_summary)}"
+        )
+        block_logger.info(f"Configured blocks: {sorted(target_block_names)}")
+    else:
+        block_logger.warning(
+            f"No blocks were modified - check block names or "
+            f"{config_label} block detection"
+        )
+
+    return modified_count


### PR DESCRIPTION
## Summary
- Extracts the duplicated block-config-application loop from `model_config.py` and `agent_config.py` into a shared `apply_config_to_blocks()` helper in `utils/config_helpers.py`
- Both `set_model_config()` and `set_agent_config()` now delegate to this single helper, eliminating ~120 lines of duplicated code
- No behavioral changes — all validation, logging, and fallback logic is preserved
## Details
`model_config.py` and `agent_config.py` contained identical ~60-line blocks for:
- `hasattr` check → `setattr` for known attributes
- Pydantic `extra=="allow"` fallback → `setattr` for dynamic attributes
- Warning log for unrecognized attributes
- Sensitive parameter redaction (`api_key`, `token`, `password`, `secret`)
- Per-block debug logging and post-apply summary logging
The new `apply_config_to_blocks()` helper accepts a `config_label` parameter (`"LLM"` or `"agent"`) to keep log messages contextual.
## Test plan
- [x] All 91 existing tests in `test_base.py` pass
- [x] Import of `config_helpers` verified
- [x] Ruff lint and format pass (both `v0.15.0` and `v0.3.4`)
Closes #644

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated configuration handling logic into a centralized utility function to improve code maintainability and consistency.
  * Streamlined how configurations are applied to flow blocks across different configuration types.
  * Removed redundant configuration application logic from individual modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->