### PR TITLE
fix(agent): resolve connector at extraction time for runtime framework switching

### DIFF
--- a/src/sdg_hub/core/blocks/agent/agent_response_extractor_block.py
+++ b/src/sdg_hub/core/blocks/agent/agent_response_extractor_block.py
@@ -178,7 +178,9 @@ class AgentResponseExtractorBlock(BaseBlock):
         """
         extracted: dict[str, Any] = {}
         missing_fields: list[str] = []
-        connector_cls = self._connector_cls
+        # Resolve connector at extraction time so that runtime changes
+        # to agent_framework (e.g. via set_agent_config) are respected.
+        connector_cls = ConnectorRegistry.get(self.agent_framework)
         assert connector_cls is not None
 
         if self.extract_text:

--- a/src/sdg_hub/core/blocks/agent/agent_response_extractor_block.py
+++ b/src/sdg_hub/core/blocks/agent/agent_response_extractor_block.py
@@ -180,8 +180,10 @@ class AgentResponseExtractorBlock(BaseBlock):
         missing_fields: list[str] = []
         # Resolve connector at extraction time so that runtime changes
         # to agent_framework (e.g. via set_agent_config) are respected.
-        connector_cls = ConnectorRegistry.get(self.agent_framework)
-        assert connector_cls is not None
+        connector_cls = cast(
+            type[BaseAgentConnector],
+            ConnectorRegistry.get(self.agent_framework),
+        )
 
         if self.extract_text:
             text = connector_cls.extract_text(response)


### PR DESCRIPTION
## Summary
- `AgentResponseExtractorBlock` cached `_connector_cls` at init time during model validation. When `set_agent_config()` changed `agent_framework` at runtime (e.g., switching from `"langflow"` to a different connector), the cached class still pointed to the original connector, causing extraction to fail with `"No requested fields found in response"`.
- Fix: resolve the connector via `ConnectorRegistry.get()` at extraction time instead of using the cached `_connector_cls`.

## Test plan
- [x] All 80 existing tests pass (connectors, agent extractor, agent config)
- [x] Verified end-to-end: load flow with `agent_framework: "langflow"` in YAML, switch at runtime via `set_agent_config()`, extraction correctly uses the new connector's classmethods

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed agent response extraction to dynamically use the connector matching the currently selected agent framework, ensuring consistent extraction of text, session IDs, and tool traces across framework changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->