### PR TITLE
feat: add MessageFormatterBlock for in-flow training data formatting

### DIFF
--- a/src/sdg_hub/core/blocks/transform/__init__.py
+++ b/src/sdg_hub/core/blocks/transform/__init__.py
@@ -10,6 +10,7 @@ from .duplicate_columns import DuplicateColumnsBlock
 from .index_based_mapper import IndexBasedMapperBlock
 from .json_structure_block import JSONStructureBlock
 from .melt_columns import MeltColumnsBlock
+from .message_formatter import MessageFormatterBlock
 from .rename_columns import RenameColumnsBlock
 from .row_multiplier import RowMultiplierBlock
 from .sampler import SamplerBlock
@@ -21,6 +22,7 @@ __all__ = [
     "DuplicateColumnsBlock",
     "JSONStructureBlock",
     "MeltColumnsBlock",
+    "MessageFormatterBlock",
     "RowMultiplierBlock",
     "IndexBasedMapperBlock",
     "RenameColumnsBlock",

--- a/src/sdg_hub/core/blocks/transform/message_formatter.py
+++ b/src/sdg_hub/core/blocks/transform/message_formatter.py
@@ -52,7 +52,7 @@ class MessageFormatterBlock(BaseBlock):
             input_cols:
               tool_trace: extract_agent_text_tool_trace
               tool_list: tool_list
-            output_cols: messages
+            output_cols: [messages]
 
     Attributes
     ----------

--- a/src/sdg_hub/core/blocks/transform/message_formatter.py
+++ b/src/sdg_hub/core/blocks/transform/message_formatter.py
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Message formatter block for converting tool traces to structured conversations.
+
+This module wraps the ``tool_trace_to_messages()`` utility so that
+training-data formatting can be expressed as a block inside a flow YAML.
+"""
+
+# Standard
+from typing import Any, cast
+
+from pydantic import field_validator
+
+# Third Party
+import pandas as pd
+
+# Local
+from ...utils.logger_config import setup_logger
+from ...utils.message_formatter import tool_trace_to_messages
+from ..base import BaseBlock
+from ..registry import BlockRegistry
+
+logger = setup_logger(__name__)
+
+
+@BlockRegistry.register(
+    "MessageFormatterBlock",
+    "transform",
+    "Converts tool traces and tool lists into structured tool-calling conversations",
+)
+class MessageFormatterBlock(BaseBlock):
+    """Block for formatting tool traces into structured training conversations.
+
+    This block applies ``tool_trace_to_messages()`` row-by-row, reading a
+    tool-trace column and a tool-list column and producing a messages column
+    suitable for fine-tuning tool-use models.
+
+    The block expects ``input_cols`` as a **dict** with two required keys:
+
+    * ``tool_trace`` -- the DataFrame column containing the tool trace
+      (list of dicts from ``AgentResponseExtractorBlock``).
+    * ``tool_list`` -- the DataFrame column containing the tool schemas
+      (list of dicts with ``name``, ``description``, ``inputSchema``).
+
+    ``output_cols`` must be a single-element list giving the name of the
+    output column that will hold the formatted message list.
+
+    Example YAML usage::
+
+        - block_type: MessageFormatterBlock
+          block_config:
+            block_name: format_training_data
+            input_cols:
+              tool_trace: extract_agent_text_tool_trace
+              tool_list: tool_list
+            output_cols: messages
+
+    Attributes
+    ----------
+    block_name : str
+        Name of the block.
+    input_cols : dict
+        Mapping with keys ``tool_trace`` and ``tool_list`` pointing to
+        DataFrame column names.
+    output_cols : list[str]
+        Single-element list with the output column name.
+    """
+
+    block_type: str = "transform"
+
+    @field_validator("input_cols", mode="after")
+    @classmethod
+    def validate_input_cols(cls, v):
+        """Validate that input_cols is a dict with the required keys."""
+        if not isinstance(v, dict):
+            raise ValueError(
+                "MessageFormatterBlock requires input_cols to be a dict "
+                "with keys 'tool_trace' and 'tool_list'"
+            )
+        missing = {"tool_trace", "tool_list"} - set(v.keys())
+        if missing:
+            raise ValueError(
+                f"MessageFormatterBlock input_cols missing required keys: "
+                f"{', '.join(sorted(missing))}"
+            )
+        return v
+
+    @field_validator("output_cols", mode="after")
+    @classmethod
+    def validate_output_cols(cls, v):
+        """Validate that exactly one output column is specified."""
+        if not v or len(v) != 1:
+            raise ValueError("MessageFormatterBlock requires exactly one output column")
+        return v
+
+    def _validate_columns(self, df: pd.DataFrame) -> None:
+        """Check that the two input columns exist in the DataFrame."""
+        input_cols = cast(dict, self.input_cols)
+        available = df.columns.tolist()
+        missing = [col for col in input_cols.values() if col not in available]
+        if missing:
+            from ...utils.error_handling import MissingColumnError
+
+            raise MissingColumnError(
+                block_name=self.block_name,
+                missing_columns=missing,
+                available_columns=available,
+            )
+
+    def generate(self, samples: pd.DataFrame, **kwargs: Any) -> pd.DataFrame:
+        """Apply ``tool_trace_to_messages`` to each row.
+
+        Parameters
+        ----------
+        samples : pd.DataFrame
+            Input dataset.  Must contain the columns referenced by
+            ``input_cols["tool_trace"]`` and ``input_cols["tool_list"]``.
+
+        Returns
+        -------
+        pd.DataFrame
+            Dataset with the new output column containing structured
+            message lists.
+        """
+        input_cols = cast(dict, self.input_cols)
+        output_cols = cast(list[str], self.output_cols)
+        output_col = output_cols[0]
+
+        trace_col = input_cols["tool_trace"]
+        tools_col = input_cols["tool_list"]
+
+        result = samples.copy()
+        result[output_col] = result.apply(
+            lambda row: tool_trace_to_messages(row[trace_col], row[tools_col]),
+            axis=1,
+        )
+        return result

--- a/tests/blocks/transform/test_message_formatter_block.py
+++ b/tests/blocks/transform/test_message_formatter_block.py
@@ -1,0 +1,248 @@
+"""Tests for MessageFormatterBlock."""
+
+import pandas as pd
+import pytest
+
+from sdg_hub.core.blocks.transform import MessageFormatterBlock
+from sdg_hub.core.utils.error_handling import MissingColumnError
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tool_list():
+    """Minimal tool schema list used across tests."""
+    return [
+        {
+            "name": "get_weather",
+            "description": "Get the current weather for a location.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "location": {"type": "string"},
+                },
+                "required": ["location"],
+            },
+        },
+    ]
+
+
+@pytest.fixture
+def tool_trace():
+    """A simple tool trace with an input, tool call, and output."""
+    return [
+        {
+            "type": "text",
+            "header": {"title": "Input"},
+            "text": "What is the weather in Paris?",
+        },
+        {
+            "type": "tool_use",
+            "name": "get_weather",
+            "tool_input": {"location": "Paris"},
+            "output": "Sunny, 22C",
+        },
+        {
+            "type": "text",
+            "header": {"title": "Output"},
+            "text": "The weather in Paris is sunny and 22C.",
+        },
+    ]
+
+
+@pytest.fixture
+def sample_dataset(tool_trace, tool_list):
+    """A two-row DataFrame with trace and tool_list columns."""
+    return pd.DataFrame(
+        {
+            "trace_col": [tool_trace, tool_trace],
+            "tools_col": [tool_list, tool_list],
+        }
+    )
+
+
+def _make_block(**overrides):
+    """Helper to build a MessageFormatterBlock with sensible defaults."""
+    defaults = {
+        "block_name": "test_formatter",
+        "input_cols": {"tool_trace": "trace_col", "tool_list": "tools_col"},
+        "output_cols": ["messages"],
+    }
+    defaults.update(overrides)
+    return MessageFormatterBlock(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Happy-path tests
+# ---------------------------------------------------------------------------
+
+
+def test_basic_generate(sample_dataset):
+    """The block should produce a messages column with the correct structure."""
+    block = _make_block()
+    result = block.generate(sample_dataset)
+
+    assert "messages" in result.columns.tolist()
+    assert len(result) == 2
+
+    messages = result.iloc[0]["messages"]
+    assert isinstance(messages, list)
+    # system, user, assistant (tool_call), tool, assistant (output)
+    assert len(messages) == 5
+
+    roles = [m["role"] for m in messages]
+    assert roles == ["system", "user", "assistant", "tool", "assistant"]
+
+
+def test_system_message_contains_tool_declarations(sample_dataset):
+    """The system message should include the tool declarations."""
+    block = _make_block()
+    result = block.generate(sample_dataset)
+    system_msg = result.iloc[0]["messages"][0]
+    assert system_msg["role"] == "system"
+    assert "get_weather" in system_msg["content"]
+
+
+def test_user_message_content(sample_dataset):
+    """The user message should reflect the Input text from the trace."""
+    block = _make_block()
+    result = block.generate(sample_dataset)
+    user_msg = result.iloc[0]["messages"][1]
+    assert user_msg["role"] == "user"
+    assert user_msg["content"] == "What is the weather in Paris?"
+
+
+def test_tool_call_structure(sample_dataset):
+    """The assistant tool_calls message should have the expected shape."""
+    block = _make_block()
+    result = block.generate(sample_dataset)
+    assistant_tool_msg = result.iloc[0]["messages"][2]
+    assert assistant_tool_msg["role"] == "assistant"
+    assert assistant_tool_msg["content"] is None
+    tool_calls = assistant_tool_msg["tool_calls"]
+    assert len(tool_calls) == 1
+    assert tool_calls[0]["type"] == "function"
+    assert tool_calls[0]["function"]["name"] == "get_weather"
+
+
+def test_tool_response_content(sample_dataset):
+    """The tool message should carry the tool output."""
+    block = _make_block()
+    result = block.generate(sample_dataset)
+    tool_msg = result.iloc[0]["messages"][3]
+    assert tool_msg["role"] == "tool"
+    assert tool_msg["content"] == "Sunny, 22C"
+    assert tool_msg["name"] == "get_weather"
+
+
+def test_final_assistant_answer(sample_dataset):
+    """The last message should be the assistant's final answer."""
+    block = _make_block()
+    result = block.generate(sample_dataset)
+    final_msg = result.iloc[0]["messages"][4]
+    assert final_msg["role"] == "assistant"
+    assert "sunny" in final_msg["content"].lower()
+
+
+def test_original_columns_preserved(sample_dataset):
+    """Input columns should still be present after generation."""
+    block = _make_block()
+    result = block.generate(sample_dataset)
+    assert "trace_col" in result.columns.tolist()
+    assert "tools_col" in result.columns.tolist()
+
+
+def test_does_not_mutate_input(sample_dataset):
+    """The block must not modify the original DataFrame."""
+    original_cols = sample_dataset.columns.tolist()
+    block = _make_block()
+    block.generate(sample_dataset)
+    assert sample_dataset.columns.tolist() == original_cols
+    assert "messages" not in sample_dataset.columns.tolist()
+
+
+# ---------------------------------------------------------------------------
+# Multiple tool calls in a single trace
+# ---------------------------------------------------------------------------
+
+
+def test_multiple_tool_calls(tool_list):
+    """Traces with more than one tool_use step should produce multiple pairs."""
+    trace = [
+        {"type": "text", "header": {"title": "Input"}, "text": "Question?"},
+        {
+            "type": "tool_use",
+            "name": "get_weather",
+            "tool_input": {"location": "Paris"},
+            "output": "Sunny",
+        },
+        {
+            "type": "tool_use",
+            "name": "get_weather",
+            "tool_input": {"location": "London"},
+            "output": "Rainy",
+        },
+        {"type": "text", "header": {"title": "Output"}, "text": "Done."},
+    ]
+    df = pd.DataFrame({"trace_col": [trace], "tools_col": [tool_list]})
+    block = _make_block()
+    result = block.generate(df)
+    messages = result.iloc[0]["messages"]
+    # system, user, assistant+tool (x2), assistant output = 7
+    assert len(messages) == 7
+    assert [m["role"] for m in messages] == [
+        "system",
+        "user",
+        "assistant",
+        "tool",
+        "assistant",
+        "tool",
+        "assistant",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Validation tests
+# ---------------------------------------------------------------------------
+
+
+def test_input_cols_must_be_dict():
+    """input_cols as a list should be rejected."""
+    with pytest.raises(ValueError, match="dict"):
+        _make_block(input_cols=["trace_col", "tools_col"])
+
+
+def test_input_cols_missing_tool_trace_key():
+    """Omitting the tool_trace key should raise."""
+    with pytest.raises(ValueError, match="tool_trace"):
+        _make_block(input_cols={"tool_list": "tools_col"})
+
+
+def test_input_cols_missing_tool_list_key():
+    """Omitting the tool_list key should raise."""
+    with pytest.raises(ValueError, match="tool_list"):
+        _make_block(input_cols={"tool_trace": "trace_col"})
+
+
+def test_output_cols_must_have_exactly_one():
+    """More than one output column should be rejected."""
+    with pytest.raises(ValueError, match="exactly one output column"):
+        _make_block(output_cols=["a", "b"])
+
+
+def test_output_cols_cannot_be_empty():
+    """Empty output_cols should be rejected."""
+    with pytest.raises(ValueError, match="exactly one output column"):
+        _make_block(output_cols=[])
+
+
+def test_missing_dataframe_column(tool_trace, tool_list):
+    """Referencing a column absent from the DataFrame should error."""
+    df = pd.DataFrame({"trace_col": [tool_trace], "tools_col": [tool_list]})
+    block = _make_block(
+        input_cols={"tool_trace": "nonexistent", "tool_list": "tools_col"},
+    )
+    with pytest.raises(MissingColumnError):
+        block(df)


### PR DESCRIPTION
## Summary

Adds a `MessageFormatterBlock` that wraps the existing `tool_trace_to_messages()` utility so training data formatting can be expressed as a block in flow YAML pipelines, instead of requiring out-of-flow post-processing.

## Changes

- **New block**: `src/sdg_hub/core/blocks/transform/message_formatter.py` — registered as `MessageFormatterBlock` in the `transform` category
  - Accepts dict-style `input_cols` with keys `tool_trace` and `tool_list` pointing to DataFrame column names
  - Produces a single output column containing structured tool-calling conversation messages
  - Full validation of input/output column specifications
- **Updated**: `src/sdg_hub/core/blocks/transform/__init__.py` — exports the new block
- **New tests**: `tests/blocks/transform/test_message_formatter_block.py` — 15 tests covering happy path, multi-tool traces, validation errors, immutability, and column preservation

### Example YAML usage

```yaml
- block_type: MessageFormatterBlock
  block_config:
    block_name: format_training_data
    input_cols:
      tool_trace: extract_agent_text_tool_trace
      tool_list: tool_list
    output_cols: messages
```

## Testing

- All 15 new tests pass
- Full test suite (873 tests) passes with no regressions
- Ruff lint and format checks pass

Fixes Red-Hat-AI-Innovation-Team/sdg_hub#645

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced MessageFormatterBlock, a new transform that converts tool execution traces and tool specifications into structured message lists for model training.

* **Tests**
  * Added comprehensive tests covering normal generation, multiple tool uses, validation of configuration constraints, non-mutation of inputs, and error handling for missing columns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->