### PR TITLE
fix: validate connector_kwargs keys to catch typos silently ignored by Pydantic

### DIFF
--- a/src/sdg_hub/core/blocks/agent/agent_block.py
+++ b/src/sdg_hub/core/blocks/agent/agent_block.py
@@ -169,7 +169,7 @@ class AgentBlock(BaseBlock):
             # ignored by Pydantic.
             if self.connector_kwargs:
                 valid_fields = connector_class.model_fields.keys() - {"config"}
-                unknown = set(self.connector_kwargs) - valid_fields
+                unknown = sorted(set(self.connector_kwargs) - valid_fields)
                 if unknown:
                     raise ConnectorError(
                         f"Unknown connector_kwargs for "

--- a/src/sdg_hub/core/blocks/agent/agent_block.py
+++ b/src/sdg_hub/core/blocks/agent/agent_block.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Agent block for integrating external agent frameworks."""
 
-from typing import Any, Optional
+from typing import Any, Optional, cast
 import asyncio
 import json
 import uuid
@@ -177,14 +177,16 @@ class AgentBlock(BaseBlock):
                         f"Valid options: {sorted(valid_fields)}"
                     )
             try:
-                self._connector = connector_class(
-                    config=config, **self.connector_kwargs
+                self._connector = cast(
+                    BaseAgentConnector,
+                    connector_class(config=config, **self.connector_kwargs),
                 )
             except (TypeError, ValidationError) as e:
                 raise ConnectorError(
                     f"Invalid connector_kwargs for '{self.agent_framework}': {e}"
                 ) from e
             self._connector_config_key = config_key
+        assert self._connector is not None  # guaranteed by the branch above
         return self._connector
 
     def _get_messages_col(self) -> str:

--- a/src/sdg_hub/core/blocks/agent/agent_block.py
+++ b/src/sdg_hub/core/blocks/agent/agent_block.py
@@ -164,6 +164,18 @@ class AgentBlock(BaseBlock):
                 timeout=self.timeout,
                 max_retries=self.max_retries,
             )
+            # Validate connector_kwargs keys before construction so that
+            # typos are surfaced immediately instead of being silently
+            # ignored by Pydantic.
+            if self.connector_kwargs:
+                valid_fields = connector_class.model_fields.keys()
+                unknown = set(self.connector_kwargs) - valid_fields
+                if unknown:
+                    raise ConnectorError(
+                        f"Unknown connector_kwargs for "
+                        f"'{self.agent_framework}': {unknown}. "
+                        f"Valid options: {sorted(valid_fields)}"
+                    )
             try:
                 self._connector = connector_class(
                     config=config, **self.connector_kwargs

--- a/src/sdg_hub/core/blocks/agent/agent_block.py
+++ b/src/sdg_hub/core/blocks/agent/agent_block.py
@@ -168,7 +168,7 @@ class AgentBlock(BaseBlock):
             # typos are surfaced immediately instead of being silently
             # ignored by Pydantic.
             if self.connector_kwargs:
-                valid_fields = connector_class.model_fields.keys()
+                valid_fields = connector_class.model_fields.keys() - {"config"}
                 unknown = set(self.connector_kwargs) - valid_fields
                 if unknown:
                     raise ConnectorError(

--- a/src/sdg_hub/core/blocks/code/python_interpreter_block.py
+++ b/src/sdg_hub/core/blocks/code/python_interpreter_block.py
@@ -8,6 +8,7 @@ from pydantic import Field, PrivateAttr, field_validator
 from tqdm.asyncio import tqdm_asyncio
 import pandas as pd
 
+from ...connectors.base import ConnectorConfig
 from ...connectors.code_interpreter.base import (
     BaseCodeInterpreterConnector,
     CodeExecutionResult,
@@ -131,9 +132,14 @@ class PythonInterpreterBlock(BaseBlock):
 
         if self._connector is None or self._connector_config_key != config_key:
             connector_class = ConnectorRegistry.get(self.interpreter_framework)
-            self._connector = connector_class()
+            self._connector = cast(
+                BaseCodeInterpreterConnector,
+                connector_class(
+                    config=ConnectorConfig()  # type: ignore[call-arg]
+                ),
+            )
             self._connector_config_key = config_key
-
+        assert self._connector is not None
         return self._connector
 
     async def _execute_one(

--- a/src/sdg_hub/core/connectors/registry.py
+++ b/src/sdg_hub/core/connectors/registry.py
@@ -1,10 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 """Registry for connector classes."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 import inspect
 
 from ..utils.logger_config import setup_logger
 from .exceptions import ConnectorError
+
+if TYPE_CHECKING:
+    from .base import BaseConnector
 
 logger = setup_logger(__name__)
 
@@ -23,7 +29,7 @@ class ConnectorRegistry:
     >>> connector_class = ConnectorRegistry.get("my_connector")
     """
 
-    _connectors: dict[str, type] = {}
+    _connectors: dict[str, type[BaseConnector]] = {}
 
     @classmethod
     def register(cls, name: str):
@@ -46,7 +52,7 @@ class ConnectorRegistry:
         ...     pass
         """
 
-        def decorator(connector_class: type) -> type:
+        def decorator(connector_class: type[BaseConnector]) -> type[BaseConnector]:
             # Validate the class
             if not inspect.isclass(connector_class):
                 raise ConnectorError(f"Expected a class, got {type(connector_class)}")
@@ -68,7 +74,7 @@ class ConnectorRegistry:
         return decorator
 
     @classmethod
-    def get(cls, name: str) -> type:
+    def get(cls, name: str) -> type[BaseConnector]:
         """Get a connector class by name.
 
         Parameters
@@ -78,7 +84,7 @@ class ConnectorRegistry:
 
         Returns
         -------
-        type
+        type[BaseConnector]
             The connector class.
 
         Raises

--- a/tests/blocks/agent/test_agent_block.py
+++ b/tests/blocks/agent/test_agent_block.py
@@ -487,11 +487,11 @@ class TestAgentBlockConnectorIntegration:
             def parse_response(self, response):
                 return response
 
-        ConnectorRegistry._connectors["_test"] = _TestConnector
+        ConnectorRegistry.register("_test_valid_kwargs")(_TestConnector)
         try:
             block = AgentBlock(
                 block_name="test",
-                agent_framework="_test",
+                agent_framework="_test_valid_kwargs",
                 agent_url="http://localhost:9999",
                 input_cols=["messages"],
                 output_cols=["response"],
@@ -500,7 +500,7 @@ class TestAgentBlockConnectorIntegration:
             connector = block._get_connector()
             assert connector.custom_option == "my-value"
         finally:
-            del ConnectorRegistry._connectors["_test"]
+            ConnectorRegistry._connectors.pop("_test_valid_kwargs", None)
 
 
 class TestAgentBlockConnectorKwargs:

--- a/tests/blocks/agent/test_agent_block.py
+++ b/tests/blocks/agent/test_agent_block.py
@@ -457,6 +457,51 @@ class TestAgentBlockConnectorIntegration:
         assert connector1 is not connector2
         assert connector2.config.url == "http://newhost:8080"
 
+    def test_get_connector_rejects_unknown_connector_kwargs(self):
+        """Test that unknown connector_kwargs keys raise ConnectorError."""
+        block = AgentBlock(
+            block_name="test",
+            agent_framework="langflow",
+            agent_url="http://localhost:7860",
+            input_cols=["messages"],
+            output_cols=["response"],
+            connector_kwargs={"nonexistent_option": "value"},
+        )
+
+        with pytest.raises(ConnectorError, match="Unknown connector_kwargs"):
+            block._get_connector()
+
+    def test_get_connector_accepts_valid_connector_kwargs(self):
+        """Test that valid connector_kwargs are accepted without error."""
+        from pydantic import Field
+
+        from sdg_hub.core.connectors.agent.base import BaseAgentConnector
+        from sdg_hub.core.connectors.registry import ConnectorRegistry
+
+        class _TestConnector(BaseAgentConnector):
+            custom_option: str = Field(default="default")
+
+            def build_request(self, messages, session_id):
+                return {}
+
+            def parse_response(self, response):
+                return response
+
+        ConnectorRegistry._connectors["_test"] = _TestConnector
+        try:
+            block = AgentBlock(
+                block_name="test",
+                agent_framework="_test",
+                agent_url="http://localhost:9999",
+                input_cols=["messages"],
+                output_cols=["response"],
+                connector_kwargs={"custom_option": "my-value"},
+            )
+            connector = block._get_connector()
+            assert connector.custom_option == "my-value"
+        finally:
+            del ConnectorRegistry._connectors["_test"]
+
 
 class TestAgentBlockConnectorKwargs:
     """Test connector_kwargs passthrough on AgentBlock."""


### PR DESCRIPTION
## Summary

- Add explicit key validation in `AgentBlock._get_connector()` to reject unknown `connector_kwargs` keys before constructing the connector
- Typos like `assitant_id` (instead of `assistant_id`) now raise a `ConnectorError` with a clear message listing valid options

## Changes

- **`src/sdg_hub/core/blocks/agent/agent_block.py`**: Added validation logic that checks `connector_kwargs` keys against `connector_class.model_fields` before connector construction
- **`tests/blocks/agent/test_agent_block.py`**: Added two tests — one verifying unknown kwargs are rejected, one verifying valid kwargs are accepted

## Testing

- [x] New test `test_get_connector_rejects_unknown_connector_kwargs` verifies `ConnectorError` is raised for invalid keys
- [x] New test `test_get_connector_accepts_valid_connector_kwargs` verifies valid keys pass through and are applied
- [x] All 492 existing tests pass (`uv run python -m pytest tests/blocks tests/connectors -m 'not (examples or slow)'`)
- [x] Ruff lint and format checks pass on changed files

Fixes Red-Hat-AI-Innovation-Team/sdg_hub#674

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of connector configuration to detect and reject unknown keys early, with clearer errors and guaranteed connector creation checks.

* **Refactor**
  * Tightened connector registration/typing to make connector selection and usage more robust.

* **Tests**
  * Added integration tests covering connector parameter validation and registry-driven connector construction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->