### PR TITLE
refactor: deduplicate config application logic in model_config.py and agent_config.py

### DIFF
--- a/src/sdg_hub/core/flow/agent_config.py
+++ b/src/sdg_hub/core/flow/agent_config.py
@@ -5,6 +5,7 @@
 from typing import TYPE_CHECKING, Any, Optional
 
 # Local
+from ..utils.config_helpers import apply_config_to_blocks, resolve_target_blocks
 from ..utils.logger_config import setup_logger
 
 if TYPE_CHECKING:
@@ -150,90 +151,15 @@ def set_agent_config(
             "(agent_framework, agent_url, agent_api_key, or **kwargs)"
         )
 
-    # Determine target blocks
-    if blocks is not None:
-        # Validate that specified blocks exist in the flow
-        existing_block_names = {block.block_name for block in flow.blocks}
-        invalid_blocks = set(blocks) - existing_block_names
-        if invalid_blocks:
-            raise ValueError(
-                f"Specified blocks not found in flow: {sorted(invalid_blocks)}. "
-                f"Available blocks: {sorted(existing_block_names)}"
-            )
-        target_block_names = set(blocks)
-        logger.info(
-            f"Targeting specific blocks for agent configuration: {sorted(target_block_names)}"
-        )
-    else:
-        # Auto-detect agent blocks
-        target_block_names = set(detect_agent_blocks(flow))
-        logger.info(
-            f"Auto-detected {len(target_block_names)} agent blocks for configuration: "
-            f"{sorted(target_block_names)}"
-        )
+    # Resolve which blocks to target
+    target_block_names = resolve_target_blocks(
+        flow, blocks, detect_agent_blocks, config_label="agent"
+    )
 
-    # Sensitive parameter names that should not be logged
-    sensitive_params = {"agent_api_key", "api_key", "token", "password", "secret"}
-
-    # Apply configuration to target blocks
-    modified_count = 0
-    for block in flow.blocks:
-        if block.block_name in target_block_names:
-            block_modified = False
-            for param_name, param_value in config_params.items():
-                if hasattr(block, param_name):
-                    setattr(block, param_name, param_value)
-                    block_modified = True
-                    # Don't log sensitive values
-                    if param_name in sensitive_params:
-                        logger.debug(
-                            f"Block '{block.block_name}': {param_name} set (redacted)"
-                        )
-                    else:
-                        logger.debug(
-                            f"Block '{block.block_name}': {param_name} "
-                            f"set to '{param_value}'"
-                        )
-                # check if allow extra
-                elif block.model_config.get("extra") == "allow":
-                    setattr(block, param_name, param_value)
-                    block_modified = True
-                    if param_name in sensitive_params:
-                        logger.debug(
-                            f"Block '{block.block_name}': {param_name} set (redacted)"
-                        )
-                    else:
-                        logger.debug(
-                            f"Block '{block.block_name}': {param_name} "
-                            f"set to '{param_value}'"
-                        )
-                else:
-                    logger.warning(
-                        f"Block '{block.block_name}' ({block.__class__.__name__}) "
-                        f"does not have attribute '{param_name}' - skipping"
-                    )
-
-            if block_modified:
-                modified_count += 1
+    # Apply configuration and mark the flow if any blocks were modified
+    modified_count = apply_config_to_blocks(
+        flow, config_params, target_block_names, config_label="agent"
+    )
 
     if modified_count > 0:
-        # Enhanced logging showing what was configured
-        param_summary = []
-        for param_name, param_value in config_params.items():
-            if param_name in sensitive_params:
-                param_summary.append(f"{param_name}: (redacted)")
-            else:
-                param_summary.append(f"{param_name}: '{param_value}'")
-
-        logger.info(
-            f"Successfully configured {modified_count} agent blocks with: "
-            f"{', '.join(param_summary)}"
-        )
-        logger.info(f"Configured blocks: {sorted(target_block_names)}")
-
-        # Mark that agent configuration has been set
         flow._agent_config_set = True
-    else:
-        logger.warning(
-            "No blocks were modified - check block names or agent block detection"
-        )

--- a/src/sdg_hub/core/flow/model_config.py
+++ b/src/sdg_hub/core/flow/model_config.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, Optional
 from pydantic import SecretStr
 
 # Local
+from ..utils.config_helpers import apply_config_to_blocks, resolve_target_blocks
 from ..utils.logger_config import setup_logger
 
 if TYPE_CHECKING:
@@ -222,89 +223,15 @@ def set_model_config(
             "(model, api_base, api_key, or **kwargs)"
         )
 
-    # Determine target blocks
-    if blocks is not None:
-        # Validate that specified blocks exist in the flow
-        existing_block_names = {block.block_name for block in flow.blocks}
-        invalid_blocks = set(blocks) - existing_block_names
-        if invalid_blocks:
-            raise ValueError(
-                f"Specified blocks not found in flow: {sorted(invalid_blocks)}. "
-                f"Available blocks: {sorted(existing_block_names)}"
-            )
-        target_block_names = set(blocks)
-        logger.info(
-            f"Targeting specific blocks for configuration: {sorted(target_block_names)}"
-        )
-    else:
-        # Auto-detect LLM blocks
-        target_block_names = set(detect_llm_blocks(flow))
-        logger.info(
-            f"Auto-detected {len(target_block_names)} LLM blocks for configuration: {sorted(target_block_names)}"
-        )
+    # Resolve which blocks to target
+    target_block_names = resolve_target_blocks(
+        flow, blocks, detect_llm_blocks, config_label="LLM"
+    )
 
-    # Sensitive parameter names that should not be logged
-    sensitive_params = {"api_key", "token", "password", "secret"}
-
-    # Apply configuration to target blocks
-    modified_count = 0
-    for block in flow.blocks:
-        if block.block_name in target_block_names:
-            block_modified = False
-            for param_name, param_value in config_params.items():
-                if hasattr(block, param_name):
-                    setattr(block, param_name, param_value)
-                    block_modified = True
-                    # Don't log sensitive values
-                    if param_name in sensitive_params:
-                        logger.debug(
-                            f"Block '{block.block_name}': {param_name} set (redacted)"
-                        )
-                    else:
-                        logger.debug(
-                            f"Block '{block.block_name}': {param_name} "
-                            f"set to '{param_value}'"
-                        )
-                # check if allow extra
-                elif block.model_config.get("extra") == "allow":
-                    setattr(block, param_name, param_value)
-                    block_modified = True
-                    if param_name in sensitive_params:
-                        logger.debug(
-                            f"Block '{block.block_name}': {param_name} set (redacted)"
-                        )
-                    else:
-                        logger.debug(
-                            f"Block '{block.block_name}': {param_name} "
-                            f"set to '{param_value}'"
-                        )
-                else:
-                    logger.warning(
-                        f"Block '{block.block_name}' ({block.__class__.__name__}) "
-                        f"does not have attribute '{param_name}' - skipping"
-                    )
-
-            if block_modified:
-                modified_count += 1
+    # Apply configuration and mark the flow if any blocks were modified
+    modified_count = apply_config_to_blocks(
+        flow, config_params, target_block_names, config_label="LLM"
+    )
 
     if modified_count > 0:
-        # Enhanced logging showing what was configured
-        # Apply same redaction rules as per-block logging
-        param_summary = []
-        for param_name, param_value in config_params.items():
-            if param_name in sensitive_params:
-                param_summary.append(f"{param_name}: (redacted)")
-            else:
-                param_summary.append(f"{param_name}: '{param_value}'")
-
-        logger.info(
-            f"Successfully configured {modified_count} LLM blocks with: {', '.join(param_summary)}"
-        )
-        logger.info(f"Configured blocks: {sorted(target_block_names)}")
-
-        # Mark that model configuration has been set
         flow._model_config_set = True
-    else:
-        logger.warning(
-            "No blocks were modified - check block names or LLM block detection"
-        )

--- a/src/sdg_hub/core/utils/config_helpers.py
+++ b/src/sdg_hub/core/utils/config_helpers.py
@@ -8,6 +8,9 @@ summary.  This module extracts that loop so it only exists once.
 """
 
 # Standard
+from __future__ import annotations
+
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 # Local
@@ -19,6 +22,8 @@ if TYPE_CHECKING:
 logger = setup_logger(__name__)
 
 # Parameter names whose values must never appear in log output.
+# Intentionally the superset of what model_config and agent_config each
+# previously defined so that both code-paths share a single set.
 DEFAULT_SENSITIVE_PARAMS: frozenset[str] = frozenset(
     {"api_key", "agent_api_key", "token", "password", "secret"}
 )
@@ -27,7 +32,7 @@ DEFAULT_SENSITIVE_PARAMS: frozenset[str] = frozenset(
 def resolve_target_blocks(
     flow: "Flow",
     blocks: list[str] | None,
-    auto_detect_fn: Any,
+    auto_detect_fn: Callable[[Flow], list[str]],
     config_label: str,
 ) -> set[str]:
     """Validate explicit block names or auto-detect target blocks.

--- a/src/sdg_hub/core/utils/config_helpers.py
+++ b/src/sdg_hub/core/utils/config_helpers.py
@@ -1,0 +1,171 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared helpers for applying configuration parameters to flow blocks.
+
+Both ``model_config.py`` and ``agent_config.py`` need identical logic to
+iterate over target blocks, set attributes (via ``hasattr`` or the Pydantic
+``extra == "allow"`` fallback), redact sensitive values in logs and build a
+summary.  This module extracts that loop so it only exists once.
+"""
+
+# Standard
+from typing import TYPE_CHECKING, Any
+
+# Local
+from .logger_config import setup_logger
+
+if TYPE_CHECKING:
+    from ..flow.base import Flow
+
+logger = setup_logger(__name__)
+
+# Parameter names whose values must never appear in log output.
+DEFAULT_SENSITIVE_PARAMS: frozenset[str] = frozenset(
+    {"api_key", "agent_api_key", "token", "password", "secret"}
+)
+
+
+def resolve_target_blocks(
+    flow: "Flow",
+    blocks: list[str] | None,
+    auto_detect_fn: Any,
+    config_label: str,
+) -> set[str]:
+    """Validate explicit block names or auto-detect target blocks.
+
+    Parameters
+    ----------
+    flow : Flow
+        The flow instance.
+    blocks : list[str] | None
+        Explicit block names supplied by the caller, or ``None`` to
+        auto-detect.
+    auto_detect_fn : Callable[[Flow], list[str]]
+        A function that returns the list of auto-detected block names
+        (e.g. ``detect_llm_blocks`` or ``detect_agent_blocks``).
+    config_label : str
+        Human-readable label used in log messages (e.g. ``"LLM"`` or
+        ``"agent"``).
+
+    Returns
+    -------
+    set[str]
+        The resolved set of target block names.
+
+    Raises
+    ------
+    ValueError
+        If any explicitly named block does not exist in the flow.
+    """
+    if blocks is not None:
+        existing_block_names = {block.block_name for block in flow.blocks}
+        invalid_blocks = set(blocks) - existing_block_names
+        if invalid_blocks:
+            raise ValueError(
+                f"Specified blocks not found in flow: {sorted(invalid_blocks)}. "
+                f"Available blocks: {sorted(existing_block_names)}"
+            )
+        target_block_names = set(blocks)
+        logger.info(
+            f"Targeting specific blocks for {config_label} configuration: "
+            f"{sorted(target_block_names)}"
+        )
+    else:
+        target_block_names = set(auto_detect_fn(flow))
+        logger.info(
+            f"Auto-detected {len(target_block_names)} {config_label} blocks "
+            f"for configuration: {sorted(target_block_names)}"
+        )
+
+    return target_block_names
+
+
+def apply_config_to_blocks(
+    flow: "Flow",
+    config_params: dict[str, Any],
+    target_block_names: set[str],
+    config_label: str,
+    sensitive_params: frozenset[str] = DEFAULT_SENSITIVE_PARAMS,
+) -> int:
+    """Apply configuration parameters to the target blocks of a flow.
+
+    For each target block, every key in *config_params* is applied using the
+    following precedence:
+
+    1. If the block already has the attribute (``hasattr``), set it directly.
+    2. Else if the block's Pydantic ``model_config`` allows extras, set it.
+    3. Otherwise log a warning and skip the parameter.
+
+    Sensitive values (as defined by *sensitive_params*) are redacted in all log
+    output.
+
+    Parameters
+    ----------
+    flow : Flow
+        The flow instance whose blocks will be mutated.
+    config_params : dict[str, Any]
+        Mapping of parameter names to values to apply.
+    target_block_names : set[str]
+        Block names that should receive the configuration.
+    config_label : str
+        Human-readable label for log messages (e.g. ``"LLM"`` or ``"agent"``).
+    sensitive_params : frozenset[str]
+        Parameter names whose values must be redacted in logs.
+
+    Returns
+    -------
+    int
+        The number of blocks that were actually modified.
+    """
+    modified_count = 0
+
+    for block in flow.blocks:
+        if block.block_name not in target_block_names:
+            continue
+
+        block_modified = False
+        for param_name, param_value in config_params.items():
+            if hasattr(block, param_name):
+                setattr(block, param_name, param_value)
+                block_modified = True
+            elif block.model_config.get("extra") == "allow":
+                setattr(block, param_name, param_value)
+                block_modified = True
+            else:
+                logger.warning(
+                    f"Block '{block.block_name}' ({block.__class__.__name__}) "
+                    f"does not have attribute '{param_name}' - skipping"
+                )
+                continue
+
+            # Log what was set, redacting sensitive values.
+            if param_name in sensitive_params:
+                logger.debug(f"Block '{block.block_name}': {param_name} set (redacted)")
+            else:
+                logger.debug(
+                    f"Block '{block.block_name}': {param_name} set to '{param_value}'"
+                )
+
+        if block_modified:
+            modified_count += 1
+
+    # Summary logging
+    if modified_count > 0:
+        param_summary = []
+        for param_name, param_value in config_params.items():
+            if param_name in sensitive_params:
+                param_summary.append(f"{param_name}: (redacted)")
+            else:
+                param_summary.append(f"{param_name}: '{param_value}'")
+
+        logger.info(
+            f"Successfully configured {modified_count} {config_label} blocks "
+            f"with: {', '.join(param_summary)}"
+        )
+        logger.info(f"Configured blocks: {sorted(target_block_names)}")
+    else:
+        logger.warning(
+            f"No blocks were modified - check block names or {config_label} "
+            f"block detection"
+        )
+
+    return modified_count

--- a/tests/flow/test_agent_config.py
+++ b/tests/flow/test_agent_config.py
@@ -118,7 +118,7 @@ class TestAgentConfigCoverage:
         )
         assert not hasattr(agent_block, "secret")
 
-        with caplog.at_level(logging.DEBUG, logger="sdg_hub.core.flow.agent_config"):
+        with caplog.at_level(logging.DEBUG, logger="sdg_hub.core.utils.config_helpers"):
             flow.set_agent_config(
                 agent_url="http://new:7860",
                 secret="super-secret-value",

--- a/tests/flow/test_base.py
+++ b/tests/flow/test_base.py
@@ -1471,7 +1471,7 @@ class TestFlow:
         )
         flow = Flow(metadata=self.test_metadata, blocks=[llm_block])
 
-        with caplog.at_level(logging.INFO, logger="sdg_hub.core.flow.model_config"):
+        with caplog.at_level(logging.INFO, logger="sdg_hub.core.utils.config_helpers"):
             flow.set_model_config(
                 model="openai/gpt-4",
                 api_key="sk-secret-key",


### PR DESCRIPTION
## Summary

- Extracts the duplicated block-config-application loop from `model_config.py` and `agent_config.py` into a new shared helper module `src/sdg_hub/core/utils/config_helpers.py`
- Both `set_model_config()` and `set_agent_config()` now delegate to `resolve_target_blocks()` and `apply_config_to_blocks()` instead of duplicating ~50 lines of identical logic
- Future config modules (e.g., connector config) can reuse the same helpers without copy-pasting

## Changes

- **New:** `src/sdg_hub/core/utils/config_helpers.py` — shared helpers `resolve_target_blocks()` (validates explicit block names or auto-detects) and `apply_config_to_blocks()` (hasattr/extra=="allow" branches, sensitive param redaction, summary logging)
- **Refactored:** `src/sdg_hub/core/flow/model_config.py` — removed ~50 lines of duplicated logic, calls shared helpers
- **Refactored:** `src/sdg_hub/core/flow/agent_config.py` — removed ~50 lines of duplicated logic, calls shared helpers
- **Updated:** `tests/flow/test_base.py` and `tests/flow/test_agent_config.py` — updated `caplog` logger names to match the new log source (`sdg_hub.core.utils.config_helpers`)

## Testing

- [x] All 732 unit tests pass (`pytest tests/blocks tests/connectors tests/flow -m 'not (examples or slow)'`)
- [x] Ruff lint and format checks pass on all changed files
- [x] mypy type checking passes on all changed files
- [x] Pre-commit hooks (ruff, ruff-format, conventional-commit) pass

Fixes Red-Hat-AI-Innovation-Team/sdg_hub#644