### PR TITLE
fix(connectors): return None instead of empty string when AI message content is None in extract_text

### DIFF
--- a/src/sdg_hub/core/connectors/agent/langflow.py
+++ b/src/sdg_hub/core/connectors/agent/langflow.py
@@ -153,14 +153,14 @@ class LangflowConnector(BaseAgentConnector):
         Returns
         -------
         str or None
-            Extracted session ID, empty string if the field is explicitly
-            None, or None if the key is missing.
+            Extracted session ID, or None if the field is missing or
+            explicitly None.
         """
         if "session_id" not in response:
             return None
         if response["session_id"] is None:
-            logger.warning("Session ID field is None, using empty string instead")
-            return ""
+            logger.warning("Session ID field is None")
+            return None
         return response["session_id"]
 
     @classmethod

--- a/src/sdg_hub/core/connectors/agent/langflow.py
+++ b/src/sdg_hub/core/connectors/agent/langflow.py
@@ -129,14 +129,14 @@ class LangflowConnector(BaseAgentConnector):
         Returns
         -------
         str or None
-            Extracted text, empty string if the field is explicitly None,
-            or None if the path does not exist.
+            Extracted text, or None if the field is missing or
+            explicitly None.
         """
         try:
             text = response["outputs"][0]["outputs"][0]["results"]["message"]["text"]
             if text is None:
-                logger.warning("Text field is None, using empty string instead")
-                return ""
+                logger.warning("Text field is None")
+                return None
             return text
         except (KeyError, IndexError, TypeError):
             return None

--- a/src/sdg_hub/core/connectors/agent/langgraph.py
+++ b/src/sdg_hub/core/connectors/agent/langgraph.py
@@ -236,8 +236,8 @@ class LangGraphConnector(BaseAgentConnector):
             if role in ("ai", "assistant"):
                 content = msg.get("content")
                 if content is None:
-                    logger.warning("AI message content is None, using empty string")
-                    return ""
+                    logger.warning("AI message content is None")
+                    return None
                 return str(content)
 
         return None

--- a/tests/blocks/agent/test_agent_response_extractor_block.py
+++ b/tests/blocks/agent/test_agent_response_extractor_block.py
@@ -576,12 +576,18 @@ class TestAgentResponseExtractorBlockErrorHandling:
 
         assert "Text field is None" in caplog.text
 
-    def test_none_session_id_handled_gracefully(self, caplog):
-        """Test handling when session_id field is None."""
+    def test_none_session_id_treated_as_missing(self, caplog):
+        """Test that None session_id is treated as a missing field.
+
+        When session_id is explicitly None, extract_session_id returns
+        None so AgentResponseExtractorBlock correctly identifies it as
+        missing rather than silently propagating an empty string.
+        """
         block = AgentResponseExtractorBlock(
             block_name="test_extractor",
             agent_framework="langflow",
             input_cols="agent_response",
+            extract_text=False,
             extract_session_id=True,
         )
 
@@ -591,11 +597,10 @@ class TestAgentResponseExtractorBlockErrorHandling:
         }
         dataset = pd.DataFrame({"agent_response": [response]})
 
-        result = block.generate(dataset)
+        with pytest.raises(ValueError, match="No requested fields found in response"):
+            block.generate(dataset)
 
-        assert len(result) == 1
-        assert result.iloc[0]["test_extractor_session_id"] == ""
-        assert "Session ID field is None, using empty string instead" in caplog.text
+        assert "Session ID field is None" in caplog.text
 
 
 class TestAgentResponseExtractorBlockIntegration:

--- a/tests/blocks/agent/test_agent_response_extractor_block.py
+++ b/tests/blocks/agent/test_agent_response_extractor_block.py
@@ -551,8 +551,13 @@ class TestAgentResponseExtractorBlockErrorHandling:
         with pytest.raises(ValueError, match="No requested fields found in response"):
             block.generate(dataset)
 
-    def test_none_text_handled_gracefully(self, caplog):
-        """Test handling when text field is None."""
+    def test_none_text_treated_as_missing(self, caplog):
+        """Test that None text content is treated as a missing field.
+
+        When AI message content is None (e.g. tool-only turns), extract_text
+        returns None so AgentResponseExtractorBlock correctly identifies it
+        as missing rather than silently propagating an empty string.
+        """
         block = AgentResponseExtractorBlock(
             block_name="test_extractor",
             agent_framework="langflow",
@@ -566,11 +571,10 @@ class TestAgentResponseExtractorBlockErrorHandling:
         }
         dataset = pd.DataFrame({"agent_response": [response]})
 
-        result = block.generate(dataset)
+        with pytest.raises(ValueError, match="No requested fields found in response"):
+            block.generate(dataset)
 
-        assert len(result) == 1
-        assert result.iloc[0]["test_extractor_text"] == ""
-        assert "Text field is None, using empty string instead" in caplog.text
+        assert "Text field is None" in caplog.text
 
     def test_none_session_id_handled_gracefully(self, caplog):
         """Test handling when session_id field is None."""

--- a/tests/connectors/agent/test_langflow_extraction.py
+++ b/tests/connectors/agent/test_langflow_extraction.py
@@ -53,11 +53,11 @@ class TestLangflowExtractText:
         response = make_langflow_response("Hello world")
         assert LangflowConnector.extract_text(response) == "Hello world"
 
-    def test_none_returns_empty_string(self, caplog):
+    def test_none_returns_none(self, caplog):
         response = make_langflow_response(None)
         result = LangflowConnector.extract_text(response)
-        assert result == ""
-        assert "Text field is None, using empty string instead" in caplog.text
+        assert result is None
+        assert "Text field is None" in caplog.text
 
     def test_missing_path_returns_none(self):
         assert LangflowConnector.extract_text({"outputs": []}) is None

--- a/tests/connectors/agent/test_langflow_extraction.py
+++ b/tests/connectors/agent/test_langflow_extraction.py
@@ -76,11 +76,11 @@ class TestLangflowExtractSessionId:
         response = make_langflow_response("text", session_id="abc-123")
         assert LangflowConnector.extract_session_id(response) == "abc-123"
 
-    def test_none_returns_empty_string(self, caplog):
+    def test_none_returns_none(self, caplog):
         response = {"session_id": None}
         result = LangflowConnector.extract_session_id(response)
-        assert result == ""
-        assert "Session ID field is None, using empty string instead" in caplog.text
+        assert result is None
+        assert "Session ID field is None" in caplog.text
 
     def test_missing_key_returns_none(self):
         assert LangflowConnector.extract_session_id({}) is None

--- a/tests/connectors/agent/test_langgraph.py
+++ b/tests/connectors/agent/test_langgraph.py
@@ -194,9 +194,9 @@ class TestLangGraphExtractText:
         }
         assert LangGraphConnector.extract_text(response) == "Hi!"
 
-    def test_none_content_returns_empty_string(self):
+    def test_none_content_returns_none(self):
         response = {"messages": [{"type": "ai", "content": None}]}
-        assert LangGraphConnector.extract_text(response) == ""
+        assert LangGraphConnector.extract_text(response) is None
 
     def test_no_ai_message_returns_none(self):
         response = {"messages": [{"type": "human", "content": "Hello"}]}


### PR DESCRIPTION
## Summary

When an AI message has `content: None` (e.g. tool-only turns where the model only emitted tool calls), `extract_text` in both `LangflowConnector` and `LangGraphConnector` was returning `""` (empty string) instead of `None`. This caused `AgentResponseExtractorBlock` to treat tool-only or interrupted runs as successful extractions, silently propagating blank output downstream.

## Changes

- **`src/sdg_hub/core/connectors/agent/langflow.py`** — `extract_text` now returns `None` instead of `""` when the text field is `None`
- **`src/sdg_hub/core/connectors/agent/langgraph.py`** — `extract_text` now returns `None` instead of `""` when AI message content is `None`
- **`tests/connectors/agent/test_langflow_extraction.py`** — Updated test to assert `None` return instead of empty string
- **`tests/connectors/agent/test_langgraph.py`** — Updated test to assert `None` return instead of empty string
- **`tests/blocks/agent/test_agent_response_extractor_block.py`** — Updated test to verify that `None` content is correctly treated as a missing field (raises `ValueError`)

## Testing

- All 858 unit tests pass
- Ruff linting and formatting checks pass
- Pre-commit hooks pass

Fixes Red-Hat-AI-Innovation-Team/sdg_hub#673

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Treats explicitly missing text/session values as absent (None) rather than as empty strings, so downstream logic can detect missing content accurately.
  * AI message content from certain connectors now returns explicit absence when empty instead of an empty string.

* **Tests**
  * Updated tests and expectations to reflect that missing text/session values are treated as absent (None) and to check corresponding log messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->