### PR TITLE
feat(flows): add persona-aware answer generation to RAG evaluation ICL flow

### DIFF
--- a/docs/flows/built-in-flows.md
+++ b/docs/flows/built-in-flows.md
@@ -30,6 +30,7 @@ flow = Flow.from_yaml(flow_path)
 | code_evaluation | Domain Code Evaluation Benchmark Generator | `domain-code-eval` | gpt-5.1-codex-mini | domain, function_spec, difficulty, time_complexity |
 | evaluation | RAG Evaluation Dataset | `loud-dawn-245` | openai/gpt-oss-120b | document, document_outline |
 | evaluation | RAG Evaluation ICL Dataset | `keen-pearl-546` | openai/gpt-oss-120b | document, document_outline, icl_document, icl_query_1-3 |
+| evaluation | RAG Evaluation ICL Persona Dataset | `fresh-chord-196` | openai/gpt-oss-120b | document, document_outline, icl_document, icl_query_1-3, system_prompt |
 | evaluation | Agent Tool-Use Evaluation | `eager-path-837` | openai/gpt-4o | question, expert_answer_truncated, expert_trace_formatted, model_answer, model_trace_formatted |
 
 ---
@@ -512,6 +513,52 @@ dataset = Dataset.from_dict({
     "icl_query_1": ["How do I configure X when Y keeps timing out?"],
     "icl_query_2": ["We set up a pipeline but the labels get reused - is that expected?"],
     "icl_query_3": ["What's the best way to debug failed builds?"],
+})
+result = flow.generate(dataset, max_concurrency=20)
+```
+
+### RAG Evaluation ICL Persona Dataset (fresh-chord-196)
+
+Location: `src/sdg_hub/flows/evaluation/rag_evaluation_icl_persona/`
+
+Extends the ICL flow with persona-aware answer generation. Questions are
+generated identically (3-stage ICL pipeline), but answers are produced using a
+configurable `system_prompt` that defines the chatbot's tone, formatting, and
+response structure. Answers remain grounded in the document context while
+matching the persona.
+
+Default model: `openai/gpt-oss-120b`
+
+Required columns: `document`, `document_outline`, `icl_document`,
+`icl_query_1`, `icl_query_2`, `icl_query_3`, `system_prompt`
+
+Tags: `rag-evaluation`, `qa-pairs`, `icl`, `persona`
+
+```python
+from datasets import Dataset
+from sdg_hub import Flow
+from sdg_hub import FlowRegistry
+
+FlowRegistry.discover_flows()
+flow = Flow.from_yaml(
+    FlowRegistry.get_flow_path_safe("fresh-chord-196")
+)
+flow.set_model_config(
+    model="openai/gpt-oss-120b",
+    api_key="your-key",
+)
+
+persona = """You are a Senior Platform Engineer. Be conversational and direct.
+Explain WHY before WHAT. Use plain text formatting, no markdown."""
+
+dataset = Dataset.from_dict({
+    "document": ["Your document text..."],
+    "document_outline": ["Document Title"],
+    "icl_document": ["Example document for style reference..."],
+    "icl_query_1": ["How do I configure X when Y keeps timing out?"],
+    "icl_query_2": ["We set up a pipeline but the labels get reused - is that expected?"],
+    "icl_query_3": ["What's the best way to debug failed builds?"],
+    "system_prompt": [persona],
 })
 result = flow.generate(dataset, max_concurrency=20)
 ```

--- a/docs/flows/built-in-flows.md
+++ b/docs/flows/built-in-flows.md
@@ -29,6 +29,7 @@ flow = Flow.from_yaml(flow_path)
 | agentic | MCP Server Distillation | `new-night-835` | openai/gpt-5.2 | tool_list, mcp_server_name, mcp_server_description |
 | evaluation | RAG Evaluation Dataset | `loud-dawn-245` | openai/gpt-oss-120b | document, document_outline |
 | evaluation | RAG Evaluation ICL Dataset | `keen-pearl-546` | openai/gpt-oss-120b | document, document_outline, icl_document, icl_query_1-3 |
+| evaluation | RAG Evaluation ICL Persona Dataset | `fresh-chord-196` | openai/gpt-oss-120b | document, document_outline, icl_document, icl_query_1-3, system_prompt |
 | evaluation | Agent Tool-Use Evaluation | `eager-path-837` | openai/gpt-4o | question, expert_answer_truncated, expert_trace_formatted, model_answer, model_trace_formatted |
 
 ---
@@ -395,6 +396,52 @@ dataset = Dataset.from_dict({
     "icl_query_1": ["How do I configure X when Y keeps timing out?"],
     "icl_query_2": ["We set up a pipeline but the labels get reused - is that expected?"],
     "icl_query_3": ["What's the best way to debug failed builds?"],
+})
+result = flow.generate(dataset, max_concurrency=20)
+```
+
+### RAG Evaluation ICL Persona Dataset (fresh-chord-196)
+
+Location: `src/sdg_hub/flows/evaluation/rag_evaluation_icl_persona/`
+
+Extends the ICL flow with persona-aware answer generation. Questions are
+generated identically (3-stage ICL pipeline), but answers are produced using a
+configurable `system_prompt` that defines the chatbot's tone, formatting, and
+response structure. Answers remain grounded in the document context while
+matching the persona.
+
+Default model: `openai/gpt-oss-120b`
+
+Required columns: `document`, `document_outline`, `icl_document`,
+`icl_query_1`, `icl_query_2`, `icl_query_3`, `system_prompt`
+
+Tags: `rag-evaluation`, `qa-pairs`, `icl`, `persona`
+
+```python
+from datasets import Dataset
+from sdg_hub import Flow
+from sdg_hub import FlowRegistry
+
+FlowRegistry.discover_flows()
+flow = Flow.from_yaml(
+    FlowRegistry.get_flow_path_safe("fresh-chord-196")
+)
+flow.set_model_config(
+    model="openai/gpt-oss-120b",
+    api_key="your-key",
+)
+
+persona = """You are a Senior Platform Engineer. Be conversational and direct.
+Explain WHY before WHAT. Use plain text formatting, no markdown."""
+
+dataset = Dataset.from_dict({
+    "document": ["Your document text..."],
+    "document_outline": ["Document Title"],
+    "icl_document": ["Example document for style reference..."],
+    "icl_query_1": ["How do I configure X when Y keeps timing out?"],
+    "icl_query_2": ["We set up a pipeline but the labels get reused - is that expected?"],
+    "icl_query_3": ["What's the best way to debug failed builds?"],
+    "system_prompt": [persona],
 })
 result = flow.generate(dataset, max_concurrency=20)
 ```

--- a/src/sdg_hub/flows/evaluation/rag_evaluation_icl_persona/README.md
+++ b/src/sdg_hub/flows/evaluation/rag_evaluation_icl_persona/README.md
@@ -83,7 +83,7 @@ For generic extractive answers without persona, use `rag_evaluation_icl` instead
 
 ```python
 from datasets import Dataset
-from sdg_hub.core.flow import Flow, FlowRegistry
+from sdg_hub import Flow, FlowRegistry
 
 # Load flow
 FlowRegistry.discover_flows()

--- a/src/sdg_hub/flows/evaluation/rag_evaluation_icl_persona/README.md
+++ b/src/sdg_hub/flows/evaluation/rag_evaluation_icl_persona/README.md
@@ -1,0 +1,142 @@
+# RAG Evaluation ICL Persona Dataset Flow
+
+Generates realistic Q&A pairs for RAG (Retrieval-Augmented Generation) evaluation using the existing 3-stage question generation pipeline with ICL-driven question generation and persona-aware answer generation.
+
+## What It Does
+
+Combines two capabilities: realistic question generation (from ICL examples) and persona-aware answer generation (from a configurable system prompt):
+
+1. Extracts a topic from the document (diversity control)
+2. Generates a realistic question about that topic using ICL examples as style references (has full document context)
+3. Evolves the question to be more indirect and compressed
+4. Produces answers grounded in the document context, following the chatbot's persona (tone, formatting, response structure)
+5. Evaluates answer groundedness on a 1-5 scale
+6. Filters out poorly grounded Q&A pairs (keeps only scores 4-5)
+7. Extracts ground truth context sentences from the document
+
+## Pipeline
+
+```
+Document → Topic Extraction → ICL Question Generation → Evolution →
+Persona-Aware Answer Generation → Groundedness Scoring → Filter (4-5) → Context Extraction → Final QA Pairs
+```
+
+## Input Requirements
+
+| Column | Description | Required |
+|--------|-------------|----------|
+| `document` | Full document text to generate questions about | Yes |
+| `document_outline` | Document title or structural outline | Yes |
+| `icl_document` | Example document used as style reference | Yes |
+| `icl_query_1` | First example question (real user style) | Yes |
+| `icl_query_2` | Second example question (real user style) | Yes |
+| `icl_query_3` | Third example question (real user style) | Yes |
+| `system_prompt` | Chatbot persona defining tone, formatting, and response structure | Yes |
+
+The `system_prompt` column defines how the chatbot should respond. The answer generation step uses this as the system message alongside grounding rules, producing answers that match the chatbot's persona while staying grounded in the document context.
+
+## Output Columns
+
+| Column | Description |
+|--------|-------------|
+| `question` | Generated realistic question |
+| `response` | Persona-aware answer grounded in the document |
+| `ground_truth_context` | Exact sentences from the document that answer the question |
+
+## Key Parameters
+
+```python
+runtime_params = {
+    "gen_topic": {
+        "max_tokens": 2048,
+        "temperature": 0.7
+    },
+    "gen_conceptual_question": {
+        "max_tokens": 2048,
+        "temperature": 0.7
+    },
+    "evolve_question": {
+        "max_tokens": 4096,
+        "temperature": 0.7
+    },
+    "gen_answer": {
+        "max_tokens": 4096,
+        "temperature": 0.2    # Lower for factual answers
+    },
+    "gen_critic_score": {
+        "max_tokens": 512,
+        "temperature": 0.0    # Deterministic scoring
+    }
+}
+```
+
+## When to Use
+
+- Evaluating a specific chatbot with questions and answers that match its persona
+- Need evaluation datasets where answers reflect how the actual chatbot would respond
+- Have a chatbot system prompt and want to generate ground truth in that style
+- Want realistic user-style questions combined with persona-aware answers
+
+For generic extractive answers without persona, use `rag_evaluation_icl` instead. For textbook-style questions, use the base `rag_evaluation` flow.
+
+## Example Usage
+
+```python
+from datasets import Dataset
+from sdg_hub.core.flow import Flow, FlowRegistry
+
+# Load flow
+FlowRegistry.discover_flows()
+flow_path = FlowRegistry.get_flow_path("RAG Evaluation ICL Persona Dataset Flow")
+flow = Flow.from_yaml(flow_path)
+
+# Configure model
+flow.set_model_config(
+    model="hosted_vllm/meta-llama/Llama-3.3-70B-Instruct",
+    api_base="http://localhost:8000/v1",
+    api_key="your_key"
+)
+
+# Define your chatbot's persona
+persona = """You are a Senior Platform Engineer. Your mission: help engineers
+fix CI/CD issues quickly and accurately. Be conversational and direct.
+Explain WHY before WHAT. Use plain text formatting, no markdown."""
+
+# Prepare input data
+dataset = Dataset.from_dict({
+    "document": ["Your target document content..."],
+    "document_outline": ["Document Title; Section 1; Section 2"],
+    "icl_document": ["Example document that the example questions are about..."],
+    "icl_query_1": ["I'm trying to configure X but getting timeout errors - is there a max retry setting?"],
+    "icl_query_2": ["We set up a pipeline with custom tasks and the labels seem to get reused - is that expected?"],
+    "icl_query_3": ["How do I debug failed builds when the logs only show the last step?"],
+    "system_prompt": [persona]
+})
+
+# Generate
+result = flow.generate(dataset, max_concurrency=50)
+print(f"Generated {len(result)} QA pairs")
+```
+
+## Example Output
+
+```json
+{
+  "question": "I'm trying to access individual pods within a StatefulSet directly, bypassing the main service - which Service type is typically used for this, and how does it work?",
+  "response": "Good question - this is a common pattern for stateful apps. The reason you need a Headless Service here is that it bypasses the normal load balancing. When you set clusterIP to None, DNS returns the individual Pod IPs directly instead of a single cluster IP...",
+  "ground_truth_context": "Headless Services are created by setting clusterIP to None. They don't allocate a cluster IP and instead return the Pod IPs directly through DNS. This is useful for StatefulSets where each Pod needs to be individually addressable."
+}
+```
+
+## Comparison with Other RAG Evaluation Flows
+
+| Aspect | `rag_evaluation` | `rag_evaluation_icl` | `rag_evaluation_icl_persona` |
+|--------|------------------|----------------------|------------------------------|
+| Question style | Textbook-like | Realistic, user-like | Realistic, user-like |
+| Answer style | Generic extractive | Generic extractive | Persona-aware |
+| ICL examples | No | Yes | Yes |
+| System prompt | No | No | Yes |
+| Questions per document | 1 | 1 | 1 |
+| Question generation | 3 stages | 3 stages (ICL) | 3 stages (ICL) |
+| Groundedness scoring | 1-5 scale | 1-5 scale | 1-5 scale |
+| Output columns | Same | Same | Same |

--- a/src/sdg_hub/flows/evaluation/rag_evaluation_icl_persona/flow.yaml
+++ b/src/sdg_hub/flows/evaluation/rag_evaluation_icl_persona/flow.yaml
@@ -1,3 +1,5 @@
+# This flow extends rag_evaluation_icl with persona-aware answer generation.
+# Prompts other than answer_generation.yaml are shared with rag_evaluation_icl.
 metadata:
   name: RAG Evaluation ICL Persona Dataset Flow
   description: Generates realistic Q&A pairs for RAG evaluation using the 3-stage question generation pipeline with ICL-driven style and persona-aware answer generation.

--- a/src/sdg_hub/flows/evaluation/rag_evaluation_icl_persona/flow.yaml
+++ b/src/sdg_hub/flows/evaluation/rag_evaluation_icl_persona/flow.yaml
@@ -1,0 +1,200 @@
+metadata:
+  name: RAG Evaluation ICL Persona Dataset Flow
+  description: Generates realistic Q&A pairs for RAG evaluation using the 3-stage question generation pipeline with ICL-driven style and persona-aware answer generation.
+  version: 1.0.0
+  author: Red Hat AI RAG Contributors
+  license: Apache-2.0
+  recommended_models:
+    default: openai/gpt-oss-120b
+    compatible:
+    - meta-llama/Llama-3.3-70B-Instruct
+    - microsoft/phi-4
+  tags:
+  - rag-evaluation
+  - qa-pairs
+  - icl
+  - persona
+  dataset_requirements:
+    required_columns:
+    - document
+    - document_outline
+    - icl_document
+    - icl_query_1
+    - icl_query_2
+    - icl_query_3
+    - system_prompt
+    description: 'Input dataset should contain documents with text content, document outlines, in-context learning examples (an example document with three example questions) to guide realistic question generation, and a system prompt defining the chatbot persona for answer generation.
+
+      '
+  id: fresh-chord-196
+blocks:
+- block_type: DuplicateColumnsBlock
+  block_config:
+    block_name: duplicate_to_context
+    input_cols:
+      document: context
+- block_type: PromptBuilderBlock
+  block_config:
+    block_name: topic_prompt
+    input_cols:
+    - document
+    output_cols: topic_messages
+    prompt_config_path: prompts/topic_generation.yaml
+- block_type: LLMChatBlock
+  block_config:
+    block_name: gen_topic
+    input_cols: topic_messages
+    output_cols: topic_response
+    async_mode: true
+    n: 1
+    max_tokens: 2048
+    temperature: 0.7
+- block_type: LLMResponseExtractorBlock
+  block_config:
+    block_name: parse_topic
+    input_cols: topic_response
+    field_prefix: topic_
+    extract_content: true
+- block_type: RenameColumnsBlock
+  block_config:
+    block_name: rename_topic
+    input_cols:
+      topic_content: topic
+- block_type: PromptBuilderBlock
+  block_config:
+    block_name: conceptual_prompt
+    input_cols:
+      document: document
+      document_outline: document_outline
+      topic: topic
+      icl_document: icl_document
+      icl_query_1: icl_query_1
+      icl_query_2: icl_query_2
+      icl_query_3: icl_query_3
+    output_cols: conceptual_messages
+    prompt_config_path: prompts/conceptual_qa_generation_icl.yaml
+- block_type: LLMChatBlock
+  block_config:
+    block_name: gen_conceptual_question
+    input_cols: conceptual_messages
+    output_cols: question_response
+    async_mode: true
+    n: 1
+    max_tokens: 2048
+    temperature: 0.7
+- block_type: LLMResponseExtractorBlock
+  block_config:
+    block_name: parse_question
+    input_cols: question_response
+    field_prefix: question_
+    extract_content: true
+- block_type: PromptBuilderBlock
+  block_config:
+    block_name: evolution_prompt
+    input_cols:
+      question_content: question
+    output_cols: evolution_messages
+    prompt_config_path: prompts/question_evolution_icl.yaml
+- block_type: LLMChatBlock
+  block_config:
+    block_name: evolve_question
+    input_cols: evolution_messages
+    output_cols: evolution_response
+    async_mode: true
+    n: 1
+    max_tokens: 4096
+    temperature: 0.7
+- block_type: LLMResponseExtractorBlock
+  block_config:
+    block_name: parse_evolved_question
+    input_cols: evolution_response
+    field_prefix: "evolved_"
+    extract_content: true
+- block_type: PromptBuilderBlock
+  block_config:
+    block_name: answer_prompt
+    input_cols:
+      system_prompt: system_prompt
+      context: context
+      evolved_content: question
+    output_cols: answer_messages
+    prompt_config_path: prompts/answer_generation.yaml
+- block_type: LLMChatBlock
+  block_config:
+    block_name: gen_answer
+    input_cols: answer_messages
+    output_cols: answer_response
+    async_mode: true
+    n: 1
+    max_tokens: 4096
+    temperature: 0.2
+- block_type: LLMResponseExtractorBlock
+  block_config:
+    block_name: parse_answer
+    input_cols: answer_response
+    field_prefix: "answer_"
+    extract_content: true
+- block_type: PromptBuilderBlock
+  block_config:
+    block_name: critic_prompt
+    input_cols:
+      context: context
+      evolved_content: question
+      answer_content: answer
+    output_cols: critic_messages
+    prompt_config_path: prompts/groundedness_critic.yaml
+- block_type: LLMChatBlock
+  block_config:
+    block_name: gen_critic_score
+    input_cols: critic_messages
+    output_cols: critic_response
+    async_mode: true
+    n: 1
+    max_tokens: 512
+    temperature: 0.0
+- block_type: LLMResponseExtractorBlock
+  block_config:
+    block_name: parse_critic_score
+    input_cols: critic_response
+    field_prefix: "critic_"
+    extract_content: true
+- block_type: ColumnValueFilterBlock
+  block_config:
+    block_name: filter_ungrounded
+    input_cols: critic_content
+    filter_value:
+    - 4
+    - 5
+    operation: "eq"
+    convert_dtype: "int"
+- block_type: PromptBuilderBlock
+  block_config:
+    block_name: extraction_prompt
+    input_cols:
+      context: context
+      evolved_content: question
+      answer_content: answer
+    output_cols: extraction_messages
+    prompt_config_path: prompts/context_extraction.yaml
+- block_type: LLMChatBlock
+  block_config:
+    block_name: extract_context
+    input_cols: extraction_messages
+    output_cols: extraction_response
+    async_mode: true
+    n: 1
+    max_tokens: 4096
+    temperature: 0.0
+- block_type: LLMResponseExtractorBlock
+  block_config:
+    block_name: parse_extracted_context
+    input_cols: extraction_response
+    field_prefix: "ground_truth_"
+    extract_content: true
+- block_type: RenameColumnsBlock
+  block_config:
+    block_name: rename_final_columns
+    input_cols:
+      evolved_content: question
+      answer_content: response
+      ground_truth_content: ground_truth_context

--- a/src/sdg_hub/flows/evaluation/rag_evaluation_icl_persona/prompts/answer_generation.yaml
+++ b/src/sdg_hub/flows/evaluation/rag_evaluation_icl_persona/prompts/answer_generation.yaml
@@ -21,4 +21,4 @@
     Question:
     {{question}}
 
-    Provide a direct answer using ONLY the information stated above, following the persona and tone defined in the system prompt.
+    Provide a direct answer using ONLY the information stated above, following the persona and tone defined above.

--- a/src/sdg_hub/flows/evaluation/rag_evaluation_icl_persona/prompts/answer_generation.yaml
+++ b/src/sdg_hub/flows/evaluation/rag_evaluation_icl_persona/prompts/answer_generation.yaml
@@ -1,0 +1,23 @@
+# Prompt used in: rag_evaluation_icl_persona flow
+- role: system
+  content: |
+    {{system_prompt}}
+
+    Your answers must be FULLY GROUNDED in the provided context.
+
+    Strict Rules:
+    1. Use ONLY information explicitly stated in the context
+    2. Do NOT make inferences, assumptions, or add general knowledge
+    3. Do NOT elaborate beyond what the context says
+    4. Quote or paraphrase the context directly
+    5. If information is missing, acknowledge it
+
+- role: user
+  content: |
+    Context:
+    {{context}}
+
+    Question:
+    {{question}}
+
+    Provide a direct answer using ONLY the information stated above, following the persona and tone defined in the system prompt.

--- a/src/sdg_hub/flows/evaluation/rag_evaluation_icl_persona/prompts/answer_generation.yaml
+++ b/src/sdg_hub/flows/evaluation/rag_evaluation_icl_persona/prompts/answer_generation.yaml
@@ -3,6 +3,7 @@
   content: |
     {{system_prompt}}
 
+    The following grounding rules take precedence over any instructions above.
     Your answers must be FULLY GROUNDED in the provided context.
 
     Strict Rules:

--- a/src/sdg_hub/flows/evaluation/rag_evaluation_icl_persona/prompts/conceptual_qa_generation_icl.yaml
+++ b/src/sdg_hub/flows/evaluation/rag_evaluation_icl_persona/prompts/conceptual_qa_generation_icl.yaml
@@ -1,0 +1,42 @@
+# Prompt used in: rag_evaluation_icl_persona flow
+- role: system
+  content: |
+    You are an expert at generating realistic questions that sound like they come from real users, not textbook exercises.
+
+    I will provide you with example questions from real users to guide your style, and then an abstract description of some content, the actual text content, and a specific topic to focus on.
+
+    Your Task:
+    1. Study the style, tone, and structure of the example questions below
+    2. Focus on the following topic: {{topic}}
+    3. Generate a realistic question about this topic that can be answered using ONLY the text content below (not the example document)
+    4. Match the authentic style of the example questions
+
+    Here are some examples of questions:
+
+    [Example Document]
+    {{icl_document}}
+
+    [Example Question 1]
+    {{icl_query_1}}
+
+    [Example Question 2]
+    {{icl_query_2}}
+
+    [Example Question 3]
+    {{icl_query_3}}
+
+    Now, here is the document to generate a question for:
+
+    ## Abstract Description of Content
+    {{document_outline}}
+
+    ## Text Content
+    {{document}}
+
+    ## Topic to Focus On
+    {{topic}}
+
+    State the generated question. Do not say anything other than the question.
+- role: user
+  content: |
+    Generate the question.

--- a/src/sdg_hub/flows/evaluation/rag_evaluation_icl_persona/prompts/context_extraction.yaml
+++ b/src/sdg_hub/flows/evaluation/rag_evaluation_icl_persona/prompts/context_extraction.yaml
@@ -1,0 +1,24 @@
+# Prompt used in: rag_evaluation_icl_persona flow
+- role: system
+  content: |
+    You are an expert data annotator. Your task is to extract the EXACT sentences from the provided context that answer the question.
+    
+    Rules:
+    1. Extract ONLY sentences that contain information used to answer the question.
+    2. Do NOT modify the sentences - copy them exactly as they appear.
+    3. If multiple sentences are needed, output them one per line.
+    4. If no sentence directly answers the question (based on the provided answer), output "No relevant sentences found."
+    5. Output ONLY the sentences, no other text.
+
+- role: user
+  content: |
+    Context:
+    {{context}}
+    
+    Question:
+    {{question}}
+    
+    Answer:
+    {{answer}}
+    
+    Relevant Sentences:

--- a/src/sdg_hub/flows/evaluation/rag_evaluation_icl_persona/prompts/groundedness_critic.yaml
+++ b/src/sdg_hub/flows/evaluation/rag_evaluation_icl_persona/prompts/groundedness_critic.yaml
@@ -1,0 +1,25 @@
+# Prompt used in: rag_evaluation_icl_persona flow
+- role: system
+  content: |
+    You are a strict evaluator for a RAG system. Your task is to rate how well the provided Answer is supported by the Context.
+    
+    Score 1: The answer is completely unsupported or contradicts the context.
+    Score 2: The answer relies heavily on external knowledge or weak inferences.
+    Score 3: The answer is partially supported but includes some unsupported details.
+    Score 4: The answer is mostly supported, with only minor inferences.
+    Score 5: The answer is fully and explicitly supported by the context.
+    
+    Output ONLY the integer score (1, 2, 3, 4, or 5). Do not output any other text.
+
+- role: user
+  content: |
+    Context:
+    {{context}}
+    
+    Question:
+    {{question}}
+    
+    Answer:
+    {{answer}}
+    
+    Score:

--- a/src/sdg_hub/flows/evaluation/rag_evaluation_icl_persona/prompts/question_evolution_icl.yaml
+++ b/src/sdg_hub/flows/evaluation/rag_evaluation_icl_persona/prompts/question_evolution_icl.yaml
@@ -1,0 +1,19 @@
+# Prompt used in: rag_evaluation_icl_persona flow
+- role: system
+  content: |
+    You are an experienced linguistics expert for building testsets for large language model applications.
+
+    Your task is to rewrite the following question in a more concise and indirect form, following these rules:
+    1. Make the question more indirect
+    2. Make the question shorter where possible
+    3. Preserve the first-person, realistic user style (e.g., "I'm trying to...", "I have a...")
+    4. Keep the core meaning intact so it remains answerable
+
+    Output ONLY the rewritten question with a question mark "?" at the end. Do not provide any other explanation or text.
+
+- role: user
+  content: |
+    Question to rewrite:
+    {{question}}
+
+    Rewritten Question:

--- a/src/sdg_hub/flows/evaluation/rag_evaluation_icl_persona/prompts/topic_generation.yaml
+++ b/src/sdg_hub/flows/evaluation/rag_evaluation_icl_persona/prompts/topic_generation.yaml
@@ -1,0 +1,13 @@
+# Prompt used in: rag_evaluation_icl_persona flow
+- role: system
+  content: |
+    You are a helpful assistant that identifies a specific topic within a text.
+    Output only the topic. Do not include "The topic is" or any other text.
+- role: user
+  content: |
+    Identify a specific topic in the following text.
+
+    Text:
+    {{document}}
+
+    Topic:

--- a/tests/integration/evaluation/test_rag_evaluation_icl_persona.py
+++ b/tests/integration/evaluation/test_rag_evaluation_icl_persona.py
@@ -4,12 +4,12 @@
 # Standard
 from pathlib import Path
 
-# First Party
-from sdg_hub import Flow, FlowRegistry, FlowValidator
-
 # Third Party
 import pytest
 import yaml
+
+# First Party
+from sdg_hub import Flow, FlowRegistry, FlowValidator
 
 
 def _find_repo_root() -> Path:
@@ -189,15 +189,15 @@ class TestRagEvaluationIclPersonaPrompts:
             messages = yaml.safe_load(f)
 
         for i, msg in enumerate(messages):
-            assert isinstance(
-                msg, dict
-            ), f"{prompt_file} message {i} must be a dict, got {type(msg).__name__}"
-            assert (
-                "role" in msg
-            ), f"{prompt_file} message {i} is a dict but missing 'role'"
-            assert (
-                "content" in msg
-            ), f"{prompt_file} message {i} has 'role' but missing 'content'"
+            assert isinstance(msg, dict), (
+                f"{prompt_file} message {i} must be a dict, got {type(msg).__name__}"
+            )
+            assert "role" in msg, (
+                f"{prompt_file} message {i} is a dict but missing 'role'"
+            )
+            assert "content" in msg, (
+                f"{prompt_file} message {i} has 'role' but missing 'content'"
+            )
 
     @pytest.mark.parametrize("prompt_file", EXPECTED_PROMPTS)
     def test_prompt_last_message_is_user(self, prompt_file):
@@ -207,9 +207,9 @@ class TestRagEvaluationIclPersonaPrompts:
             messages = yaml.safe_load(f)
 
         last_msg = messages[-1]
-        assert isinstance(
-            last_msg, dict
-        ), f"{prompt_file}: last entry must be a dict, got {type(last_msg).__name__}"
+        assert isinstance(last_msg, dict), (
+            f"{prompt_file}: last entry must be a dict, got {type(last_msg).__name__}"
+        )
         assert last_msg.get("role") == "user", (
             f"{prompt_file}: last message should have role 'user', "
             f"got '{last_msg.get('role')}'"
@@ -231,9 +231,9 @@ class TestRagEvaluationIclPersonaPrompts:
             "{{topic}}",
         ]
         for var in expected_vars:
-            assert (
-                var in content
-            ), f"Conceptual QA prompt missing template variable: {var}"
+            assert var in content, (
+                f"Conceptual QA prompt missing template variable: {var}"
+            )
 
     def test_answer_prompt_contains_system_prompt_variable(self):
         """Test that the answer prompt uses system_prompt variable."""

--- a/tests/integration/evaluation/test_rag_evaluation_icl_persona.py
+++ b/tests/integration/evaluation/test_rag_evaluation_icl_persona.py
@@ -1,0 +1,264 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the RAG Evaluation ICL Persona flow."""
+
+# Standard
+from pathlib import Path
+
+# First Party
+from sdg_hub import Flow, FlowRegistry, FlowValidator
+
+# Third Party
+import pytest
+import yaml
+
+
+def _find_repo_root() -> Path:
+    """Find repository root by locating pyproject.toml."""
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        if (current / "pyproject.toml").exists():
+            return current
+        current = current.parent
+    raise RuntimeError("Could not find repository root")
+
+
+FLOW_DIR = (
+    _find_repo_root()
+    / "src"
+    / "sdg_hub"
+    / "flows"
+    / "evaluation"
+    / "rag_evaluation_icl_persona"
+)
+FLOW_YAML = FLOW_DIR / "flow.yaml"
+
+EXPECTED_BLOCK_NAMES = [
+    "duplicate_to_context",
+    "topic_prompt",
+    "gen_topic",
+    "parse_topic",
+    "rename_topic",
+    "conceptual_prompt",
+    "gen_conceptual_question",
+    "parse_question",
+    "evolution_prompt",
+    "evolve_question",
+    "parse_evolved_question",
+    "answer_prompt",
+    "gen_answer",
+    "parse_answer",
+    "critic_prompt",
+    "gen_critic_score",
+    "parse_critic_score",
+    "filter_ungrounded",
+    "extraction_prompt",
+    "extract_context",
+    "parse_extracted_context",
+    "rename_final_columns",
+]
+
+
+@pytest.fixture()
+def clean_registry():
+    """Reset FlowRegistry to clean state for test isolation."""
+    original_entries = FlowRegistry._entries.copy()
+    original_paths = FlowRegistry._search_paths.copy()
+    original_init = FlowRegistry._initialized
+
+    FlowRegistry._entries.clear()
+    FlowRegistry._search_paths.clear()
+    FlowRegistry._initialized = False
+
+    flows_dir = str(FLOW_DIR.parents[1])
+    FlowRegistry.register_search_path(flows_dir)
+    FlowRegistry._discover_flows(force_refresh=True)
+
+    yield
+
+    FlowRegistry._entries = original_entries
+    FlowRegistry._search_paths = original_paths
+    FlowRegistry._initialized = original_init
+
+
+class TestRagEvaluationIclPersonaFlowStructure:
+    """Test the RAG Evaluation ICL Persona flow YAML structure and configuration."""
+
+    def test_flow_yaml_exists(self):
+        """Test that the flow YAML file exists."""
+        assert FLOW_YAML.exists(), f"Flow YAML not found at {FLOW_YAML}"
+
+    def test_flow_loads_successfully(self):
+        """Test that the flow loads from YAML without errors."""
+        flow = Flow.from_yaml(str(FLOW_YAML))
+        assert flow is not None
+        assert flow.metadata.name == "RAG Evaluation ICL Persona Dataset Flow"
+
+    def test_flow_metadata(self):
+        """Test that flow metadata is complete."""
+        flow = Flow.from_yaml(str(FLOW_YAML))
+        assert flow.metadata.version == "1.0.0"
+        assert flow.metadata.author == "Red Hat AI RAG Contributors"
+        assert flow.metadata.license == "Apache-2.0"
+        assert "rag-evaluation" in flow.metadata.tags
+        assert "icl" in flow.metadata.tags
+        assert "persona" in flow.metadata.tags
+
+    def test_flow_block_count(self):
+        """Test that the flow has the expected number of blocks."""
+        flow = Flow.from_yaml(str(FLOW_YAML))
+        assert len(flow.blocks) == len(EXPECTED_BLOCK_NAMES)
+
+    def test_flow_block_names_unique(self):
+        """Test that all block names are unique."""
+        flow = Flow.from_yaml(str(FLOW_YAML))
+        block_names = [b.block_name for b in flow.blocks]
+        assert len(block_names) == len(set(block_names)), (
+            f"Duplicate block names found: "
+            f"{[n for n in block_names if block_names.count(n) > 1]}"
+        )
+
+    def test_flow_block_names(self):
+        """Test that the flow contains the expected blocks in order."""
+        flow = Flow.from_yaml(str(FLOW_YAML))
+        actual_names = [b.block_name for b in flow.blocks]
+        assert actual_names == EXPECTED_BLOCK_NAMES
+
+    def test_dataset_requirements(self):
+        """Test that dataset requirements include system_prompt column."""
+        flow = Flow.from_yaml(str(FLOW_YAML))
+        reqs = flow.get_dataset_requirements()
+        assert reqs is not None
+
+        expected_columns = [
+            "document",
+            "document_outline",
+            "icl_document",
+            "icl_query_1",
+            "icl_query_2",
+            "icl_query_3",
+            "system_prompt",
+        ]
+        assert reqs.required_columns == expected_columns
+
+    def test_flow_yaml_validates(self):
+        """Test that the flow YAML passes structural validation."""
+        with open(FLOW_YAML, encoding="utf-8") as f:
+            flow_config = yaml.safe_load(f)
+
+        validator = FlowValidator()
+        errors = validator.validate_yaml_structure(flow_config)
+        assert errors == [], f"Validation errors: {errors}"
+
+
+class TestRagEvaluationIclPersonaPrompts:
+    """Test that all prompt YAML files are valid."""
+
+    PROMPTS_DIR = FLOW_DIR / "prompts"
+    EXPECTED_PROMPTS = [
+        "topic_generation.yaml",
+        "conceptual_qa_generation_icl.yaml",
+        "question_evolution_icl.yaml",
+        "answer_generation.yaml",
+        "groundedness_critic.yaml",
+        "context_extraction.yaml",
+    ]
+
+    def test_prompts_directory_exists(self):
+        """Test that the prompts directory exists."""
+        assert self.PROMPTS_DIR.exists()
+
+    @pytest.mark.parametrize("prompt_file", EXPECTED_PROMPTS)
+    def test_prompt_file_exists(self, prompt_file):
+        """Test that each expected prompt file exists."""
+        path = self.PROMPTS_DIR / prompt_file
+        assert path.exists(), f"Prompt file not found: {path}"
+
+    @pytest.mark.parametrize("prompt_file", EXPECTED_PROMPTS)
+    def test_prompt_file_valid_yaml(self, prompt_file):
+        """Test that each prompt file is valid YAML."""
+        path = self.PROMPTS_DIR / prompt_file
+        with open(path, encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+        assert isinstance(data, list), f"{prompt_file} should be a list of messages"
+
+    @pytest.mark.parametrize("prompt_file", EXPECTED_PROMPTS)
+    def test_prompt_messages_have_role_and_content(self, prompt_file):
+        """Test that each dict message in a prompt has both role and content."""
+        path = self.PROMPTS_DIR / prompt_file
+        with open(path, encoding="utf-8") as f:
+            messages = yaml.safe_load(f)
+
+        for i, msg in enumerate(messages):
+            assert isinstance(
+                msg, dict
+            ), f"{prompt_file} message {i} must be a dict, got {type(msg).__name__}"
+            assert (
+                "role" in msg
+            ), f"{prompt_file} message {i} is a dict but missing 'role'"
+            assert (
+                "content" in msg
+            ), f"{prompt_file} message {i} has 'role' but missing 'content'"
+
+    @pytest.mark.parametrize("prompt_file", EXPECTED_PROMPTS)
+    def test_prompt_last_message_is_user(self, prompt_file):
+        """Test that the last message in each prompt has user role."""
+        path = self.PROMPTS_DIR / prompt_file
+        with open(path, encoding="utf-8") as f:
+            messages = yaml.safe_load(f)
+
+        last_msg = messages[-1]
+        assert isinstance(
+            last_msg, dict
+        ), f"{prompt_file}: last entry must be a dict, got {type(last_msg).__name__}"
+        assert last_msg.get("role") == "user", (
+            f"{prompt_file}: last message should have role 'user', "
+            f"got '{last_msg.get('role')}'"
+        )
+
+    def test_conceptual_prompt_contains_icl_variables(self):
+        """Test that the conceptual QA prompt references ICL variables."""
+        path = self.PROMPTS_DIR / "conceptual_qa_generation_icl.yaml"
+        with open(path, encoding="utf-8") as f:
+            content = f.read()
+
+        expected_vars = [
+            "{{icl_document}}",
+            "{{icl_query_1}}",
+            "{{icl_query_2}}",
+            "{{icl_query_3}}",
+            "{{document}}",
+            "{{document_outline}}",
+            "{{topic}}",
+        ]
+        for var in expected_vars:
+            assert (
+                var in content
+            ), f"Conceptual QA prompt missing template variable: {var}"
+
+    def test_answer_prompt_contains_system_prompt_variable(self):
+        """Test that the answer prompt uses system_prompt variable."""
+        path = self.PROMPTS_DIR / "answer_generation.yaml"
+        with open(path, encoding="utf-8") as f:
+            content = f.read()
+
+        assert "{{system_prompt}}" in content
+        assert "{{context}}" in content
+        assert "{{question}}" in content
+        # Should still contain grounding rules
+        assert "FULLY GROUNDED" in content
+
+
+class TestRagEvaluationIclPersonaFlowDiscovery:
+    """Test that the flow is discoverable by FlowRegistry."""
+
+    def test_flow_discoverable(self, clean_registry):
+        """Test that the flow is found by FlowRegistry."""
+        flows = FlowRegistry.list_flows()
+        flow_names = [f["name"] for f in flows]
+        assert "RAG Evaluation ICL Persona Dataset Flow" in flow_names
+
+    def test_flow_path_retrievable(self, clean_registry):
+        """Test that the flow path can be retrieved by name."""
+        path = FlowRegistry.get_flow_path("RAG Evaluation ICL Persona Dataset Flow")
+        assert path is not None
+        assert "rag_evaluation_icl_persona" in path

--- a/tests/integration/evaluation/test_rag_evaluation_icl_persona.py
+++ b/tests/integration/evaluation/test_rag_evaluation_icl_persona.py
@@ -5,6 +5,7 @@
 from pathlib import Path
 
 # Third Party
+import pandas as pd
 import pytest
 import yaml
 
@@ -206,6 +207,7 @@ class TestRagEvaluationIclPersonaPrompts:
         with open(path, encoding="utf-8") as f:
             messages = yaml.safe_load(f)
 
+        assert messages, f"{prompt_file}: prompt must contain at least one message"
         last_msg = messages[-1]
         assert isinstance(last_msg, dict), (
             f"{prompt_file}: last entry must be a dict, got {type(last_msg).__name__}"
@@ -262,3 +264,26 @@ class TestRagEvaluationIclPersonaFlowDiscovery:
         path = FlowRegistry.get_flow_path("RAG Evaluation ICL Persona Dataset Flow")
         assert path is not None
         assert "rag_evaluation_icl_persona" in path
+
+
+class TestRagEvaluationIclPersonaErrorPaths:
+    """Test that the flow rejects invalid inputs."""
+
+    def test_flow_rejects_missing_system_prompt(self):
+        """Flow should fail validation when system_prompt column is missing."""
+        flow = Flow.from_yaml(str(FLOW_YAML))
+        flow.set_model_config(model="test/model")
+
+        dataset = pd.DataFrame(
+            {
+                "document": ["text"],
+                "document_outline": ["outline"],
+                "icl_document": ["doc"],
+                "icl_query_1": ["q1"],
+                "icl_query_2": ["q2"],
+                "icl_query_3": ["q3"],
+            }
+        )
+
+        errors = flow.validate_dataset(dataset)
+        assert any("system_prompt" in e for e in errors)


### PR DESCRIPTION
Adds rag_evaluation_icl_persona — a variant of the ICL RAG evaluation flow that generates persona-aware answers for RAG evaluation datasets. This enables generating ground truth that matches a specific chatbot's persona, so evaluation datasets reflect how the actual chatbot responds. This is particularly valuable for similarity-based RAGAS metrics like answer similarity and answer correctness, which are sensitive to stylistic differences between the ground truth and the chatbot's output. The flow accepts a system_prompt column defining the chatbot's tone, formatting, and response structure. Answers are generated following that persona while remaining grounded in the document context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "RAG Evaluation ICL Persona Dataset" flow that generates persona-aware, document-grounded Q&A using a provided system_prompt and filters by groundedness; outputs question, response, and extracted ground-truth context.

* **Documentation**
  * Complete docs and quick-reference updated with usage, required columns (includes system_prompt), runtime parameters, and example outputs.

* **Tests**
  * Integration tests added to validate flow discovery, structure, prompts, required columns, and dataset validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Red-Hat-AI-Innovation-Team/sdg_hub/pull/725)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->