### PR TITLE
feat(connectors): add generic HTTP connector for arbitrary REST endpoints

### DIFF
--- a/src/sdg_hub/core/connectors/__init__.py
+++ b/src/sdg_hub/core/connectors/__init__.py
@@ -24,7 +24,12 @@ Example
 """
 
 # Import agent module to register connectors
-from .agent import BaseAgentConnector, LangflowConnector, LangGraphConnector
+from .agent import (
+    BaseAgentConnector,
+    GenericHTTPConnector,
+    LangflowConnector,
+    LangGraphConnector,
+)
 from .base import BaseConnector, ConnectorConfig
 from .code_interpreter import (
     BaseCodeInterpreterConnector,
@@ -48,6 +53,7 @@ __all__ = [
     # Agent connectors
     "BaseAgentConnector",
     "LangflowConnector",
+    "GenericHTTPConnector",
     "LangGraphConnector",
     # Code interpreter connectors
     "BaseCodeInterpreterConnector",

--- a/src/sdg_hub/core/connectors/agent/__init__.py
+++ b/src/sdg_hub/core/connectors/agent/__init__.py
@@ -2,11 +2,13 @@
 """Agent connector implementations."""
 
 from .base import BaseAgentConnector
+from .generic_http import GenericHTTPConnector
 from .langflow import LangflowConnector
 from .langgraph import LangGraphConnector
 
 __all__ = [
     "BaseAgentConnector",
+    "GenericHTTPConnector",
     "LangflowConnector",
     "LangGraphConnector",
 ]

--- a/src/sdg_hub/core/connectors/agent/generic_http.py
+++ b/src/sdg_hub/core/connectors/agent/generic_http.py
@@ -100,10 +100,17 @@ class GenericHTTPConnector(BaseAgentConnector):
         description="Dot-notation path where session ID is placed in the request body.",
     )
 
-    @field_validator("request_message_path", "response_text_path")
+    @field_validator(
+        "request_message_path",
+        "response_text_path",
+        "request_session_id_path",
+        "response_session_id_path",
+    )
     @classmethod
-    def validate_path_format(cls, v: str) -> str:
+    def validate_path_format(cls, v: str | None) -> str | None:
         """Validate that path contains only valid dot-notation segments."""
+        if v is None:
+            return v
         for segment in v.split("."):
             if not segment:
                 raise ValueError(

--- a/src/sdg_hub/core/connectors/agent/generic_http.py
+++ b/src/sdg_hub/core/connectors/agent/generic_http.py
@@ -185,6 +185,10 @@ class GenericHTTPConnector(BaseAgentConnector):
                 f"Expected dict response, got {type(response).__name__}"
             )
 
+        # Remove reserved keys so upstream values can't leak through
+        response.pop("_extracted_text", None)
+        response.pop("_extracted_session_id", None)
+
         text = _get_nested(response, self.response_text_path)
         if text is not None:
             response["_extracted_text"] = str(text)

--- a/src/sdg_hub/core/connectors/agent/generic_http.py
+++ b/src/sdg_hub/core/connectors/agent/generic_http.py
@@ -195,20 +195,23 @@ class GenericHTTPConnector(BaseAgentConnector):
                 f"Expected dict response, got {type(response).__name__}"
             )
 
-        # Remove reserved keys so upstream values can't leak through
-        response.pop("_extracted_text", None)
-        response.pop("_extracted_session_id", None)
+        # Work on a copy to avoid mutating the caller's dict
+        parsed = dict(response)
 
-        text = _get_nested(response, self.response_text_path)
+        # Remove reserved keys so upstream values can't leak through
+        parsed.pop("_extracted_text", None)
+        parsed.pop("_extracted_session_id", None)
+
+        text = _get_nested(parsed, self.response_text_path)
         if text is not None:
-            response["_extracted_text"] = str(text)
+            parsed["_extracted_text"] = str(text)
 
         if self.response_session_id_path:
-            session_id = _get_nested(response, self.response_session_id_path)
+            session_id = _get_nested(parsed, self.response_session_id_path)
             if session_id is not None:
-                response["_extracted_session_id"] = str(session_id)
+                parsed["_extracted_session_id"] = str(session_id)
 
-        return response
+        return parsed
 
     def _extract_last_user_message(self, messages: list[dict[str, Any]]) -> str:
         """Extract the last user message content.

--- a/src/sdg_hub/core/connectors/agent/generic_http.py
+++ b/src/sdg_hub/core/connectors/agent/generic_http.py
@@ -1,0 +1,279 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Generic HTTP agent connector for arbitrary REST chat endpoints."""
+
+from typing import Any, Optional
+
+from pydantic import Field, field_validator
+
+from ...utils.logger_config import setup_logger
+from ..exceptions import ConnectorError
+from ..registry import ConnectorRegistry
+from .base import BaseAgentConnector
+
+logger = setup_logger(__name__)
+
+
+def _set_nested(obj: dict, path: str, value: Any) -> None:
+    """Set a value in a nested dict using dot-notation path."""
+    keys = path.split(".")
+    for key in keys[:-1]:
+        obj = obj.setdefault(key, {})
+    obj[keys[-1]] = value
+
+
+def _get_nested(obj: dict, path: str) -> Any:
+    """Get a value from a nested dict using dot-notation path.
+
+    Returns None if any key in the path is missing.
+    """
+    for key in path.split("."):
+        if not isinstance(obj, dict) or key not in obj:
+            return None
+        obj = obj[key]
+    return obj
+
+
+@ConnectorRegistry.register("generic_http")
+class GenericHTTPConnector(BaseAgentConnector):
+    """Connector for arbitrary REST chat endpoints.
+
+    Uses declarative JSON path configuration to map between the standard
+    message format and any REST API's request/response structure.
+
+    Parameters
+    ----------
+    request_message_path : str
+        Dot-notation path where the message content is placed in the
+        request body. Example: ``"input.question"`` produces
+        ``{"input": {"question": "<message>"}}``.
+    response_text_path : str
+        Dot-notation path to extract the text response.
+        Example: ``"output.answer"`` extracts from
+        ``{"output": {"answer": "..."}}``.
+    response_session_id_path : str, optional
+        Dot-notation path to extract session ID from the response.
+    request_session_id_path : str, optional
+        Dot-notation path where session ID is placed in the request body.
+
+    Example
+    -------
+    >>> from sdg_hub.core.connectors import ConnectorConfig
+    >>> from sdg_hub.core.connectors.agent.generic_http import GenericHTTPConnector
+    >>>
+    >>> config = ConnectorConfig(
+    ...     url="http://localhost:8000/api/chat",
+    ...     api_key="your-api-key",
+    ... )
+    >>> connector = GenericHTTPConnector(
+    ...     config=config,
+    ...     request_message_path="input.query",
+    ...     response_text_path="output.result",
+    ... )
+    >>> response = connector.send(
+    ...     messages=[{"role": "user", "content": "Hello!"}],
+    ...     session_id="session-123",
+    ... )
+    """
+
+    request_message_path: str = Field(
+        ...,
+        min_length=1,
+        description=(
+            "Dot-notation path where the message content is placed "
+            "in the request body (e.g., 'input.question')."
+        ),
+    )
+    response_text_path: str = Field(
+        ...,
+        min_length=1,
+        description=(
+            "Dot-notation path to extract text from the response "
+            "(e.g., 'output.answer')."
+        ),
+    )
+    response_session_id_path: Optional[str] = Field(
+        None,
+        description="Dot-notation path to extract session ID from the response.",
+    )
+    request_session_id_path: Optional[str] = Field(
+        None,
+        description="Dot-notation path where session ID is placed in the request body.",
+    )
+
+    @field_validator("request_message_path", "response_text_path")
+    @classmethod
+    def validate_path_format(cls, v: str) -> str:
+        """Validate that path contains only valid dot-notation segments."""
+        for segment in v.split("."):
+            if not segment:
+                raise ValueError(
+                    f"Invalid path '{v}': empty segment. "
+                    f"Use dot-notation like 'output.answer'."
+                )
+        return v
+
+    def build_request(
+        self,
+        messages: list[dict[str, Any]],
+        session_id: str,
+    ) -> dict[str, Any]:
+        """Build request payload by placing message content at the configured path.
+
+        Extracts the last user message and places it at
+        ``request_message_path`` in the request body.
+
+        Parameters
+        ----------
+        messages : list[dict]
+            Messages in standard format.
+        session_id : str
+            Session identifier.
+
+        Returns
+        -------
+        dict
+            Request payload with message at the configured path.
+
+        Raises
+        ------
+        ConnectorError
+            If no user message is found.
+        """
+        content = self._extract_last_user_message(messages)
+
+        payload: dict[str, Any] = {}
+        _set_nested(payload, self.request_message_path, content)
+
+        if self.request_session_id_path:
+            _set_nested(payload, self.request_session_id_path, session_id)
+
+        return payload
+
+    def parse_response(self, response: dict[str, Any]) -> dict[str, Any]:
+        """Validate response and extract fields using configured paths.
+
+        Extracts text (and optionally session ID) from the response using
+        the configured dot-notation paths, storing them under known keys
+        so the ``extract_text`` and ``extract_session_id`` classmethods
+        can retrieve them without instance access.
+
+        Parameters
+        ----------
+        response : dict
+            Raw response from the endpoint.
+
+        Returns
+        -------
+        dict
+            Response dict with ``_extracted_text`` (and optionally
+            ``_extracted_session_id``) injected.
+
+        Raises
+        ------
+        ConnectorError
+            If response is not a dict.
+        """
+        if not isinstance(response, dict):
+            raise ConnectorError(
+                f"Expected dict response, got {type(response).__name__}"
+            )
+
+        text = _get_nested(response, self.response_text_path)
+        if text is not None:
+            response["_extracted_text"] = str(text)
+
+        if self.response_session_id_path:
+            session_id = _get_nested(response, self.response_session_id_path)
+            if session_id is not None:
+                response["_extracted_session_id"] = str(session_id)
+
+        return response
+
+    def _extract_last_user_message(self, messages: list[dict[str, Any]]) -> str:
+        """Extract the last user message content.
+
+        Parameters
+        ----------
+        messages : list[dict]
+            List of messages.
+
+        Returns
+        -------
+        str
+            Content of the last user message.
+
+        Raises
+        ------
+        ConnectorError
+            If no user message is found.
+        """
+        for msg in reversed(messages):
+            if msg.get("role") == "user" and msg.get("content"):
+                return msg["content"]
+
+        raise ConnectorError(
+            "No user message found in messages. "
+            "Expected at least one message with role='user' and content."
+        )
+
+    # ------------------------------------------------------------------
+    # Response field extraction
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def extract_text(cls, response: dict[str, Any]) -> str | None:
+        """Extract text content from a generic HTTP response.
+
+        Reads from ``_extracted_text``, which is injected by
+        ``parse_response`` using the configured ``response_text_path``.
+
+        Parameters
+        ----------
+        response : dict
+            Response dict from ``parse_response``.
+
+        Returns
+        -------
+        str or None
+            Extracted text, or None if not found.
+        """
+        return response.get("_extracted_text")
+
+    @classmethod
+    def extract_session_id(cls, response: dict[str, Any]) -> str | None:
+        """Extract session ID from a generic HTTP response.
+
+        Reads from ``_extracted_session_id``, which is injected by
+        ``parse_response`` using the configured ``response_session_id_path``.
+
+        Parameters
+        ----------
+        response : dict
+            Response dict from ``parse_response``.
+
+        Returns
+        -------
+        str or None
+            Extracted session ID, or None if not configured or not found.
+        """
+        return response.get("_extracted_session_id")
+
+    @classmethod
+    def extract_tool_trace(
+        cls, response: dict[str, Any]
+    ) -> list[dict[str, Any]] | None:
+        """Extract tool trace from a generic HTTP response.
+
+        Generic HTTP endpoints typically don't produce tool traces.
+
+        Parameters
+        ----------
+        response : dict
+            Raw response from the endpoint.
+
+        Returns
+        -------
+        None
+            Always returns None.
+        """
+        return None

--- a/src/sdg_hub/core/connectors/agent/generic_http.py
+++ b/src/sdg_hub/core/connectors/agent/generic_http.py
@@ -152,6 +152,16 @@ class GenericHTTPConnector(BaseAgentConnector):
         _set_nested(payload, self.request_message_path, content)
 
         if self.request_session_id_path:
+            message_path = self.request_message_path
+            session_path = self.request_session_id_path
+            if (
+                message_path == session_path
+                or message_path.startswith(f"{session_path}.")
+                or session_path.startswith(f"{message_path}.")
+            ):
+                raise ConnectorError(
+                    "request_message_path and request_session_id_path must not overlap"
+                )
             _set_nested(payload, self.request_session_id_path, session_id)
 
         return payload

--- a/tests/connectors/agent/test_generic_http.py
+++ b/tests/connectors/agent/test_generic_http.py
@@ -260,6 +260,15 @@ class TestGenericHTTPConnector:
         with pytest.raises(ValueError, match="empty segment"):
             self._make_connector(response_session_id_path="meta..sid")
 
+    def test_validation_accepts_none_optional_paths(self):
+        """Test validation passes when optional paths are None."""
+        connector = self._make_connector(
+            request_session_id_path=None,
+            response_session_id_path=None,
+        )
+        assert connector.request_session_id_path is None
+        assert connector.response_session_id_path is None
+
     def test_validation_requires_request_message_path(self):
         """Test that request_message_path is required."""
         with pytest.raises(ValueError):

--- a/tests/connectors/agent/test_generic_http.py
+++ b/tests/connectors/agent/test_generic_http.py
@@ -191,6 +191,19 @@ class TestGenericHTTPConnector:
         assert parsed["_extracted_text"] == "hi"
         assert parsed["_extracted_session_id"] == "s-1"
 
+    def test_parse_response_strips_upstream_reserved_keys(self):
+        """Test that upstream _extracted_text/_extracted_session_id are stripped."""
+        connector = self._make_connector()
+        response = {
+            "output": {"answer": "real"},
+            "_extracted_text": "spoofed",
+            "_extracted_session_id": "spoofed-sid",
+        }
+        parsed = connector.parse_response(response)
+
+        assert parsed["_extracted_text"] == "real"
+        assert "_extracted_session_id" not in parsed
+
     def test_parse_response_non_dict_raises(self):
         """Test non-dict raises error."""
         connector = self._make_connector()

--- a/tests/connectors/agent/test_generic_http.py
+++ b/tests/connectors/agent/test_generic_http.py
@@ -242,6 +242,11 @@ class TestGenericHTTPConnector:
         with pytest.raises(ValueError, match="empty segment"):
             self._make_connector(request_message_path="input..question")
 
+    def test_validation_empty_path_segment_optional_field(self):
+        """Test validation rejects optional paths with empty segments."""
+        with pytest.raises(ValueError, match="empty segment"):
+            self._make_connector(response_session_id_path="meta..sid")
+
     def test_validation_requires_request_message_path(self):
         """Test that request_message_path is required."""
         with pytest.raises(ValueError):

--- a/tests/connectors/agent/test_generic_http.py
+++ b/tests/connectors/agent/test_generic_http.py
@@ -1,0 +1,259 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for GenericHTTPConnector."""
+
+import pytest
+
+from sdg_hub.core.connectors.agent.generic_http import (
+    GenericHTTPConnector,
+    _get_nested,
+    _set_nested,
+)
+from sdg_hub.core.connectors.base import ConnectorConfig
+from sdg_hub.core.connectors.exceptions import ConnectorError
+from sdg_hub.core.connectors.registry import ConnectorRegistry
+
+
+class TestHelperFunctions:
+    """Tests for _set_nested and _get_nested helper functions."""
+
+    def test_set_nested_single_key(self):
+        obj = {}
+        _set_nested(obj, "message", "hello")
+        assert obj == {"message": "hello"}
+
+    def test_set_nested_dotted_path(self):
+        obj = {}
+        _set_nested(obj, "input.question", "hello")
+        assert obj == {"input": {"question": "hello"}}
+
+    def test_set_nested_deep_path(self):
+        obj = {}
+        _set_nested(obj, "a.b.c.d", "value")
+        assert obj == {"a": {"b": {"c": {"d": "value"}}}}
+
+    def test_set_nested_preserves_existing_keys(self):
+        obj = {"input": {"other": "keep"}}
+        _set_nested(obj, "input.question", "hello")
+        assert obj == {"input": {"other": "keep", "question": "hello"}}
+
+    def test_get_nested_single_key(self):
+        assert _get_nested({"message": "hello"}, "message") == "hello"
+
+    def test_get_nested_dotted_path(self):
+        obj = {"output": {"answer": "world"}}
+        assert _get_nested(obj, "output.answer") == "world"
+
+    def test_get_nested_missing_key(self):
+        assert _get_nested({"output": {}}, "output.answer") is None
+
+    def test_get_nested_missing_intermediate(self):
+        assert _get_nested({}, "a.b.c") is None
+
+    def test_get_nested_non_dict_intermediate(self):
+        assert _get_nested({"a": "string"}, "a.b") is None
+
+
+class TestGenericHTTPConnector:
+    """Tests for GenericHTTPConnector."""
+
+    def _make_connector(self, **kwargs):
+        """Create a connector with defaults."""
+        defaults = {
+            "config": ConnectorConfig(url="http://test"),
+            "request_message_path": "input.question",
+            "response_text_path": "output.answer",
+        }
+        defaults.update(kwargs)
+        return GenericHTTPConnector(**defaults)
+
+    def test_registered_in_registry(self):
+        """Test connector is registered."""
+        assert ConnectorRegistry.get("generic_http") == GenericHTTPConnector
+
+    def test_build_request_nested_path(self):
+        """Test request builds nested JSON from dot-notation path."""
+        connector = self._make_connector(
+            request_message_path="input.question",
+        )
+        messages = [{"role": "user", "content": "How do I get started?"}]
+        request = connector.build_request(messages, "session-1")
+
+        assert request == {"input": {"question": "How do I get started?"}}
+
+    def test_build_request_single_key(self):
+        """Test request with a flat path."""
+        connector = self._make_connector(
+            request_message_path="message",
+        )
+        messages = [{"role": "user", "content": "Hello"}]
+        request = connector.build_request(messages, "session-1")
+
+        assert request == {"message": "Hello"}
+
+    def test_build_request_deep_path(self):
+        """Test request with a deeply nested path."""
+        connector = self._make_connector(
+            request_message_path="data.input.text.content",
+        )
+        messages = [{"role": "user", "content": "Deep"}]
+        request = connector.build_request(messages, "session-1")
+
+        assert request == {"data": {"input": {"text": {"content": "Deep"}}}}
+
+    def test_build_request_extracts_last_user_message(self):
+        """Test that the last user message is extracted."""
+        connector = self._make_connector()
+        messages = [
+            {"role": "user", "content": "First"},
+            {"role": "assistant", "content": "Reply"},
+            {"role": "user", "content": "Second"},
+        ]
+        request = connector.build_request(messages, "session-1")
+
+        assert request == {"input": {"question": "Second"}}
+
+    def test_build_request_no_user_message_raises(self):
+        """Test error when no user message exists."""
+        connector = self._make_connector()
+        with pytest.raises(ConnectorError, match="No user message"):
+            connector.build_request([{"role": "system", "content": "hi"}], "session-1")
+
+    def test_build_request_with_session_id_path(self):
+        """Test session ID is included when path is configured."""
+        connector = self._make_connector(
+            request_session_id_path="session_id",
+        )
+        messages = [{"role": "user", "content": "Hello"}]
+        request = connector.build_request(messages, "session-1")
+
+        assert request == {
+            "input": {"question": "Hello"},
+            "session_id": "session-1",
+        }
+
+    def test_build_request_with_nested_session_id_path(self):
+        """Test session ID at a nested path."""
+        connector = self._make_connector(
+            request_session_id_path="metadata.session.id",
+        )
+        messages = [{"role": "user", "content": "Hello"}]
+        request = connector.build_request(messages, "s-123")
+
+        assert request == {
+            "input": {"question": "Hello"},
+            "metadata": {"session": {"id": "s-123"}},
+        }
+
+    def test_build_request_without_session_id_path(self):
+        """Test session ID is excluded when path is not configured."""
+        connector = self._make_connector()
+        messages = [{"role": "user", "content": "Hello"}]
+        request = connector.build_request(messages, "session-1")
+
+        assert "session_id" not in request
+        assert request == {"input": {"question": "Hello"}}
+
+    def test_parse_response_valid_dict(self):
+        """Test valid dict passes through with extracted text."""
+        connector = self._make_connector()
+        response = {"output": {"answer": "42"}}
+        parsed = connector.parse_response(response)
+
+        assert parsed["output"]["answer"] == "42"
+        assert parsed["_extracted_text"] == "42"
+
+    def test_parse_response_extracts_text_from_configured_path(self):
+        """Test parse_response uses response_text_path to extract text."""
+        connector = self._make_connector(
+            response_text_path="data.reply.content",
+        )
+        response = {"data": {"reply": {"content": "hello world"}}}
+        parsed = connector.parse_response(response)
+
+        assert parsed["_extracted_text"] == "hello world"
+
+    def test_parse_response_missing_text_path(self):
+        """Test parse_response does not inject key when path is missing."""
+        connector = self._make_connector()
+        response = {"other": "value"}
+        parsed = connector.parse_response(response)
+
+        assert "_extracted_text" not in parsed
+
+    def test_parse_response_extracts_session_id(self):
+        """Test parse_response extracts session ID when path is configured."""
+        connector = self._make_connector(
+            response_session_id_path="meta.sid",
+        )
+        response = {"output": {"answer": "hi"}, "meta": {"sid": "s-1"}}
+        parsed = connector.parse_response(response)
+
+        assert parsed["_extracted_text"] == "hi"
+        assert parsed["_extracted_session_id"] == "s-1"
+
+    def test_parse_response_non_dict_raises(self):
+        """Test non-dict raises error."""
+        connector = self._make_connector()
+        with pytest.raises(ConnectorError, match="Expected dict"):
+            connector.parse_response(["not", "a", "dict"])
+
+    def test_extract_text_reads_injected_key(self):
+        """Test extract_text reads _extracted_text from parse_response."""
+        assert (
+            GenericHTTPConnector.extract_text({"_extracted_text": "hello"}) == "hello"
+        )
+
+    def test_extract_text_returns_none_without_key(self):
+        """Test extract_text returns None when _extracted_text is absent."""
+        assert GenericHTTPConnector.extract_text({"output": "value"}) is None
+
+    def test_extract_session_id_reads_injected_key(self):
+        """Test extract_session_id reads _extracted_session_id."""
+        assert (
+            GenericHTTPConnector.extract_session_id({"_extracted_session_id": "s-1"})
+            == "s-1"
+        )
+
+    def test_extract_session_id_returns_none_without_key(self):
+        """Test extract_session_id returns None when key is absent."""
+        assert GenericHTTPConnector.extract_session_id({"other": "val"}) is None
+
+    def test_extract_tool_trace_returns_none(self):
+        """Test extract_tool_trace always returns None."""
+        assert GenericHTTPConnector.extract_tool_trace({"any": "thing"}) is None
+
+    def test_build_headers_with_api_key(self):
+        """Test default headers include Bearer auth."""
+        connector = self._make_connector(
+            config=ConnectorConfig(url="http://test", api_key="secret"),
+        )
+        headers = connector._build_headers()
+        assert headers["Authorization"] == "Bearer secret"
+
+    def test_build_headers_without_api_key(self):
+        """Test headers without API key."""
+        connector = self._make_connector()
+        headers = connector._build_headers()
+        assert headers == {"Content-Type": "application/json"}
+        assert "Authorization" not in headers
+
+    def test_validation_empty_path_segment(self):
+        """Test validation rejects paths with empty segments."""
+        with pytest.raises(ValueError, match="empty segment"):
+            self._make_connector(request_message_path="input..question")
+
+    def test_validation_requires_request_message_path(self):
+        """Test that request_message_path is required."""
+        with pytest.raises(ValueError):
+            GenericHTTPConnector(
+                config=ConnectorConfig(url="http://test"),
+                response_text_path="output.answer",
+            )
+
+    def test_validation_requires_response_text_path(self):
+        """Test that response_text_path is required."""
+        with pytest.raises(ValueError):
+            GenericHTTPConnector(
+                config=ConnectorConfig(url="http://test"),
+                request_message_path="input.question",
+            )

--- a/tests/connectors/agent/test_generic_http.py
+++ b/tests/connectors/agent/test_generic_http.py
@@ -153,6 +153,49 @@ class TestGenericHTTPConnector:
         assert "session_id" not in request
         assert request == {"input": {"question": "Hello"}}
 
+    def test_build_request_overlapping_paths_identical(self):
+        """Test error when message and session ID paths are identical."""
+        connector = self._make_connector(
+            request_message_path="input.query",
+            request_session_id_path="input.query",
+        )
+        messages = [{"role": "user", "content": "Hello"}]
+        with pytest.raises(ConnectorError, match="must not overlap"):
+            connector.build_request(messages, "session-1")
+
+    def test_build_request_overlapping_paths_parent_child(self):
+        """Test error when session ID path is parent of message path."""
+        connector = self._make_connector(
+            request_message_path="input.query",
+            request_session_id_path="input",
+        )
+        messages = [{"role": "user", "content": "Hello"}]
+        with pytest.raises(ConnectorError, match="must not overlap"):
+            connector.build_request(messages, "session-1")
+
+    def test_build_request_overlapping_paths_child_parent(self):
+        """Test error when message path is parent of session ID path."""
+        connector = self._make_connector(
+            request_message_path="input",
+            request_session_id_path="input.session_id",
+        )
+        messages = [{"role": "user", "content": "Hello"}]
+        with pytest.raises(ConnectorError, match="must not overlap"):
+            connector.build_request(messages, "session-1")
+
+    def test_build_request_non_overlapping_paths(self):
+        """Test that sibling paths work without error."""
+        connector = self._make_connector(
+            request_message_path="input.query",
+            request_session_id_path="input.session_id",
+        )
+        messages = [{"role": "user", "content": "Hello"}]
+        request = connector.build_request(messages, "s-1")
+
+        assert request == {
+            "input": {"query": "Hello", "session_id": "s-1"},
+        }
+
     def test_parse_response_valid_dict(self):
         """Test valid dict passes through with extracted text."""
         connector = self._make_connector()


### PR DESCRIPTION
Add a generic HTTP connector (GenericHTTPConnector) that enables AgentBlock to communicate with any REST chat endpoint, not just Langflow and LangGraph. Instead of hardcoding a specific API format, the connector uses declarative dot-notation JSON paths to configure where the message content is placed in the request body and  where the answer is extracted from the response. This allows users to point sdg_hub at any REST endpoint by simply specifying the paths (e.g., request_message_path="input.query", response_text_path="output.result"),  without writing a custom connector. Includes 33 unit tests and has been verified end-to-end against a live endpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Generic HTTP connector for REST chat endpoints with configurable dot-notation mappings for request message and response text, optional session ID propagation, validation of path formats, and safe extraction of response text/session IDs.
* **Tests**
  * Added comprehensive unit and end-to-end tests covering request construction, response parsing, header/auth behavior, dotted-path helpers, and error cases.
* **Chores**
  * Registered and exported the new connector for general use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->