### PR TITLE
fix: make docs right-column sticky on scroll

### DIFF
--- a/website/src/app/docs/layout.tsx
+++ b/website/src/app/docs/layout.tsx
@@ -9,7 +9,7 @@ export default function DocsLayout({
   return (
     <div className="flex min-h-screen flex-col" style={{ background: "var(--color-bg-0)" }}>
       <Header />
-      <div className="flex flex-1 overflow-hidden">
+      <div className="flex flex-1">
         <Sidebar />
         {/* Main content area offset by sidebar width on large screens */}
         <main className="min-w-0 flex-1 overflow-y-auto lg:pl-[248px]">{children}</main>

--- a/website/src/components/TableOfContents.tsx
+++ b/website/src/components/TableOfContents.tsx
@@ -39,7 +39,7 @@ export function TableOfContents({ headings }: { headings: Heading[] }) {
 
   return (
     <nav className="hidden xl:block">
-      <div className="sticky top-24">
+      <div className="sticky top-24 max-h-[calc(100vh-6rem)] overflow-y-auto">
         <p
           className="mb-3 text-[11px] tracking-wider text-text-3"
           style={{ fontFamily: "var(--font-mono)", fontWeight: 600 }}


### PR DESCRIPTION
## Summary

Fixes the docs site right-column Table of Contents so it follows the user as they scroll, instead of being statically fixed at the top of the page.

## Changes

- **`website/src/app/docs/layout.tsx`**: Removed `overflow-hidden` from the docs layout flex container. This class was creating a containing block that prevented `position: sticky` from working on descendant elements.
- **`website/src/components/TableOfContents.tsx`**: Added `max-h-[calc(100vh-6rem)]` and `overflow-y-auto` to the sticky TOC div so it scrolls internally when the table of contents is longer than the viewport.

## Testing

- [ ] Open the docs site and navigate to a page with a long Table of Contents
- [ ] Scroll down -- the right-column TOC should follow the scroll and stay visible
- [ ] Verify the TOC does not overlap with the sticky header
- [ ] On pages with many headings, verify the TOC scrolls internally
- [ ] Verify the left sidebar still works correctly on desktop and mobile

Fixes Red-Hat-AI-Innovation-Team/sdg_hub#705

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved layout flexibility in the documentation area to better handle content overflow.
  * Enhanced Table of Contents with viewport-aware height constraints and scrolling.
  * Refined main content area scrolling behavior for improved user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->