### PR TITLE
docs: add docs website link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,9 @@
 </p>
 <p align="center"><em>Composable blocks and flows for synthetic data generation</em></p>
 <p align="center">
-  <a href="https://pypi.org/project/sdg-hub/"><img src="https://img.shields.io/pypi/v/sdg-hub?style=flat-square" alt="PyPI"></a>
-  <a href="https://github.com/Red-Hat-AI-Innovation-Team/sdg_hub/actions/workflows/test.yml"><img src="https://img.shields.io/github/actions/workflow/status/Red-Hat-AI-Innovation-Team/sdg_hub/test.yml?style=flat-square&label=tests" alt="Tests"></a>
-  <img src="https://img.shields.io/badge/python-3.10%2B-brightgreen?style=flat-square" alt="Python 3.10+">
-  <a href="https://github.com/Red-Hat-AI-Innovation-Team/sdg_hub/blob/main/LICENSE"><img src="https://img.shields.io/github/license/Red-Hat-AI-Innovation-Team/sdg_hub?style=flat-square" alt="License"></a>
-  <a href="https://codecov.io/gh/Red-Hat-AI-Innovation-Team/sdg_hub"><img src="https://img.shields.io/codecov/c/github/Red-Hat-AI-Innovation-Team/sdg_hub?style=flat-square" alt="Coverage"></a>
-  <a href="https://deepwiki.com/Red-Hat-AI-Innovation-Team/sdg_hub"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
+  <a href="https://ai-innovation.team/sdg_hub/"><img src="https://img.shields.io/badge/docs-ai--innovation.team-e8975d?style=flat-square" alt="Docs"></a>
+  <a href="https://pypi.org/project/sdg-hub/"><img src="https://img.shields.io/pypi/v/sdg-hub?style=flat-square&color=7daa8c" alt="PyPI"></a>
+  <a href="https://github.com/Red-Hat-AI-Innovation-Team/sdg_hub/blob/main/LICENSE"><img src="https://img.shields.io/github/license/Red-Hat-AI-Innovation-Team/sdg_hub?style=flat-square&color=8097c4" alt="License"></a>
 </p>
 
 ---
@@ -44,6 +41,8 @@ result = flow.generate(dataset)
 See the [Quick Start](docs/quickstart.md) for a full walkthrough, or browse [all built-in flows](docs/flows/built-in-flows.md).
 
 ## Documentation
+
+**[Full documentation at ai-innovation.team/sdg_hub](https://ai-innovation.team/sdg_hub/)**
 
 - [Installation](docs/installation.md) -- setup, optional dependencies, development install
 - [Quick Start](docs/quickstart.md) -- end-to-end walkthrough from loading a flow to generating data

--- a/README.md
+++ b/README.md
@@ -8,8 +8,12 @@
 <p align="center"><em>Composable blocks and flows for synthetic data generation</em></p>
 <p align="center">
   <a href="https://ai-innovation.team/sdg_hub/"><img src="https://img.shields.io/badge/docs-ai--innovation.team-e8975d?style=flat-square" alt="Docs"></a>
-  <a href="https://pypi.org/project/sdg-hub/"><img src="https://img.shields.io/pypi/v/sdg-hub?style=flat-square&color=7daa8c" alt="PyPI"></a>
-  <a href="https://github.com/Red-Hat-AI-Innovation-Team/sdg_hub/blob/main/LICENSE"><img src="https://img.shields.io/github/license/Red-Hat-AI-Innovation-Team/sdg_hub?style=flat-square&color=8097c4" alt="License"></a>
+  <a href="https://pypi.org/project/sdg-hub/"><img src="https://img.shields.io/pypi/v/sdg-hub?style=flat-square" alt="PyPI"></a>
+  <a href="https://github.com/Red-Hat-AI-Innovation-Team/sdg_hub/actions/workflows/test.yml"><img src="https://img.shields.io/github/actions/workflow/status/Red-Hat-AI-Innovation-Team/sdg_hub/test.yml?style=flat-square&label=tests" alt="Tests"></a>
+  <img src="https://img.shields.io/badge/python-3.10%2B-brightgreen?style=flat-square" alt="Python 3.10+">
+  <a href="https://github.com/Red-Hat-AI-Innovation-Team/sdg_hub/blob/main/LICENSE"><img src="https://img.shields.io/github/license/Red-Hat-AI-Innovation-Team/sdg_hub?style=flat-square" alt="License"></a>
+  <a href="https://codecov.io/gh/Red-Hat-AI-Innovation-Team/sdg_hub"><img src="https://img.shields.io/codecov/c/github/Red-Hat-AI-Innovation-Team/sdg_hub?style=flat-square" alt="Coverage"></a>
+  <a href="https://deepwiki.com/Red-Hat-AI-Innovation-Team/sdg_hub"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
 </p>
 
 ---


### PR DESCRIPTION
Adds the live docs site link to the README in two places:

1. **Badge row** -- new amber 'docs' badge linking to https://ai-innovation.team/sdg_hub/
2. **Documentation section** -- prominent link at the top before the page list

No PR needed for the `.github.io` repo -- `ai-innovation.team/sdg_hub/` already resolves correctly via GitHub Pages org-level routing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a centered "Docs" badge to the top badge section of the README, linking to the project documentation site.
  * Added a corresponding "Full documentation" link entry under the README's Documentation section. No other README content, structure, or public API declarations were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->