### PR TITLE
Use modern tool_calls/tool format in message_formatter

### DIFF
--- a/src/sdg_hub/core/utils/message_formatter.py
+++ b/src/sdg_hub/core/utils/message_formatter.py
@@ -114,12 +114,14 @@ def tool_trace_to_messages(
 
             # tool returns its result
             result_text = _extract_tool_output(output)
-            messages.append({
-                "role": "tool",
-                "tool_call_id": tool_call_id,
-                "name": name,
-                "content": result_text,
-            })
+            messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": tool_call_id,
+                    "name": name,
+                    "content": result_text,
+                }
+            )
 
     return messages
 

--- a/src/sdg_hub/core/utils/message_formatter.py
+++ b/src/sdg_hub/core/utils/message_formatter.py
@@ -1,14 +1,16 @@
-"""Convert Langflow agent tool traces into structured function-calling conversations.
+"""Convert Langflow agent tool traces into structured tool-calling conversations.
 
-The output format is compatible with standard SFT training pipelines for
-tool-use models (system with tool declarations, user, assistant function_call /
-function response pairs, and final assistant answer).
+The output format uses the modern OpenAI tool_calls/tool message format,
+compatible with training pipelines for tool-use models (system with tool
+declarations, user, assistant tool_calls / tool response pairs, and final
+assistant answer).
 """
 
 from __future__ import annotations
 
 from typing import Any
 import json
+import uuid
 
 
 def tool_trace_to_messages(
@@ -16,7 +18,7 @@ def tool_trace_to_messages(
     tool_list: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
     """Convert a Langflow tool trace and tool schemas into a structured
-    function-calling conversation.
+    tool-calling conversation.
 
     Parameters
     ----------
@@ -37,13 +39,13 @@ def tool_trace_to_messages(
     Returns
     -------
     list[dict]
-        A conversation in the function-calling message format::
+        A conversation in the tool-calling message format::
 
             [
                 {"role": "system",    "content": "<tool declarations>"},
                 {"role": "user",      "content": "question"},
-                {"role": "assistant", "content": "", "function_call": {"name": ..., "arguments": ...}},
-                {"role": "function",  "content": "result JSON", "name": "tool_name"},
+                {"role": "assistant", "content": null, "tool_calls": [...]},
+                {"role": "tool",      "content": "result", "tool_call_id": "...", "name": "..."},
                 ...
                 {"role": "assistant", "content": "final answer"},
             ]
@@ -90,21 +92,34 @@ def tool_trace_to_messages(
             tool_input = step.get("tool_input", {})
             output = step.get("output")
 
+            tool_call_id = f"call_{uuid.uuid4().hex[:24]}"
+
             # assistant decides to call a tool
             messages.append(
                 {
                     "role": "assistant",
-                    "content": "",
-                    "function_call": {
-                        "name": name,
-                        "arguments": json.dumps(tool_input),
-                    },
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": tool_call_id,
+                            "type": "function",
+                            "function": {
+                                "name": name,
+                                "arguments": json.dumps(tool_input),
+                            },
+                        }
+                    ],
                 }
             )
 
             # tool returns its result
             result_text = _extract_tool_output(output)
-            messages.append({"role": "function", "content": result_text, "name": name})
+            messages.append({
+                "role": "tool",
+                "tool_call_id": tool_call_id,
+                "name": name,
+                "content": result_text,
+            })
 
     return messages
 

--- a/tests/utils/test_message_formatter.py
+++ b/tests/utils/test_message_formatter.py
@@ -19,7 +19,7 @@ SAMPLE_TOOL_LIST = [
 
 
 class TestToolTraceToMessages:
-    """Test converting Langflow tool traces to function-calling messages."""
+    """Test converting Langflow tool traces to tool-calling messages."""
 
     def test_basic_trace(self):
         """Test a trace with input, one tool call, and output."""
@@ -39,9 +39,10 @@ class TestToolTraceToMessages:
         assert msgs[0]["role"] == "system"
         assert msgs[1] == {"role": "user", "content": "find laptops"}
         assert msgs[2]["role"] == "assistant"
-        assert msgs[2]["function_call"]["name"] == "search_products"
-        assert msgs[3]["role"] == "function"
+        assert msgs[2]["tool_calls"][0]["function"]["name"] == "search_products"
+        assert msgs[3]["role"] == "tool"
         assert msgs[3]["name"] == "search_products"
+        assert msgs[3]["tool_call_id"] == msgs[2]["tool_calls"][0]["id"]
         assert msgs[4] == {"role": "assistant", "content": "No results."}
 
     def test_system_message_declares_all_tools(self):
@@ -78,8 +79,8 @@ class TestToolTraceToMessages:
         msgs = tool_trace_to_messages(trace, SAMPLE_TOOL_LIST)
 
         assert len(msgs) == 7  # system + user + 2*(call+response) + output
-        assert msgs[2]["function_call"]["name"] == "search_products"
-        assert msgs[4]["function_call"]["name"] == "get_details"
+        assert msgs[2]["tool_calls"][0]["function"]["name"] == "search_products"
+        assert msgs[4]["tool_calls"][0]["function"]["name"] == "get_details"
 
     def test_string_output(self):
         """Test tool_use with plain string output."""
@@ -92,6 +93,7 @@ class TestToolTraceToMessages:
             },
         ]
         msgs = tool_trace_to_messages(trace, SAMPLE_TOOL_LIST)
+        assert msgs[2]["role"] == "tool"
         assert msgs[2]["content"] == "plain text result"
 
     def test_structured_content_fallback(self):
@@ -105,6 +107,7 @@ class TestToolTraceToMessages:
             },
         ]
         msgs = tool_trace_to_messages(trace, SAMPLE_TOOL_LIST)
+        assert msgs[2]["role"] == "tool"
         assert json.loads(msgs[2]["content"]) == {"count": 5}
 
     def test_intermediate_reasoning(self):
@@ -128,6 +131,7 @@ class TestToolTraceToMessages:
             },
         ]
         msgs = tool_trace_to_messages(trace, SAMPLE_TOOL_LIST)
+        assert msgs[2]["role"] == "tool"
         assert msgs[2]["content"] == ""
 
     # --- Edge cases for malformed traces (issue #646) ---
@@ -152,6 +156,7 @@ class TestToolTraceToMessages:
         ]
         msgs = tool_trace_to_messages(trace, SAMPLE_TOOL_LIST)
         # Empty content list is falsy, so falls through to json.dumps(output)
+        assert msgs[2]["role"] == "tool"
         assert json.loads(msgs[2]["content"]) == {"content": []}
 
     def test_missing_header_field(self):
@@ -172,6 +177,7 @@ class TestToolTraceToMessages:
             },
         ]
         msgs = tool_trace_to_messages(trace, SAMPLE_TOOL_LIST)
+        assert msgs[2]["role"] == "tool"
         assert msgs[2]["content"] == ""
 
     def test_non_list_content_field(self):
@@ -186,6 +192,7 @@ class TestToolTraceToMessages:
         ]
         msgs = tool_trace_to_messages(trace, SAMPLE_TOOL_LIST)
         # isinstance("not a list", list) is False, so falls through
+        assert msgs[2]["role"] == "tool"
         assert json.loads(msgs[2]["content"]) == {"content": "not a list"}
 
     def test_unknown_type_value(self):
@@ -206,4 +213,5 @@ class TestToolTraceToMessages:
             },
         ]
         msgs = tool_trace_to_messages(trace, SAMPLE_TOOL_LIST)
+        assert msgs[2]["role"] == "tool"
         assert msgs[2]["content"] == "42"


### PR DESCRIPTION
## Summary

- Updates `message_formatter.py` to produce the modern OpenAI `tool_calls`/`tool` message format instead of the deprecated `function_call`/`function` format
- The old format was causing compatibility issues with vLLM, training_hub's GRPO pipeline, and current OpenAI-compatible APIs

### Before (deprecated)
```json
{"role": "assistant", "content": "", "function_call": {"name": "...", "arguments": "..."}}
{"role": "function", "name": "...", "content": "..."}
```

### After (modern)
```json
{"role": "assistant", "content": null, "tool_calls": [{"id": "call_...", "type": "function", "function": {"name": "...", "arguments": "..."}}]}
{"role": "tool", "tool_call_id": "call_...", "name": "...", "content": "..."}
```

## Test plan

- [x] All 14 existing tests updated and passing
- [x] Verified generated data loads correctly in training_hub's ART and verl backends

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated tool-calling message format to align with OpenAI's latest API standards, improving compatibility and reliability with current tools and external services.

* **Tests**
  * Enhanced test coverage to thoroughly validate the updated tool-calling message format and ensure proper compliance with OpenAI's API specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->