### PR TITLE
fix: make docs TOC sticky on scroll

### DIFF
--- a/website/src/app/docs/layout.tsx
+++ b/website/src/app/docs/layout.tsx
@@ -12,7 +12,7 @@ export default function DocsLayout({
       <div className="flex flex-1">
         <Sidebar />
         {/* Main content area offset by sidebar width on large screens */}
-        <main className="min-w-0 flex-1 overflow-y-auto lg:pl-[248px]">{children}</main>
+        <main className="min-w-0 flex-1 lg:pl-[248px]">{children}</main>
       </div>
     </div>
   );

--- a/website/src/components/TableOfContents.tsx
+++ b/website/src/components/TableOfContents.tsx
@@ -38,7 +38,7 @@ export function TableOfContents({ headings }: { headings: Heading[] }) {
   if (headings.length === 0) return null;
 
   return (
-    <nav className="hidden xl:block">
+    <nav className="hidden h-full xl:block">
       <div className="sticky top-24 max-h-[calc(100vh-6rem)] overflow-y-auto">
         <p
           className="mb-3 text-[11px] tracking-wider text-text-3"


### PR DESCRIPTION
## Summary

- Remove `overflow-y-auto` from `<main>` in docs layout — this created a non-scrolling scroll container that intercepted `position: sticky`, preventing the TOC from following scroll
- Add `h-full` to the `<nav>` wrapper in `TableOfContents` — the nav was only as tall as its content, giving the sticky element zero travel room within its containing block

Both fixes are required together for sticky to work. PR #710 addressed `overflow-hidden` on a different ancestor but missed these two root causes.

## Test plan

- [ ] Open a docs page with enough content to scroll (e.g., one with multiple h2/h3 headings)
- [ ] Scroll down — right-column TOC should follow, sticking below the header
- [ ] Verify the header still sticks at the top
- [ ] Verify the left sidebar still scrolls independently
- [ ] Check a short docs page — TOC should behave normally
- [ ] Check the API Reference page is unaffected

Closes #705

https://claude.ai/code/session_01KuTrTQtxx9Q3w4g1UNTpLL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted scrolling behavior in the documentation's main content area.
  * Updated table of contents to properly extend full height on larger screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->