### PR TITLE
fix: scope lib/ gitignore to repo root for website/src/lib/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,8 +17,8 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
-lib64/
+/lib/
+/lib64/
 parts/
 sdist/
 var/

--- a/website/src/lib/markdoc.ts
+++ b/website/src/lib/markdoc.ts
@@ -1,0 +1,157 @@
+import { type Config, nodes, Tag } from "@markdoc/markdoc";
+import { createHighlighterCoreSync } from "shiki/core";
+import { createJavaScriptRegexEngine } from "shiki/engine/javascript";
+import python from "shiki/langs/python.mjs";
+import bash from "shiki/langs/bash.mjs";
+import yaml from "shiki/langs/yaml.mjs";
+import json from "shiki/langs/json.mjs";
+import toml from "shiki/langs/toml.mjs";
+
+const shiki = createHighlighterCoreSync({
+  themes: [],
+  langs: [python, bash, yaml, json, toml],
+  engine: createJavaScriptRegexEngine(),
+});
+
+// Kanagawa-warm inspired theme
+const kanagawa = {
+  name: "kanagawa",
+  type: "dark" as const,
+  colors: {
+    "editor.background": "#13111a",
+    "editor.foreground": "#c8bfb0",
+  },
+  tokenColors: [
+    { scope: ["comment", "punctuation.definition.comment"], settings: { foreground: "#3d3a36", fontStyle: "italic" } },
+    { scope: ["string", "string.quoted"], settings: { foreground: "#8ea383" } },
+    { scope: ["keyword", "storage.type", "storage.modifier"], settings: { foreground: "#c4746e" } },
+    { scope: ["entity.name.function", "support.function", "meta.function-call"], settings: { foreground: "#7e9cba" } },
+    { scope: ["variable", "variable.other", "variable.parameter"], settings: { foreground: "#c8bfb0" } },
+    { scope: ["constant.numeric", "constant.language"], settings: { foreground: "#d4956a" } },
+    { scope: ["entity.name.type", "support.type", "support.class", "entity.name.class"], settings: { foreground: "#a88bb8" } },
+    { scope: ["keyword.operator"], settings: { foreground: "#a09b93" } },
+    { scope: ["punctuation"], settings: { foreground: "#a09b93" } },
+    { scope: ["entity.name.tag"], settings: { foreground: "#c4746e" } },
+    { scope: ["entity.other.attribute-name"], settings: { foreground: "#d4956a" } },
+    { scope: ["meta.decorator", "punctuation.decorator"], settings: { foreground: "#e8975d" } },
+    { scope: ["keyword.control.import", "keyword.control.from"], settings: { foreground: "#c4746e" } },
+  ],
+};
+
+/**
+ * Highlight code with shiki using the kanagawa theme.
+ * Returns raw HTML string with <pre><code> wrapping.
+ */
+export function highlightCode(code: string, lang: string): string {
+  const supported = ["python", "bash", "yaml", "json", "toml", "sh", "shell"];
+  const normalizedLang = lang === "sh" || lang === "shell" ? "bash" : lang;
+
+  if (!supported.includes(lang) && lang !== "sh" && lang !== "shell") {
+    // Return plain text for unsupported languages
+    const escaped = code.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+    return `<pre data-language="${lang}"><code>${escaped}</code></pre>`;
+  }
+
+  const html = shiki.codeToHtml(code, {
+    lang: normalizedLang,
+    theme: kanagawa,
+  });
+
+  // Inject our data-language attribute into the <pre> tag
+  return html.replace("<pre", `<pre data-language="${lang}"`);
+}
+
+/**
+ * Generate a URL-friendly ID from heading text.
+ * Uses a page-level counter to ensure uniqueness for duplicate headings.
+ */
+let headingCounter = 0;
+
+function generateId(children: unknown[]): string {
+  headingCounter++;
+  const base = children
+    .filter((child) => typeof child === "string")
+    .join("")
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, "")
+    .replace(/\s+/g, "-");
+
+  return `${base}-${headingCounter}`;
+}
+
+/** Reset heading counter between pages. */
+export function resetHeadingIds() {
+  headingCounter = 0;
+}
+
+export const markdocConfig: Config = {
+  nodes: {
+    heading: {
+      ...nodes.heading,
+      transform(node, config) {
+        const attributes = node.transformAttributes(config);
+        const children = node.transformChildren(config);
+        const id = generateId(children);
+
+        return new Tag(
+          `h${node.attributes.level}`,
+          { ...attributes, id },
+          children
+        );
+      },
+    },
+    fence: {
+      ...nodes.fence,
+      transform(node, config) {
+        const attributes = node.transformAttributes(config);
+        const language = node.attributes.language || "";
+
+        return new Tag(
+          "pre",
+          { "data-language": language, ...attributes },
+          [
+            new Tag("code", { class: language ? `language-${language}` : "" }, [
+              node.attributes.content,
+            ]),
+          ]
+        );
+      },
+    },
+    link: {
+      ...nodes.link,
+      transform(node, config) {
+        const attributes = node.transformAttributes(config);
+        const children = node.transformChildren(config);
+        let href = (node.attributes.href as string) || "";
+
+        // Rewrite .md links to website paths
+        if (href.endsWith(".md")) {
+          href = href
+            .replace(/\.md$/, "")
+            .replace(/\/index$/, "")
+            .replace(/^\.\.\//, "")
+            .replace(/^\.\//, "");
+
+          // Make it an absolute /docs/ path
+          if (!href.startsWith("/")) {
+            href = `/docs/${href}`;
+          }
+        }
+
+        return new Tag("a", { ...attributes, href }, children);
+      },
+    },
+  },
+  tags: {
+    callout: {
+      render: "Callout",
+      attributes: {
+        type: {
+          type: String,
+          default: "info",
+          matches: ["info", "warning", "error"],
+        },
+      },
+    },
+  },
+};

--- a/website/src/lib/markdoc.ts
+++ b/website/src/lib/markdoc.ts
@@ -49,7 +49,7 @@ export function highlightCode(code: string, lang: string): string {
   if (!supported.includes(lang) && lang !== "sh" && lang !== "shell") {
     // Return plain text for unsupported languages
     const escaped = code.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-    return `<pre data-language="${lang}"><code>${escaped}</code></pre>`;
+    const safeLang = lang.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;"); return `<pre data-language="${safeLang}"><code>${escaped}</code></pre>`;
   }
 
   const html = shiki.codeToHtml(code, {
@@ -58,7 +58,7 @@ export function highlightCode(code: string, lang: string): string {
   });
 
   // Inject our data-language attribute into the <pre> tag
-  return html.replace("<pre", `<pre data-language="${lang}"`);
+  const safeLang = lang.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;"); return html.replace("<pre", `<pre data-language="${safeLang}"`);
 }
 
 /**
@@ -124,8 +124,8 @@ export const markdocConfig: Config = {
         const children = node.transformChildren(config);
         let href = (node.attributes.href as string) || "";
 
-        // Rewrite .md links to website paths
-        if (href.endsWith(".md")) {
+        // Rewrite relative .md links to website paths (skip absolute URLs)
+        if (href.endsWith(".md") && !href.startsWith("http")) {
           href = href
             .replace(/\.md$/, "")
             .replace(/\/index$/, "")

--- a/website/src/lib/navigation.ts
+++ b/website/src/lib/navigation.ts
@@ -75,6 +75,10 @@ export function getPrevNext(href: string): {
   const flat = getFlatNavItems();
   const index = flat.findIndex((item) => item.href === href);
 
+  if (index === -1) {
+    return { prev: null, next: null };
+  }
+
   return {
     prev: index > 0 ? flat[index - 1] : null,
     next: index < flat.length - 1 ? flat[index + 1] : null,

--- a/website/src/lib/navigation.ts
+++ b/website/src/lib/navigation.ts
@@ -1,0 +1,82 @@
+export interface NavItem {
+  title: string;
+  href: string;
+}
+
+export interface NavSection {
+  title: string;
+  items: NavItem[];
+}
+
+export const navigation: NavSection[] = [
+  {
+    title: "Getting Started",
+    items: [
+      { title: "Introduction", href: "/docs" },
+      { title: "Installation", href: "/docs/installation" },
+      { title: "Quick Start", href: "/docs/quickstart" },
+      { title: "Core Concepts", href: "/docs/concepts" },
+    ],
+  },
+  {
+    title: "Blocks",
+    items: [
+      { title: "Overview", href: "/docs/blocks" },
+      { title: "LLM Blocks", href: "/docs/blocks/llm-blocks" },
+      { title: "Parsing Blocks", href: "/docs/blocks/parsing-blocks" },
+      { title: "Transform Blocks", href: "/docs/blocks/transform-blocks" },
+      { title: "Filtering Blocks", href: "/docs/blocks/filtering-blocks" },
+      { title: "Agent Blocks", href: "/docs/blocks/agent-blocks" },
+      { title: "Custom Blocks", href: "/docs/blocks/custom-blocks" },
+    ],
+  },
+  {
+    title: "Flows",
+    items: [
+      { title: "Overview", href: "/docs/flows" },
+      { title: "YAML Reference", href: "/docs/flows/yaml-reference" },
+      { title: "Built-in Flows", href: "/docs/flows/built-in-flows" },
+      { title: "Custom Flows", href: "/docs/flows/custom-flows" },
+    ],
+  },
+  {
+    title: "Connectors",
+    items: [{ title: "Overview", href: "/docs/connectors" }],
+  },
+  {
+    title: "Reference",
+    items: [
+      { title: "Overview", href: "/docs/reference" },
+      { title: "Blocks API", href: "/docs/reference/blocks" },
+      { title: "Flow API", href: "/docs/reference/flow" },
+      { title: "Connectors API", href: "/docs/reference/connectors" },
+    ],
+  },
+  {
+    title: "Contributing",
+    items: [{ title: "Development", href: "/docs/development" }],
+  },
+];
+
+/**
+ * Returns a flat ordered list of all nav items, used for prev/next links.
+ */
+export function getFlatNavItems(): NavItem[] {
+  return navigation.flatMap((section) => section.items);
+}
+
+/**
+ * Find prev/next pages relative to a given href.
+ */
+export function getPrevNext(href: string): {
+  prev: NavItem | null;
+  next: NavItem | null;
+} {
+  const flat = getFlatNavItems();
+  const index = flat.findIndex((item) => item.href === href);
+
+  return {
+    prev: index > 0 ? flat[index - 1] : null,
+    next: index < flat.length - 1 ? flat[index + 1] : null,
+  };
+}


### PR DESCRIPTION
The broad `lib/` pattern in .gitignore was ignoring `website/src/lib/*.ts` files, causing the GitHub Pages deploy workflow to fail with module-not-found errors. Changed to `/lib/` so it only matches at repo root.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Anchored .gitignore patterns for top-level library directories to avoid accidental matches in subfolders.

* **New Features**
  * Enhanced docs rendering with syntax-highlighted code blocks, consistent per-page heading IDs, and callout block support.
  * Improved documentation links normalization and site navigation with ordered sections plus previous/next navigation between pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->