### PR TITLE
ci: add mypy to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,15 @@ repos:
       # Run the formatter
       - id: ruff-format
 
+  - repo: local
+    hooks:
+      - id: mypy
+        name: mypy
+        entry: uv run mypy src/sdg_hub --show-error-codes
+        language: system
+        types: [python]
+        pass_filenames: false
+
   - repo: https://github.com/compilerla/conventional-pre-commit
     rev: v3.6.0
     hooks:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,7 @@ Hooks run automatically on commit:
 - **uv-lock**: Keeps `uv.lock` in sync with `pyproject.toml`
 - **ruff**: Linter with auto-fix
 - **ruff-format**: Code formatter
+- **mypy**: Type checker (runs `mypy src/sdg_hub`)
 - **conventional-pre-commit**: Enforces [Conventional Commits](https://www.conventionalcommits.org/)
 
 Commit prefixes: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`


### PR DESCRIPTION
## Summary

- Add a local mypy pre-commit hook that runs `mypy src/sdg_hub --show-error-codes`, matching the CI lint workflow
- Uses `language: system` so it picks up the project's installed mypy and `pyproject.toml` config
- Update CLAUDE.md to list mypy in the pre-commit hooks section

Closes #723