### PR TITLE
refactor: replace print() calls with proper logging

### DIFF
--- a/src/sdg_hub/core/blocks/base.py
+++ b/src/sdg_hub/core/blocks/base.py
@@ -8,6 +8,7 @@ with unified constructor patterns, column handling, and common functionality.
 # Standard
 from abc import ABC, abstractmethod
 from typing import Any, ClassVar, Optional, Union
+import logging
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 from rich.console import Console
@@ -26,7 +27,7 @@ from ..utils.error_handling import (
 from ..utils.logger_config import setup_logger
 
 logger = setup_logger(__name__)
-console = Console()
+_console = Console()
 
 
 class BaseBlock(BaseModel, ABC):
@@ -217,9 +218,14 @@ class BaseBlock(BaseModel, ABC):
             else "None specified"
         )
         content.append(f"Expected Output Columns: {expected}", style="green")
-        console.print(
-            Panel(content, title=f"[bold]{self.block_name}[/bold]", border_style="blue")
-        )
+        if logger.isEnabledFor(logging.INFO):
+            _console.print(
+                Panel(
+                    content,
+                    title=f"[bold]{self.block_name}[/bold]",
+                    border_style="blue",
+                )
+            )
 
     def _log_output_data(self, input_df: pd.DataFrame, output_df: pd.DataFrame) -> None:
         """Print a Rich panel summarizing output DataFrame differences."""
@@ -243,13 +249,14 @@ class BaseBlock(BaseModel, ABC):
         content.append(
             f"\U0001f4cb Final Columns: {', '.join(sorted(out_cols))}", style="white"
         )
-        console.print(
-            Panel(
-                content,
-                title=f"[bold green]{self.block_name} - Complete[/bold green]",
-                border_style="green",
+        if logger.isEnabledFor(logging.INFO):
+            _console.print(
+                Panel(
+                    content,
+                    title=f"[bold green]{self.block_name} - Complete[/bold green]",
+                    border_style="green",
+                )
             )
-        )
 
     @abstractmethod
     def generate(self, samples: pd.DataFrame, **kwargs: Any) -> pd.DataFrame:

--- a/src/sdg_hub/core/blocks/base.py
+++ b/src/sdg_hub/core/blocks/base.py
@@ -200,6 +200,8 @@ class BaseBlock(BaseModel, ABC):
 
     def _log_input_data(self, df: pd.DataFrame) -> None:
         """Print a summary of the input DataFrame with Rich formatting."""
+        if not logger.isEnabledFor(logging.INFO):
+            return
         row_count = len(df)
         columns = df.columns.tolist()
         content = Text()
@@ -218,17 +220,18 @@ class BaseBlock(BaseModel, ABC):
             else "None specified"
         )
         content.append(f"Expected Output Columns: {expected}", style="green")
-        if logger.isEnabledFor(logging.INFO):
-            _console.print(
-                Panel(
-                    content,
-                    title=f"[bold]{self.block_name}[/bold]",
-                    border_style="blue",
-                )
+        _console.print(
+            Panel(
+                content,
+                title=f"[bold]{self.block_name}[/bold]",
+                border_style="blue",
             )
+        )
 
     def _log_output_data(self, input_df: pd.DataFrame, output_df: pd.DataFrame) -> None:
         """Print a Rich panel summarizing output DataFrame differences."""
+        if not logger.isEnabledFor(logging.INFO):
+            return
         in_rows, out_rows = len(input_df), len(output_df)
         in_cols = set(input_df.columns.tolist())
         out_cols = set(output_df.columns.tolist())
@@ -249,14 +252,13 @@ class BaseBlock(BaseModel, ABC):
         content.append(
             f"\U0001f4cb Final Columns: {', '.join(sorted(out_cols))}", style="white"
         )
-        if logger.isEnabledFor(logging.INFO):
-            _console.print(
-                Panel(
-                    content,
-                    title=f"[bold green]{self.block_name} - Complete[/bold green]",
-                    border_style="green",
-                )
+        _console.print(
+            Panel(
+                content,
+                title=f"[bold green]{self.block_name} - Complete[/bold green]",
+                border_style="green",
             )
+        )
 
     @abstractmethod
     def generate(self, samples: pd.DataFrame, **kwargs: Any) -> pd.DataFrame:

--- a/src/sdg_hub/core/blocks/registry.py
+++ b/src/sdg_hub/core/blocks/registry.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from difflib import get_close_matches
 from typing import Optional
 import inspect
+import logging
 
 # Third Party
 from rich.console import Console
@@ -19,7 +20,7 @@ from rich.table import Table
 from ..utils.logger_config import setup_logger
 
 logger = setup_logger(__name__)
-console = Console()
+_console = Console()
 
 
 @dataclass
@@ -308,7 +309,7 @@ class BlockRegistry:
     def discover_blocks(cls) -> None:
         """Print a Rich-formatted table of all available blocks."""
         if not cls._metadata:
-            console.print("[yellow]No blocks registered yet.[/yellow]")
+            logger.warning("No blocks registered yet.")
             return
 
         table = Table(
@@ -331,15 +332,16 @@ class BlockRegistry:
 
             table.add_row(block_name, metadata.category, description)
 
-        console.print(table)
+        if logger.isEnabledFor(logging.INFO):
+            _console.print(table)
 
         # Show summary
         total_blocks = len(cls._metadata)
         total_categories = len(cls._categories)
         deprecated_count = sum(1 for m in cls._metadata.values() if m.deprecated)
 
-        console.print(
-            f"\n[bold]Summary:[/bold] {total_blocks} blocks across {total_categories} categories"
+        logger.info(
+            f"Summary: {total_blocks} blocks across {total_categories} categories"
         )
         if deprecated_count > 0:
-            console.print(f"[yellow]⚠️  {deprecated_count} deprecated blocks[/yellow]")
+            logger.warning(f"{deprecated_count} deprecated blocks")

--- a/src/sdg_hub/core/blocks/registry.py
+++ b/src/sdg_hub/core/blocks/registry.py
@@ -312,6 +312,9 @@ class BlockRegistry:
             logger.warning("No blocks registered yet.")
             return
 
+        if not logger.isEnabledFor(logging.INFO):
+            return
+
         table = Table(
             title="Available Blocks", show_header=True, header_style="bold magenta"
         )
@@ -332,8 +335,7 @@ class BlockRegistry:
 
             table.add_row(block_name, metadata.category, description)
 
-        if logger.isEnabledFor(logging.INFO):
-            _console.print(table)
+        _console.print(table)
 
         # Show summary
         total_blocks = len(cls._metadata)

--- a/src/sdg_hub/core/flow/display.py
+++ b/src/sdg_hub/core/flow/display.py
@@ -184,6 +184,9 @@ def print_flow_info(flow: "Flow") -> None:
     None
     """
 
+    if not logger.isEnabledFor(logging.INFO):
+        return
+
     # Create main tree structure
     flow_tree = Tree(f"[bold bright_blue]{flow.metadata.name}[/bold bright_blue] Flow")
 
@@ -218,21 +221,20 @@ def print_flow_info(flow: "Flow") -> None:
         )
 
     # Print everything
-    if logger.isEnabledFor(logging.INFO):
-        _console.print()
-        _console.print(
-            Panel(
-                flow_tree,
-                title="[bold bright_white]Flow Information[/bold bright_white]",
-                border_style="bright_blue",
-            )
+    _console.print()
+    _console.print(
+        Panel(
+            flow_tree,
+            title="[bold bright_white]Flow Information[/bold bright_white]",
+            border_style="bright_blue",
         )
-        _console.print()
-        _console.print(
-            Panel(
-                blocks_table,
-                title="[bold bright_white]Block Details[/bold bright_white]",
-                border_style="bright_magenta",
-            )
+    )
+    _console.print()
+    _console.print(
+        Panel(
+            blocks_table,
+            title="[bold bright_white]Block Details[/bold bright_white]",
+            border_style="bright_magenta",
         )
-        _console.print()
+    )
+    _console.print()

--- a/src/sdg_hub/core/flow/display.py
+++ b/src/sdg_hub/core/flow/display.py
@@ -3,6 +3,7 @@
 
 # Standard
 from typing import TYPE_CHECKING, Any, Optional
+import logging
 
 from rich.console import Console
 from rich.panel import Panel
@@ -13,7 +14,11 @@ from rich.tree import Tree
 import pandas as pd
 
 # Local
+from ..utils.logger_config import setup_logger
 from .metadata import DatasetRequirements
+
+logger = setup_logger(__name__)
+_console = Console()
 
 if TYPE_CHECKING:
     from .base import Flow
@@ -178,7 +183,6 @@ def print_flow_info(flow: "Flow") -> None:
     -------
     None
     """
-    console = Console()
 
     # Create main tree structure
     flow_tree = Tree(f"[bold bright_blue]{flow.metadata.name}[/bold bright_blue] Flow")
@@ -214,20 +218,21 @@ def print_flow_info(flow: "Flow") -> None:
         )
 
     # Print everything
-    console.print()
-    console.print(
-        Panel(
-            flow_tree,
-            title="[bold bright_white]Flow Information[/bold bright_white]",
-            border_style="bright_blue",
+    if logger.isEnabledFor(logging.INFO):
+        _console.print()
+        _console.print(
+            Panel(
+                flow_tree,
+                title="[bold bright_white]Flow Information[/bold bright_white]",
+                border_style="bright_blue",
+            )
         )
-    )
-    console.print()
-    console.print(
-        Panel(
-            blocks_table,
-            title="[bold bright_white]Block Details[/bold bright_white]",
-            border_style="bright_magenta",
+        _console.print()
+        _console.print(
+            Panel(
+                blocks_table,
+                title="[bold bright_white]Block Details[/bold bright_white]",
+                border_style="bright_magenta",
+            )
         )
-    )
-    console.print()
+        _console.print()

--- a/src/sdg_hub/core/flow/registry.py
+++ b/src/sdg_hub/core/flow/registry.py
@@ -5,6 +5,7 @@
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
+import logging
 import os
 import warnings
 
@@ -19,6 +20,7 @@ from ..utils.yaml_utils import save_flow_yaml
 from .metadata import FlowMetadata
 
 logger = setup_logger(__name__)
+_console = Console()
 
 # Deprecated flows mapping: flow name/id -> (deprecation message, suggested alternative)
 DEPRECATED_FLOWS: Dict[str, Tuple[str, Optional[str]]] = {
@@ -375,10 +377,10 @@ class FlowRegistry:
         cls._discover_flows()
 
         if not cls._entries:
-            print(
+            logger.info(
                 "No flows discovered. Try adding search paths with register_search_path()"
             )
-            print("Note: Only flows with 'metadata' section are discoverable.")
+            logger.info("Note: Only flows with 'metadata' section are discoverable.")
             return
 
         # Prepare data with fallbacks
@@ -400,9 +402,6 @@ class FlowRegistry:
         flow_data.sort(key=lambda x: x["id"])
 
         # Display Rich table
-        # Third Party
-
-        console = Console()
         table = Table(show_header=True, header_style="bold bright_magenta")
 
         # Add columns with better visibility colors
@@ -422,4 +421,5 @@ class FlowRegistry:
                 flow["description"],
             )
 
-        console.print(table)
+        if logger.isEnabledFor(logging.INFO):
+            _console.print(table)

--- a/src/sdg_hub/core/flow/registry.py
+++ b/src/sdg_hub/core/flow/registry.py
@@ -383,6 +383,9 @@ class FlowRegistry:
             logger.info("Note: Only flows with 'metadata' section are discoverable.")
             return
 
+        if not logger.isEnabledFor(logging.INFO):
+            return
+
         # Prepare data with fallbacks
         flow_data = []
         for _, entry in cls._entries.items():
@@ -421,5 +424,4 @@ class FlowRegistry:
                 flow["description"],
             )
 
-        if logger.isEnabledFor(logging.INFO):
-            _console.print(table)
+        _console.print(table)

--- a/src/sdg_hub/core/utils/flow_metrics.py
+++ b/src/sdg_hub/core/utils/flow_metrics.py
@@ -166,6 +166,9 @@ def display_metrics_summary(
     if not block_metrics:
         return
 
+    if not logger.isEnabledFor(logging.INFO):
+        return
+
     # Create the metrics table
     table = Table(
         show_header=True,
@@ -217,16 +220,15 @@ def display_metrics_summary(
     failed_blocks = len(block_metrics) - successful_blocks
     title, border_style = _resolve_panel_style(flow_name, failed_blocks, final_dataset)
 
-    if logger.isEnabledFor(logging.INFO):
-        _console.print()
-        _console.print(
-            Panel(
-                table,
-                title=title,
-                border_style=border_style,
-            )
+    _console.print()
+    _console.print(
+        Panel(
+            table,
+            title=title,
+            border_style=border_style,
         )
-        _console.print()
+    )
+    _console.print()
 
 
 def _format_time_str(seconds: float) -> str:

--- a/src/sdg_hub/core/utils/flow_metrics.py
+++ b/src/sdg_hub/core/utils/flow_metrics.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Optional
 import json
+import logging
 import time
 
 from rich.console import Console
@@ -14,6 +15,12 @@ from rich.table import Table
 
 # Third Party
 import pandas as pd
+
+# Local
+from .logger_config import setup_logger
+
+logger = setup_logger(__name__)
+_console = Console()
 
 
 def aggregate_block_metrics(entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -159,8 +166,6 @@ def display_metrics_summary(
     if not block_metrics:
         return
 
-    console = Console()
-
     # Create the metrics table
     table = Table(
         show_header=True,
@@ -209,19 +214,19 @@ def display_metrics_summary(
     )
 
     # Display the table with panel
-    console.print()
-
     failed_blocks = len(block_metrics) - successful_blocks
     title, border_style = _resolve_panel_style(flow_name, failed_blocks, final_dataset)
 
-    console.print(
-        Panel(
-            table,
-            title=title,
-            border_style=border_style,
+    if logger.isEnabledFor(logging.INFO):
+        _console.print()
+        _console.print(
+            Panel(
+                table,
+                title=title,
+                border_style=border_style,
+            )
         )
-    )
-    console.print()
+        _console.print()
 
 
 def _format_time_str(seconds: float) -> str:
@@ -342,12 +347,13 @@ def display_time_estimation_summary(
     max_concurrency : Optional[int], optional
         Maximum concurrency used for estimation.
     """
-    console = Console()
+    if not logger.isEnabledFor(logging.INFO):
+        return
 
     summary_table = _build_summary_table(time_estimation, dataset_size, max_concurrency)
 
-    console.print()
-    console.print(
+    _console.print()
+    _console.print(
         Panel(
             summary_table,
             title=f"[bold bright_white]Time Estimation for {dataset_size:,} Samples[/bold bright_white]",
@@ -357,9 +363,9 @@ def display_time_estimation_summary(
 
     block_estimates = time_estimation.get("block_estimates", [])
     if block_estimates:
-        console.print()
+        _console.print()
         block_table = _build_block_breakdown_table(block_estimates)
-        console.print(
+        _console.print(
             Panel(
                 block_table,
                 title="[bold bright_white]Per-Block Breakdown[/bold bright_white]",
@@ -367,7 +373,7 @@ def display_time_estimation_summary(
             )
         )
 
-    console.print()
+    _console.print()
 
 
 def save_metrics_to_json(

--- a/tests/blocks/test_base_block.py
+++ b/tests/blocks/test_base_block.py
@@ -371,6 +371,20 @@ class TestLogging:
 
     @patch("sdg_hub.core.blocks.base._console")
     @patch("sdg_hub.core.blocks.base.logger")
+    def test_log_input_data_logging_disabled(self, mock_logger, mock_console):
+        """Test input data logging is suppressed when logging level is above INFO."""
+        mock_logger.isEnabledFor.return_value = False
+        dataset = self.create_test_dataset()
+        block = DummyBlock(
+            block_name="test_block", input_cols=["input"], output_cols=["output"]
+        )
+
+        block._log_input_data(dataset)
+
+        mock_console.print.assert_not_called()
+
+    @patch("sdg_hub.core.blocks.base._console")
+    @patch("sdg_hub.core.blocks.base.logger")
     def test_log_output_data(self, mock_logger, mock_console):
         """Test output data logging."""
         mock_logger.isEnabledFor.return_value = True
@@ -397,6 +411,23 @@ class TestLogging:
         # Verify panel properties
         assert "test_block - Complete" in str(panel.title)
         assert panel.border_style == "green"
+
+    @patch("sdg_hub.core.blocks.base._console")
+    @patch("sdg_hub.core.blocks.base.logger")
+    def test_log_output_data_logging_disabled(self, mock_logger, mock_console):
+        """Test output data logging is suppressed when logging level is above INFO."""
+        mock_logger.isEnabledFor.return_value = False
+        input_dataset = self.create_test_dataset()
+        output_data = [
+            {"input": "test1", "category": "A", "new_col": "value1"},
+            {"input": "test2", "category": "B", "new_col": "value2"},
+        ]
+        output_dataset = pd.DataFrame(output_data)
+
+        block = DummyBlock(block_name="test_block")
+        block._log_output_data(input_dataset, output_dataset)
+
+        mock_console.print.assert_not_called()
 
 
 class TestCallMethod:
@@ -707,7 +738,7 @@ class TestStructuralFieldProtection:
             ]
         return pd.DataFrame(data)
 
-    @patch("sdg_hub.core.blocks.base.console")
+    @patch("sdg_hub.core.blocks.base._console")
     def test_reject_input_cols_override(self, mock_console):
         """Test that overriding input_cols at runtime raises ValueError."""
         dataset = self.create_test_dataset()
@@ -720,7 +751,7 @@ class TestStructuralFieldProtection:
         with pytest.raises(ValueError, match="Cannot override structural fields"):
             block(dataset, input_cols=["category"])
 
-    @patch("sdg_hub.core.blocks.base.console")
+    @patch("sdg_hub.core.blocks.base._console")
     def test_reject_output_cols_override(self, mock_console):
         """Test that overriding output_cols at runtime raises ValueError."""
         dataset = self.create_test_dataset()
@@ -733,7 +764,7 @@ class TestStructuralFieldProtection:
         with pytest.raises(ValueError, match="Cannot override structural fields"):
             block(dataset, output_cols=["other_output"])
 
-    @patch("sdg_hub.core.blocks.base.console")
+    @patch("sdg_hub.core.blocks.base._console")
     def test_reject_block_name_override(self, mock_console):
         """Test that overriding block_name at runtime raises ValueError."""
         dataset = self.create_test_dataset()
@@ -746,7 +777,7 @@ class TestStructuralFieldProtection:
         with pytest.raises(ValueError, match="Cannot override structural fields"):
             block(dataset, block_name="new_name")
 
-    @patch("sdg_hub.core.blocks.base.console")
+    @patch("sdg_hub.core.blocks.base._console")
     def test_reject_block_type_override(self, mock_console):
         """Test that overriding block_type at runtime raises ValueError."""
         dataset = self.create_test_dataset()
@@ -759,7 +790,7 @@ class TestStructuralFieldProtection:
         with pytest.raises(ValueError, match="Cannot override structural fields"):
             block(dataset, block_type="llm")
 
-    @patch("sdg_hub.core.blocks.base.console")
+    @patch("sdg_hub.core.blocks.base._console")
     def test_reject_multiple_structural_overrides(self, mock_console):
         """Test that overriding multiple structural fields lists all in the error."""
         dataset = self.create_test_dataset()
@@ -778,7 +809,7 @@ class TestStructuralFieldProtection:
         assert "input_cols" in str(exc_info.value)
         assert "output_cols" in str(exc_info.value)
 
-    @patch("sdg_hub.core.blocks.base.console")
+    @patch("sdg_hub.core.blocks.base._console")
     def test_allow_non_structural_overrides(self, mock_console):
         """Test that non-structural fields can still be overridden."""
         dataset = self.create_test_dataset()

--- a/tests/blocks/test_base_block.py
+++ b/tests/blocks/test_base_block.py
@@ -346,9 +346,11 @@ class TestLogging:
             ]
         return pd.DataFrame(data)
 
-    @patch("sdg_hub.core.blocks.base.console")
-    def test_log_input_data(self, mock_console):
+    @patch("sdg_hub.core.blocks.base._console")
+    @patch("sdg_hub.core.blocks.base.logger")
+    def test_log_input_data(self, mock_logger, mock_console):
         """Test input data logging."""
+        mock_logger.isEnabledFor.return_value = True
         dataset = self.create_test_dataset()
         block = DummyBlock(
             block_name="test_block", input_cols=["input"], output_cols=["output"]
@@ -356,7 +358,7 @@ class TestLogging:
 
         block._log_input_data(dataset)
 
-        # Verify console.print was called
+        # Verify _console.print was called
         mock_console.print.assert_called_once()
 
         # Get the panel that was printed
@@ -367,9 +369,11 @@ class TestLogging:
         assert "test_block" in str(panel.title)
         assert panel.border_style == "blue"
 
-    @patch("sdg_hub.core.blocks.base.console")
-    def test_log_output_data(self, mock_console):
+    @patch("sdg_hub.core.blocks.base._console")
+    @patch("sdg_hub.core.blocks.base.logger")
+    def test_log_output_data(self, mock_logger, mock_console):
         """Test output data logging."""
+        mock_logger.isEnabledFor.return_value = True
         input_dataset = self.create_test_dataset()
 
         # Create output dataset with changes
@@ -383,7 +387,7 @@ class TestLogging:
         block = DummyBlock(block_name="test_block")
         block._log_output_data(input_dataset, output_dataset)
 
-        # Verify console.print was called
+        # Verify _console.print was called
         mock_console.print.assert_called_once()
 
         # Get the panel that was printed
@@ -407,9 +411,11 @@ class TestCallMethod:
             ]
         return pd.DataFrame(data)
 
-    @patch("sdg_hub.core.blocks.base.console")
-    def test_call_success(self, mock_console):
+    @patch("sdg_hub.core.blocks.base._console")
+    @patch("sdg_hub.core.blocks.base.logger")
+    def test_call_success(self, mock_logger, mock_console):
         """Test successful __call__ execution."""
+        mock_logger.isEnabledFor.return_value = True
         dataset = self.create_test_dataset()
         block = DummyBlock(
             block_name="test_block",
@@ -429,9 +435,11 @@ class TestCallMethod:
         # Verify logging was called (input and output panels)
         assert mock_console.print.call_count == 2
 
-    @patch("sdg_hub.core.blocks.base.console")
-    def test_call_with_kwargs_override_success(self, mock_console):
+    @patch("sdg_hub.core.blocks.base._console")
+    @patch("sdg_hub.core.blocks.base.logger")
+    def test_call_with_kwargs_override_success(self, mock_logger, mock_console):
         """Test successful __call__ execution with kwargs override."""
+        mock_logger.isEnabledFor.return_value = True
         dataset = self.create_test_dataset()
 
         # Create a dummy block with custom field for override testing
@@ -468,7 +476,7 @@ class TestCallMethod:
         # Verify logging was called (input and output panels)
         assert mock_console.print.call_count == 2
 
-    @patch("sdg_hub.core.blocks.base.console")
+    @patch("sdg_hub.core.blocks.base._console")
     @patch("sdg_hub.core.blocks.base.logger")
     def test_call_with_invalid_kwargs_field(self, mock_logger, mock_console):
         """Test __call__ with extra kwargs field name.
@@ -476,6 +484,7 @@ class TestCallMethod:
         BaseBlock now accepts extra parameters (extra='allow') to support
         dynamic parameter forwarding to LLM blocks, so no warning is expected.
         """
+        mock_logger.isEnabledFor.return_value = True
         dataset = self.create_test_dataset()
         block = DummyBlock(
             block_name="test_block",
@@ -498,9 +507,11 @@ class TestCallMethod:
         # Verify logging was called (input and output panels)
         assert mock_console.print.call_count == 2
 
-    @patch("sdg_hub.core.blocks.base.console")
-    def test_call_with_invalid_kwargs_value(self, mock_console):
+    @patch("sdg_hub.core.blocks.base._console")
+    @patch("sdg_hub.core.blocks.base.logger")
+    def test_call_with_invalid_kwargs_value(self, mock_logger, mock_console):
         """Test __call__ with invalid kwargs field value."""
+        mock_logger.isEnabledFor.return_value = True
         dataset = self.create_test_dataset()
 
         # Create a dummy block with validated field
@@ -519,9 +530,11 @@ class TestCallMethod:
         # Verify no logging was called since validation failed early
         assert mock_console.print.call_count == 0
 
-    @patch("sdg_hub.core.blocks.base.console")
-    def test_call_kwargs_restoration_on_exception(self, mock_console):
+    @patch("sdg_hub.core.blocks.base._console")
+    @patch("sdg_hub.core.blocks.base.logger")
+    def test_call_kwargs_restoration_on_exception(self, mock_logger, mock_console):
         """Test that kwargs are restored even if generation fails."""
+        mock_logger.isEnabledFor.return_value = True
         dataset = self.create_test_dataset()
 
         class FailingBlock(DummyBlock):
@@ -542,9 +555,11 @@ class TestCallMethod:
         # Verify original value was restored despite exception
         assert block.custom_field == "original"
 
-    @patch("sdg_hub.core.blocks.base.console")
-    def test_call_multiple_kwargs_override(self, mock_console):
+    @patch("sdg_hub.core.blocks.base._console")
+    @patch("sdg_hub.core.blocks.base.logger")
+    def test_call_multiple_kwargs_override(self, mock_logger, mock_console):
         """Test __call__ with multiple kwargs overrides."""
+        mock_logger.isEnabledFor.return_value = True
         dataset = self.create_test_dataset()
 
         class MultiFieldBlock(DummyBlock):
@@ -574,9 +589,11 @@ class TestCallMethod:
         assert block.field2 == 42
         assert block.field3 is True
 
-    @patch("sdg_hub.core.blocks.base.console")
-    def test_call_kwargs_no_overrides(self, mock_console):
+    @patch("sdg_hub.core.blocks.base._console")
+    @patch("sdg_hub.core.blocks.base.logger")
+    def test_call_kwargs_no_overrides(self, mock_logger, mock_console):
         """Test that normal execution without kwargs still works."""
+        mock_logger.isEnabledFor.return_value = True
         dataset = self.create_test_dataset()
 
         class NormalBlock(DummyBlock):
@@ -624,9 +641,11 @@ class TestCallMethod:
         assert block.parent_field == "parent_value"
         assert block.child_field == "child_value"
 
-    @patch("sdg_hub.core.blocks.base.console")
-    def test_call_validation_failure(self, mock_console):
+    @patch("sdg_hub.core.blocks.base._console")
+    @patch("sdg_hub.core.blocks.base.logger")
+    def test_call_validation_failure(self, mock_logger, mock_console):
         """Test __call__ with validation failure."""
+        mock_logger.isEnabledFor.return_value = True
         dataset = self.create_test_dataset()
         block = DummyBlock(block_name="test_block", input_cols=["missing_col"])
 
@@ -639,9 +658,11 @@ class TestCallMethod:
         # Verify input logging was called but not output logging
         assert mock_console.print.call_count == 1
 
-    @patch("sdg_hub.core.blocks.base.console")
-    def test_call_empty_dataset(self, mock_console):
+    @patch("sdg_hub.core.blocks.base._console")
+    @patch("sdg_hub.core.blocks.base.logger")
+    def test_call_empty_dataset(self, mock_logger, mock_console):
         """Test __call__ with empty dataset."""
+        mock_logger.isEnabledFor.return_value = True
         empty_dataset = pd.DataFrame([])
         block = DummyBlock(block_name="test_block")
 
@@ -654,9 +675,11 @@ class TestCallMethod:
         # Verify input logging was called
         assert mock_console.print.call_count == 1
 
-    @patch("sdg_hub.core.blocks.base.console")
-    def test_call_column_collision(self, mock_console):
+    @patch("sdg_hub.core.blocks.base._console")
+    @patch("sdg_hub.core.blocks.base.logger")
+    def test_call_column_collision(self, mock_logger, mock_console):
         """Test __call__ with output column collision."""
+        mock_logger.isEnabledFor.return_value = True
         dataset = self.create_test_dataset()
         block = DummyBlock(
             block_name="test_block", output_cols=["input"]
@@ -1114,9 +1137,11 @@ class TestCustomValidation:
         ):
             block(dataset)
 
-    @patch("sdg_hub.core.blocks.base.console")
-    def test_custom_validation_with_logging(self, mock_console):
+    @patch("sdg_hub.core.blocks.base._console")
+    @patch("sdg_hub.core.blocks.base.logger")
+    def test_custom_validation_with_logging(self, mock_logger, mock_console):
         """Test that custom validation works with Rich logging."""
+        mock_logger.isEnabledFor.return_value = True
         dataset = self.create_test_dataset()
 
         class TestBlockWithLoggingValidation(DummyBlock):
@@ -1267,9 +1292,11 @@ class TestEdgeCases:
         result = block._normalize_columns("")
         assert result == [""]
 
-    @patch("sdg_hub.core.blocks.base.console")
-    def test_logging_with_many_columns(self, mock_console):
+    @patch("sdg_hub.core.blocks.base._console")
+    @patch("sdg_hub.core.blocks.base.logger")
+    def test_logging_with_many_columns(self, mock_logger, mock_console):
         """Test logging with datasets that have many columns."""
+        mock_logger.isEnabledFor.return_value = True
         # Create dataset with many columns
         data = [{f"col_{i}": f"value_{i}" for i in range(50)}]
         dataset = pd.DataFrame(data)

--- a/tests/blocks/test_registry.py
+++ b/tests/blocks/test_registry.py
@@ -504,6 +504,23 @@ class TestBlockRegistry:
                 "Summary" in str(call) for call in mock_logger.info.call_args_list
             )
 
+    def test_print_blocks_logging_disabled(self):
+        """Test that discover_blocks skips display when logging is above INFO."""
+
+        @BlockRegistry.register("ActiveBlock2", "test", "An active test block")
+        class ActiveBlock2(BaseBlock):
+            def generate(self, samples: pd.DataFrame, **kwargs) -> pd.DataFrame:
+                return samples
+
+        with (
+            patch("sdg_hub.core.blocks.registry._console") as mock_console,
+            patch("sdg_hub.core.blocks.registry.logger") as mock_logger,
+        ):
+            mock_logger.isEnabledFor.return_value = False
+            BlockRegistry.discover_blocks()
+
+            mock_console.print.assert_not_called()
+
     def test_fallback_validation_without_baseblock(self):
         """Test validation fallback when BaseBlock is not available."""
 

--- a/tests/blocks/test_registry.py
+++ b/tests/blocks/test_registry.py
@@ -470,11 +470,9 @@ class TestBlockRegistry:
 
     def test_print_blocks_empty_registry(self):
         """Test printing blocks when registry is empty."""
-        with patch("sdg_hub.core.blocks.registry.console") as mock_console:
+        with patch("sdg_hub.core.blocks.registry.logger") as mock_logger:
             BlockRegistry.discover_blocks()
-            mock_console.print.assert_called_once_with(
-                "[yellow]No blocks registered yet.[/yellow]"
-            )
+            mock_logger.warning.assert_called_once_with("No blocks registered yet.")
 
     def test_print_blocks_with_blocks(self):
         """Test printing blocks with Rich formatting."""
@@ -491,15 +489,19 @@ class TestBlockRegistry:
             def generate(self, samples: pd.DataFrame, **kwargs) -> pd.DataFrame:
                 return samples
 
-        with patch("sdg_hub.core.blocks.registry.console") as mock_console:
+        with (
+            patch("sdg_hub.core.blocks.registry._console") as mock_console,
+            patch("sdg_hub.core.blocks.registry.logger") as mock_logger,
+        ):
+            mock_logger.isEnabledFor.return_value = True
             BlockRegistry.discover_blocks()
 
-            # Check that console.print was called (for table and summary)
-            assert mock_console.print.call_count >= 2
+            # Check that _console.print was called for the table
+            assert mock_console.print.call_count >= 1
 
-            # Check that Table was created and used
+            # Check that logger.info was called with summary
             assert any(
-                "Summary" in str(call) for call in mock_console.print.call_args_list
+                "Summary" in str(call) for call in mock_logger.info.call_args_list
             )
 
     def test_fallback_validation_without_baseblock(self):

--- a/tests/utils/test_flow_metrics.py
+++ b/tests/utils/test_flow_metrics.py
@@ -108,6 +108,30 @@ class TestDisplayMetricsSummary:
 
     @patch("sdg_hub.core.utils.flow_metrics._console")
     @patch("sdg_hub.core.utils.flow_metrics.logger")
+    def test_display_with_logging_disabled(self, mock_logger, mock_console):
+        """Test display is suppressed when logging level is above INFO."""
+        mock_logger.isEnabledFor.return_value = False
+
+        metrics = [
+            {
+                "block_name": "test_block",
+                "block_class": "TestType",
+                "execution_time": 1.5,
+                "input_rows": 10,
+                "output_rows": 10,
+                "added_cols": ["col1"],
+                "removed_cols": [],
+                "status": "success",
+            }
+        ]
+
+        dataset = pd.DataFrame({"col1": list(range(10))})
+        display_metrics_summary(metrics, "Test Flow", dataset)
+
+        mock_console.print.assert_not_called()
+
+    @patch("sdg_hub.core.utils.flow_metrics._console")
+    @patch("sdg_hub.core.utils.flow_metrics.logger")
     def test_display_with_successful_blocks(self, mock_logger, mock_console):
         """Test display with successful block execution."""
         mock_logger.isEnabledFor.return_value = True
@@ -246,6 +270,21 @@ class TestDisplayMetricsSummary:
 
 class TestDisplayTimeEstimationSummary:
     """Tests for display_time_estimation_summary function."""
+
+    @patch("sdg_hub.core.utils.flow_metrics._console")
+    @patch("sdg_hub.core.utils.flow_metrics.logger")
+    def test_display_time_estimation_logging_disabled(self, mock_logger, mock_console):
+        """Test time estimation display is suppressed when logging is above INFO."""
+        mock_logger.isEnabledFor.return_value = False
+
+        time_estimation = {
+            "estimated_time_seconds": 300,
+            "total_estimated_requests": 500,
+        }
+
+        display_time_estimation_summary(time_estimation, 100)
+
+        mock_console.print.assert_not_called()
 
     @patch("sdg_hub.core.utils.flow_metrics._console")
     @patch("sdg_hub.core.utils.flow_metrics.logger")

--- a/tests/utils/test_flow_metrics.py
+++ b/tests/utils/test_flow_metrics.py
@@ -98,19 +98,19 @@ class TestAggregateBlockMetrics:
 class TestDisplayMetricsSummary:
     """Tests for display_metrics_summary function."""
 
-    @patch("sdg_hub.core.utils.flow_metrics.Console")
+    @patch("sdg_hub.core.utils.flow_metrics._console")
     def test_display_with_no_metrics(self, mock_console):
         """Test display when no metrics are provided."""
         display_metrics_summary([], "Test Flow")
 
-        # Console should not be instantiated if no metrics
-        mock_console.assert_not_called()
+        # Console should not be used if no metrics
+        mock_console.print.assert_not_called()
 
-    @patch("sdg_hub.core.utils.flow_metrics.Console")
-    def test_display_with_successful_blocks(self, mock_console):
+    @patch("sdg_hub.core.utils.flow_metrics._console")
+    @patch("sdg_hub.core.utils.flow_metrics.logger")
+    def test_display_with_successful_blocks(self, mock_logger, mock_console):
         """Test display with successful block execution."""
-        mock_console_instance = MagicMock()
-        mock_console.return_value = mock_console_instance
+        mock_logger.isEnabledFor.return_value = True
 
         metrics = [
             {
@@ -128,14 +128,14 @@ class TestDisplayMetricsSummary:
         dataset = pd.DataFrame({"col1": list(range(10))})
         display_metrics_summary(metrics, "Test Flow", dataset)
 
-        # Verify console.print was called
-        assert mock_console_instance.print.call_count >= 2
+        # Verify _console.print was called
+        assert mock_console.print.call_count >= 2
 
-    @patch("sdg_hub.core.utils.flow_metrics.Console")
-    def test_display_with_failed_blocks(self, mock_console):
+    @patch("sdg_hub.core.utils.flow_metrics._console")
+    @patch("sdg_hub.core.utils.flow_metrics.logger")
+    def test_display_with_failed_blocks(self, mock_logger, mock_console):
         """Test display with failed block execution."""
-        mock_console_instance = MagicMock()
-        mock_console.return_value = mock_console_instance
+        mock_logger.isEnabledFor.return_value = True
 
         metrics = [
             {
@@ -153,14 +153,14 @@ class TestDisplayMetricsSummary:
 
         display_metrics_summary(metrics, "Test Flow", None)
 
-        # Verify console.print was called
-        assert mock_console_instance.print.call_count >= 2
+        # Verify _console.print was called
+        assert mock_console.print.call_count >= 2
 
-    @patch("sdg_hub.core.utils.flow_metrics.Console")
-    def test_display_with_added_and_removed_columns(self, mock_console):
+    @patch("sdg_hub.core.utils.flow_metrics._console")
+    @patch("sdg_hub.core.utils.flow_metrics.logger")
+    def test_display_with_added_and_removed_columns(self, mock_logger, mock_console):
         """Test display with blocks that both add and remove columns."""
-        mock_console_instance = MagicMock()
-        mock_console.return_value = mock_console_instance
+        mock_logger.isEnabledFor.return_value = True
 
         metrics = [
             {
@@ -178,14 +178,14 @@ class TestDisplayMetricsSummary:
         dataset = pd.DataFrame({"col1": list(range(10)), "col2": list(range(10))})
         display_metrics_summary(metrics, "Test Flow", dataset)
 
-        # Verify console.print was called
-        assert mock_console_instance.print.call_count >= 2
+        # Verify _console.print was called
+        assert mock_console.print.call_count >= 2
 
-    @patch("sdg_hub.core.utils.flow_metrics.Console")
-    def test_display_with_removed_columns_only(self, mock_console):
+    @patch("sdg_hub.core.utils.flow_metrics._console")
+    @patch("sdg_hub.core.utils.flow_metrics.logger")
+    def test_display_with_removed_columns_only(self, mock_logger, mock_console):
         """Test display with a block that only removes columns."""
-        mock_console_instance = MagicMock()
-        mock_console.return_value = mock_console_instance
+        mock_logger.isEnabledFor.return_value = True
 
         metrics = [
             {
@@ -203,14 +203,14 @@ class TestDisplayMetricsSummary:
         dataset = pd.DataFrame({"col1": list(range(10))})
         display_metrics_summary(metrics, "Test Flow", dataset)
 
-        assert mock_console_instance.print.call_count >= 2
+        assert mock_console.print.call_count >= 2
         assert _format_block_row(metrics[0])[2] == "-1"
 
-    @patch("sdg_hub.core.utils.flow_metrics.Console")
-    def test_display_with_partial_completion(self, mock_console):
+    @patch("sdg_hub.core.utils.flow_metrics._console")
+    @patch("sdg_hub.core.utils.flow_metrics.logger")
+    def test_display_with_partial_completion(self, mock_logger, mock_console):
         """Test display with some blocks succeeded and some failed."""
-        mock_console_instance = MagicMock()
-        mock_console.return_value = mock_console_instance
+        mock_logger.isEnabledFor.return_value = True
 
         metrics = [
             {
@@ -240,18 +240,18 @@ class TestDisplayMetricsSummary:
         dataset = pd.DataFrame({"col1": list(range(10))})
         display_metrics_summary(metrics, "Test Flow", dataset)
 
-        # Verify console.print was called
-        assert mock_console_instance.print.call_count >= 2
+        # Verify _console.print was called
+        assert mock_console.print.call_count >= 2
 
 
 class TestDisplayTimeEstimationSummary:
     """Tests for display_time_estimation_summary function."""
 
-    @patch("sdg_hub.core.utils.flow_metrics.Console")
-    def test_display_time_under_60_seconds(self, mock_console):
+    @patch("sdg_hub.core.utils.flow_metrics._console")
+    @patch("sdg_hub.core.utils.flow_metrics.logger")
+    def test_display_time_under_60_seconds(self, mock_logger, mock_console):
         """Test display when estimated time is under 60 seconds."""
-        mock_console_instance = MagicMock()
-        mock_console.return_value = mock_console_instance
+        mock_logger.isEnabledFor.return_value = True
 
         time_estimation = {
             "estimated_time_seconds": 45.5,
@@ -260,14 +260,14 @@ class TestDisplayTimeEstimationSummary:
 
         display_time_estimation_summary(time_estimation, 100)
 
-        # Verify console was used
-        assert mock_console_instance.print.call_count >= 2
+        # Verify _console was used
+        assert mock_console.print.call_count >= 2
 
-    @patch("sdg_hub.core.utils.flow_metrics.Console")
-    def test_display_time_between_60_and_3600_seconds(self, mock_console):
+    @patch("sdg_hub.core.utils.flow_metrics._console")
+    @patch("sdg_hub.core.utils.flow_metrics.logger")
+    def test_display_time_between_60_and_3600_seconds(self, mock_logger, mock_console):
         """Test display when estimated time is between 1 minute and 1 hour."""
-        mock_console_instance = MagicMock()
-        mock_console.return_value = mock_console_instance
+        mock_logger.isEnabledFor.return_value = True
 
         time_estimation = {
             "estimated_time_seconds": 1800,  # 30 minutes
@@ -276,14 +276,14 @@ class TestDisplayTimeEstimationSummary:
 
         display_time_estimation_summary(time_estimation, 100)
 
-        # Verify console was used
-        assert mock_console_instance.print.call_count >= 2
+        # Verify _console was used
+        assert mock_console.print.call_count >= 2
 
-    @patch("sdg_hub.core.utils.flow_metrics.Console")
-    def test_display_time_over_3600_seconds(self, mock_console):
+    @patch("sdg_hub.core.utils.flow_metrics._console")
+    @patch("sdg_hub.core.utils.flow_metrics.logger")
+    def test_display_time_over_3600_seconds(self, mock_logger, mock_console):
         """Test display when estimated time is over 1 hour."""
-        mock_console_instance = MagicMock()
-        mock_console.return_value = mock_console_instance
+        mock_logger.isEnabledFor.return_value = True
 
         time_estimation = {
             "estimated_time_seconds": 7200,  # 2 hours
@@ -292,14 +292,14 @@ class TestDisplayTimeEstimationSummary:
 
         display_time_estimation_summary(time_estimation, 100)
 
-        # Verify console was used
-        assert mock_console_instance.print.call_count >= 2
+        # Verify _console was used
+        assert mock_console.print.call_count >= 2
 
-    @patch("sdg_hub.core.utils.flow_metrics.Console")
-    def test_display_with_requests_per_sample(self, mock_console):
+    @patch("sdg_hub.core.utils.flow_metrics._console")
+    @patch("sdg_hub.core.utils.flow_metrics.logger")
+    def test_display_with_requests_per_sample(self, mock_logger, mock_console):
         """Test display includes requests per sample when requests > 0."""
-        mock_console_instance = MagicMock()
-        mock_console.return_value = mock_console_instance
+        mock_logger.isEnabledFor.return_value = True
 
         time_estimation = {
             "estimated_time_seconds": 300,
@@ -308,14 +308,14 @@ class TestDisplayTimeEstimationSummary:
 
         display_time_estimation_summary(time_estimation, 100)
 
-        # Verify console was used
-        assert mock_console_instance.print.call_count >= 2
+        # Verify _console was used
+        assert mock_console.print.call_count >= 2
 
-    @patch("sdg_hub.core.utils.flow_metrics.Console")
-    def test_display_without_requests(self, mock_console):
+    @patch("sdg_hub.core.utils.flow_metrics._console")
+    @patch("sdg_hub.core.utils.flow_metrics.logger")
+    def test_display_without_requests(self, mock_logger, mock_console):
         """Test display when total_estimated_requests is 0."""
-        mock_console_instance = MagicMock()
-        mock_console.return_value = mock_console_instance
+        mock_logger.isEnabledFor.return_value = True
 
         time_estimation = {
             "estimated_time_seconds": 300,
@@ -324,14 +324,14 @@ class TestDisplayTimeEstimationSummary:
 
         display_time_estimation_summary(time_estimation, 100)
 
-        # Verify console was used
-        assert mock_console_instance.print.call_count >= 2
+        # Verify _console was used
+        assert mock_console.print.call_count >= 2
 
-    @patch("sdg_hub.core.utils.flow_metrics.Console")
-    def test_display_with_max_concurrency(self, mock_console):
+    @patch("sdg_hub.core.utils.flow_metrics._console")
+    @patch("sdg_hub.core.utils.flow_metrics.logger")
+    def test_display_with_max_concurrency(self, mock_logger, mock_console):
         """Test display includes max concurrency when provided."""
-        mock_console_instance = MagicMock()
-        mock_console.return_value = mock_console_instance
+        mock_logger.isEnabledFor.return_value = True
 
         time_estimation = {
             "estimated_time_seconds": 300,
@@ -340,14 +340,16 @@ class TestDisplayTimeEstimationSummary:
 
         display_time_estimation_summary(time_estimation, 100, max_concurrency=50)
 
-        # Verify console was used
-        assert mock_console_instance.print.call_count >= 2
+        # Verify _console was used
+        assert mock_console.print.call_count >= 2
 
-    @patch("sdg_hub.core.utils.flow_metrics.Console")
-    def test_display_with_block_estimates_under_60_seconds(self, mock_console):
+    @patch("sdg_hub.core.utils.flow_metrics._console")
+    @patch("sdg_hub.core.utils.flow_metrics.logger")
+    def test_display_with_block_estimates_under_60_seconds(
+        self, mock_logger, mock_console
+    ):
         """Test display with per-block estimates (time < 60 seconds)."""
-        mock_console_instance = MagicMock()
-        mock_console.return_value = mock_console_instance
+        mock_logger.isEnabledFor.return_value = True
 
         time_estimation = {
             "estimated_time_seconds": 300,
@@ -365,14 +367,16 @@ class TestDisplayTimeEstimationSummary:
 
         display_time_estimation_summary(time_estimation, 100)
 
-        # Verify console was used, should include block table
-        assert mock_console_instance.print.call_count >= 3
+        # Verify _console was used, should include block table
+        assert mock_console.print.call_count >= 3
 
-    @patch("sdg_hub.core.utils.flow_metrics.Console")
-    def test_display_with_block_estimates_over_60_seconds(self, mock_console):
+    @patch("sdg_hub.core.utils.flow_metrics._console")
+    @patch("sdg_hub.core.utils.flow_metrics.logger")
+    def test_display_with_block_estimates_over_60_seconds(
+        self, mock_logger, mock_console
+    ):
         """Test display with per-block estimates (time > 60 seconds)."""
-        mock_console_instance = MagicMock()
-        mock_console.return_value = mock_console_instance
+        mock_logger.isEnabledFor.return_value = True
 
         time_estimation = {
             "estimated_time_seconds": 300,
@@ -397,14 +401,14 @@ class TestDisplayTimeEstimationSummary:
 
         display_time_estimation_summary(time_estimation, 100)
 
-        # Verify console was used, should include block table
-        assert mock_console_instance.print.call_count >= 3
+        # Verify _console was used, should include block table
+        assert mock_console.print.call_count >= 3
 
-    @patch("sdg_hub.core.utils.flow_metrics.Console")
-    def test_display_without_block_estimates(self, mock_console):
+    @patch("sdg_hub.core.utils.flow_metrics._console")
+    @patch("sdg_hub.core.utils.flow_metrics.logger")
+    def test_display_without_block_estimates(self, mock_logger, mock_console):
         """Test display without per-block estimates."""
-        mock_console_instance = MagicMock()
-        mock_console.return_value = mock_console_instance
+        mock_logger.isEnabledFor.return_value = True
 
         time_estimation = {
             "estimated_time_seconds": 300,
@@ -414,8 +418,8 @@ class TestDisplayTimeEstimationSummary:
 
         display_time_estimation_summary(time_estimation, 100)
 
-        # Verify console was used, but no extra prints for block table
-        assert mock_console_instance.print.call_count >= 2
+        # Verify _console was used, but no extra prints for block table
+        assert mock_console.print.call_count >= 2
 
 
 class TestSaveMetricsToJson:


### PR DESCRIPTION
## Summary

- Replace all `print()` and `console.print()` calls in production source code with logger-controlled output
- Gate Rich display output (tables, panels) behind `logger.isEnabledFor(logging.INFO)` so users can control verbosity via `LOG_LEVEL` environment variable
- Replace bare `print()` calls with `logger.info()` / `logger.warning()` as appropriate
- Rename module-level `console` to `_console` to signal internal use
- Move logger guards to early returns so Rich objects are not constructed when logging is disabled
- Add tests for the logging-disabled path to close coverage gaps
- Update all affected tests to mock the new logger+console pattern

Supersedes #700 (contributor's fork does not allow maintainer pushes). Original work by @shivchander, rebased onto main with conflict resolution, review feedback addressed, and additional fixes applied.

Fixes #688

## Changes from original PR (#700)

Based on review feedback:
1. **Early return pattern**: Moved `logger.isEnabledFor(logging.INFO)` checks to the top of all display functions as early returns, so Rich Table/Panel/Text objects are not constructed when logging is disabled
2. **Logging-disabled tests**: Added tests with `isEnabledFor.return_value = False` verifying `_console.print` is not called for `_log_input_data`, `_log_output_data`, `discover_blocks`, `display_metrics_summary`, and `display_time_estimation_summary`
3. **Conflict resolution**: Resolved merge conflict in `base.py` imports (main added `ClassVar` to typing imports)
4. **Stale mock targets**: Fixed `TestStructuralFieldProtection` tests that still referenced `console` instead of `_console` (added to main after the original PR)

## Test plan

- [x] All 912 unit tests pass
- [x] Ruff lint passes
- [x] Ruff format passes
- [x] mypy passes
- [x] Pre-commit hooks pass (conventional commit, ruff, ruff-format)