### PR TITLE
docs: document code interpreter block and benchmark flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ uv pip install .[dev]
 # For vLLM support
 uv pip install sdg-hub[vllm]
 
+# For code interpreter support
+uv pip install sdg-hub[code]
+
 # For examples
 uv pip install sdg-hub[examples]
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,6 +48,7 @@ Learn about the modular block architecture that powers SDG Hub:
 - **[Block Overview](blocks/overview.md)** - Understanding the block system
 - **[LLM Blocks](blocks/llm-blocks.md)** - Chat, prompt building, and text parsing
 - **[Transform Blocks](blocks/transform-blocks.md)** - Data transformation and manipulation
+- **[Code Blocks](blocks/code-blocks.md)** - Sandboxed Python execution and validation
 - **[Filtering Blocks](blocks/filtering-blocks.md)** - Quality filtering and data validation
 - **[Custom Blocks](blocks/custom-blocks.md)** - Building your own processing blocks
 

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -8,6 +8,7 @@
   * [Overview](blocks/overview.md)
   * [LLM Blocks](blocks/llm-blocks.md)
   * [Transform Blocks](blocks/transform-blocks.md)
+  * [Code Blocks](blocks/code-blocks.md)
   * [Filtering Blocks](blocks/filtering-blocks.md)
   * [Custom Blocks](blocks/custom-blocks.md)
 

--- a/docs/blocks/code-blocks.md
+++ b/docs/blocks/code-blocks.md
@@ -1,0 +1,56 @@
+# Code Blocks
+
+Code blocks execute and validate generated code inside sandboxed runtimes. They are useful when your flow needs to verify that synthesized code actually runs before it is used for training or benchmarking.
+
+## Available Code Blocks
+
+### PythonInterpreterBlock
+
+Executes Python code from one input column and stores structured execution results in one output column. The default runtime is the `monty` connector, which runs code in a restricted sandbox.
+
+**Configuration:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `input_cols` | `list[str]` | - | Exactly one column containing Python code |
+| `output_cols` | `list[str]` | - | Exactly one column to store execution results |
+| `interpreter_framework` | `str` | `"monty"` | Code interpreter connector name |
+| `timeout` | `float` | `30.0` | Max execution time per row in seconds |
+| `max_concurrency` | `int` | `10` | Maximum concurrent code executions |
+
+**YAML Example:**
+
+```yaml
+- block_type: "PythonInterpreterBlock"
+  block_config:
+    block_name: "verify_code"
+    interpreter_framework: "monty"
+    input_cols:
+      - "executable_code"
+    output_cols:
+      - "execution_result"
+    timeout: 10.0
+    max_concurrency: 5
+```
+
+**Output Schema (per row):**
+
+- `success` - `true` when execution completes without runtime errors
+- `output` - captured stdout content
+- `error` - runtime error message when execution fails
+- `return_value` - returned value from the interpreter
+- `execution_time_ms` - execution duration in milliseconds
+
+## Runtime Setup
+
+Install the optional code runtime dependency:
+
+```bash
+uv pip install sdg-hub[code]
+```
+
+## Next Steps
+
+- **[Block Overview](overview.md)** - How block composition works end-to-end
+- **[Flow Catalog](../flows/available-flows.md)** - Flows that use code execution
+- **[Custom Blocks](custom-blocks.md)** - Build your own block types

--- a/docs/blocks/overview.md
+++ b/docs/blocks/overview.md
@@ -63,6 +63,10 @@ Data manipulation and transformation:
 - **MeltColumnsBlock** - Reshape wide data to long format
 - **SamplerBlock** - Randomly sample values from list or weighted pools
 
+### 💻 Code Blocks (`code/`)
+Sandboxed code execution and validation:
+- **PythonInterpreterBlock** - Execute Python code snippets and capture structured results
+
 ### 🔍 Filtering Blocks (`filtering/`)
 Quality control and data validation:
 - **ColumnValueFilterBlock** - Filter rows based on column values
@@ -196,5 +200,6 @@ Ready to dive deeper? Explore specific block categories:
 
 - **[LLM Blocks](blocks/llm-blocks.md)** - AI-powered language model operations
 - **[Transform Blocks](blocks/transform-blocks.md)** - Data manipulation and reshaping
+- **[Code Blocks](blocks/code-blocks.md)** - Sandboxed code execution and validation
 - **[Filtering Blocks](blocks/filtering-blocks.md)** - Quality control and validation
 - **[Custom Blocks](blocks/custom-blocks.md)** - Build your own processing blocks

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -23,6 +23,7 @@ SDG Hub organizes blocks into logical categories:
 |----------|---------|----------|
 | **LLM** | Language model operations | Chat, prompt building, text parsing |
 | **Transform** | Data manipulation | Column operations, text concatenation |
+| **Code** | Sandboxed code execution | Python snippet execution and validation |
 | **Filtering** | Quality control | Value-based filtering, threshold checks |
 | **Evaluation** | Quality assessment | Faithfulness scoring, relevancy evaluation |
 

--- a/docs/flows/available-flows.md
+++ b/docs/flows/available-flows.md
@@ -27,6 +27,7 @@ All flows support:
 | [Multilingual QA](#japanese-multilingual-multi-summary-qa-flow) | 1 | Japanese language QA generation | `multilingual`, `japanese` |
 | [Text Analysis](#structured-text-insights-extraction-flow) | 1 | NLP insights extraction | `text-analysis`, `nlp` |
 | [Red Team Prompt Generation](#red-team-prompt-generation-flow) | 1 | Adversarial prompt generation for safety testing | `red-team`, `safety-testing` |
+| [Code Evaluation](#domain-code-evaluation-benchmark-generator-flow) | 1 | Generate execution-verified domain code benchmarks | `code-evaluation`, `benchmark-generation` |
 
 ---
 
@@ -161,6 +162,73 @@ LLMResponseExtractorBlock → JSONParserBlock → Structured Prompt Dataset
 - Uses `SamplerBlock` with `num_samples: 1` and `return_scalar: true` so sampled dimensions are emitted as scalar values.
 - Uses `response_format.type: json_schema` for structured generation from the model.
 - Uses `JSONParserBlock` to expand parsed JSON fields into output columns and remove the raw extracted text when `drop_input: true`.
+
+---
+
+## Domain Code Evaluation Benchmark Generator Flow
+
+**Name:** `Domain Code Evaluation Benchmark Generator`
+
+**Purpose:** Generate domain-specific Python evaluation benchmarks by creating function implementations, generating tests, and execution-verifying each candidate in a sandbox before reverse-generating a problem description.
+
+**Location:** `src/sdg_hub/flows/code_evaluation/domain_code_eval/`
+
+### Architecture
+
+```yaml
+Domain Spec → Function Generation → Test Generation →
+TextConcatBlock (function + tests) → PythonInterpreterBlock (sandbox verify) →
+Problem Statement Generation → Verified Benchmark Rows
+```
+
+### Input Requirements
+
+| Column | Description | Required |
+|--------|-------------|----------|
+| `domain` | Target problem domain (e.g., "financial calculations") | Yes |
+| `function_spec` | Functional requirements for generated code | Yes |
+| `difficulty` | Difficulty level (`beginner`, `intermediate`, `advanced`) | Yes |
+| `time_complexity` | Expected complexity target (e.g., `O(n log n)`) | Yes |
+
+### Key Output Columns
+
+- `function_code` - Generated Python function implementation
+- `test_code` - Generated test suite for the function
+- `execution_result` - Structured sandbox execution result from `PythonInterpreterBlock`
+- `problem_description` - Reverse-generated problem statement derived from verified code
+
+### Runtime Notes
+
+- Install code execution dependencies before running this flow: `uv pip install .[code]`
+- The flow verifies composed `function_code + test_code` via `PythonInterpreterBlock` with `interpreter_framework: monty`
+- Tune `verify_execution.timeout` and `verify_execution.max_concurrency` via runtime parameters for longer or higher-volume workloads
+
+### Example Usage
+
+```python
+from datasets import Dataset
+from sdg_hub.core.flow import Flow, FlowRegistry
+
+FlowRegistry.discover_flows()
+flow_path = FlowRegistry.get_flow_path("Domain Code Evaluation Benchmark Generator")
+flow = Flow.from_yaml(flow_path)
+
+flow.set_model_config(
+    model="openai/gpt-5.1-codex-mini",
+    api_key="your-key",
+)
+
+seed = Dataset.from_dict(
+    {
+        "domain": ["financial calculations"],
+        "function_spec": ["Compute compound annual growth rate for two values."],
+        "difficulty": ["intermediate"],
+        "time_complexity": ["O(1)"],
+    }
+)
+
+result = flow.generate(seed, runtime_params={"verify_execution": {"timeout": 15.0}})
+```
 
 ---
 

--- a/docs/flows/discovery.md
+++ b/docs/flows/discovery.md
@@ -45,6 +45,10 @@ src/sdg_hub/flows/                    # Built-in flows
 │   └── mcp_distillation/
 │       ├── flow.yaml
 │       └── prompts/
+├── code_evaluation/                  # Code generation and verification flows
+│   └── domain_code_eval/
+│       ├── flow.yaml
+│       └── prompts/
 ├── text_analysis/                    # Text analysis flows
 │   └── structured_insights/
 │       ├── flow.yaml
@@ -165,6 +169,8 @@ flows/
 │   └── japanese_multi_summary_qa/
 ├── agentic/             # Agentic tool-use and distillation flows
 │   └── mcp_distillation/
+├── code_evaluation/     # Code benchmark generation and verification flows
+│   └── domain_code_eval/
 ├── text_analysis/       # Text processing and insights
 │   └── structured_insights/
 └── evaluation/          # Quality assessment flows

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -37,6 +37,17 @@ pip install sdg-hub[vllm]
 uv pip install sdg-hub[vllm]
 ```
 
+### Code Interpreter Support
+For sandboxed Python code execution with `PythonInterpreterBlock`:
+
+```bash
+# With pip
+pip install sdg-hub[code]
+
+# With uv
+uv pip install sdg-hub[code]
+```
+
 ### Examples Dependencies
 For running example notebooks and workflows:
 
@@ -53,10 +64,10 @@ To install everything at once:
 
 ```bash
 # With pip
-pip install sdg-hub[vllm,examples]
+pip install sdg-hub[vllm,code,examples]
 
 # With uv
-uv pip install sdg-hub[vllm,examples]
+uv pip install sdg-hub[vllm,code,examples]
 ```
 
 ## 🛠️ Development Installation


### PR DESCRIPTION
Add docs for the new code execution capability by covering the PythonInterpreterBlock, installation extras, and the Domain Code Evaluation benchmark flow in the docs catalog.

Made-with: Cursor