### PR TITLE
feat(tests): add flow regression tests with auto-generated mocks

### DIFF
--- a/tests/blocks/transform/test_duplicate_columns.py
+++ b/tests/blocks/transform/test_duplicate_columns.py
@@ -61,5 +61,14 @@ class TestDuplicateColumnsBlock:
             DuplicateColumnsBlock(block_name="dup", input_cols={})
 
     def test_list_input_cols_raises(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="input_cols must be a dictionary"):
             DuplicateColumnsBlock(block_name="dup", input_cols=["col_a"])
+
+    def test_overwrite_existing_column(self):
+        block = DuplicateColumnsBlock(
+            block_name="dup", input_cols={"source": "existing"}
+        )
+        df = pd.DataFrame({"source": ["new"], "existing": ["old"]})
+        result = block.generate(df)
+
+        assert result["existing"].tolist() == ["new"]

--- a/tests/blocks/transform/test_duplicate_columns.py
+++ b/tests/blocks/transform/test_duplicate_columns.py
@@ -31,9 +31,10 @@ class TestDuplicateColumnsBlock:
     def test_original_unmodified(self):
         block = DuplicateColumnsBlock(block_name="dup", input_cols={"source": "target"})
         df = pd.DataFrame({"source": ["a", "b"]})
+        original = df.copy()
         block.generate(df)
 
-        assert "target" not in df.columns
+        pd.testing.assert_frame_equal(df, original)
 
     def test_preserves_other_columns(self):
         block = DuplicateColumnsBlock(block_name="dup", input_cols={"source": "target"})

--- a/tests/blocks/transform/test_duplicate_columns.py
+++ b/tests/blocks/transform/test_duplicate_columns.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for DuplicateColumnsBlock."""
+
+import pandas as pd
+import pytest
+
+from sdg_hub.core.blocks.transform.duplicate_columns import DuplicateColumnsBlock
+
+
+class TestDuplicateColumnsBlock:
+    def test_single_column(self):
+        block = DuplicateColumnsBlock(block_name="dup", input_cols={"source": "target"})
+        df = pd.DataFrame({"source": ["a", "b", "c"]})
+        result = block.generate(df)
+
+        assert "target" in result.columns
+        assert result["target"].tolist() == ["a", "b", "c"]
+        assert result["source"].tolist() == ["a", "b", "c"]
+
+    def test_multiple_columns(self):
+        block = DuplicateColumnsBlock(
+            block_name="dup",
+            input_cols={"col_a": "copy_a", "col_b": "copy_b"},
+        )
+        df = pd.DataFrame({"col_a": [1, 2], "col_b": [3, 4]})
+        result = block.generate(df)
+
+        assert result["copy_a"].tolist() == [1, 2]
+        assert result["copy_b"].tolist() == [3, 4]
+
+    def test_original_unmodified(self):
+        block = DuplicateColumnsBlock(block_name="dup", input_cols={"source": "target"})
+        df = pd.DataFrame({"source": ["a", "b"]})
+        block.generate(df)
+
+        assert "target" not in df.columns
+
+    def test_preserves_other_columns(self):
+        block = DuplicateColumnsBlock(block_name="dup", input_cols={"source": "target"})
+        df = pd.DataFrame({"source": [1], "other": [2]})
+        result = block.generate(df)
+
+        assert result["other"].tolist() == [2]
+
+    def test_output_cols_auto_set(self):
+        block = DuplicateColumnsBlock(block_name="dup", input_cols={"a": "b", "c": "d"})
+        assert block.output_cols == ["b", "d"]
+
+    def test_missing_source_column_raises(self):
+        block = DuplicateColumnsBlock(
+            block_name="dup", input_cols={"missing": "target"}
+        )
+        df = pd.DataFrame({"other": ["a"]})
+
+        with pytest.raises(ValueError, match="Source column 'missing' not found"):
+            block.generate(df)
+
+    def test_empty_input_cols_raises(self):
+        with pytest.raises(ValueError, match="input_cols cannot be empty"):
+            DuplicateColumnsBlock(block_name="dup", input_cols={})
+
+    def test_list_input_cols_raises(self):
+        with pytest.raises(ValueError):
+            DuplicateColumnsBlock(block_name="dup", input_cols=["col_a"])

--- a/tests/flow/regression/__init__.py
+++ b/tests/flow/regression/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/flow/regression/conftest.py
+++ b/tests/flow/regression/conftest.py
@@ -19,8 +19,9 @@ import yaml
 
 from sdg_hub.core.blocks.llm.llm_chat_block import LLMChatBlock
 from sdg_hub.core.flow.base import Flow
+import sdg_hub
 
-FLOWS_DIR = Path(__file__).resolve().parents[3] / "src" / "sdg_hub" / "flows"
+FLOWS_DIR = Path(sdg_hub.__file__).resolve().parent / "flows"
 
 SKIP_BLOCK_TYPES = frozenset(
     {
@@ -88,26 +89,32 @@ class MockResponseBuilder:
             if block["block_type"] != "LLMChatBlock":
                 continue
             block_name = block["block_config"]["block_name"]
-            parser = self._find_downstream_parser(i)
-            filt = self._find_downstream_filter(i, parser)
+            parser_result = self._find_downstream_parser(i)
+            if parser_result is not None:
+                parser, parser_idx = parser_result
+            else:
+                parser, parser_idx = None, None
+            filt = self._find_downstream_filter(i, parser_idx)
             response_map[block_name] = self._generate_content(parser, filt)
         return response_map
 
     # -- chain walking helpers ------------------------------------------------
 
-    def _find_downstream_parser(self, llm_idx: int) -> dict[str, Any] | None:
+    def _find_downstream_parser(
+        self, llm_idx: int
+    ) -> tuple[dict[str, Any], int] | None:
         for j in range(llm_idx + 1, min(llm_idx + 5, len(self.blocks))):
             btype = self.blocks[j]["block_type"]
             if btype in _PARSER_TYPES:
-                return self.blocks[j]
+                return self.blocks[j], j
             if btype == "LLMChatBlock":
                 break
         return None
 
     def _find_downstream_filter(
-        self, llm_idx: int, parser: dict[str, Any] | None
+        self, llm_idx: int, parser_idx: int | None
     ) -> dict[str, Any] | None:
-        start = self.blocks.index(parser) + 1 if parser is not None else llm_idx + 1
+        start = (parser_idx + 1) if parser_idx is not None else (llm_idx + 1)
         for j in range(start, min(start + 4, len(self.blocks))):
             btype = self.blocks[j]["block_type"]
             if btype == "ColumnValueFilterBlock":
@@ -182,7 +189,14 @@ class MockResponseBuilder:
     def _filter_passing_value(filt: dict[str, Any]) -> str:
         cfg = filt.get("block_config", {})
         val = cfg.get("filter_value")
+        if val is None:
+            block_name = cfg.get("block_name", "<unknown>")
+            raise ValueError(
+                f"ColumnValueFilterBlock '{block_name}' has no filter_value"
+            )
         if isinstance(val, list):
+            if not val:
+                raise ValueError("ColumnValueFilterBlock has empty filter_value list")
             return str(val[0])
         return str(val)
 

--- a/tests/flow/regression/conftest.py
+++ b/tests/flow/regression/conftest.py
@@ -125,6 +125,14 @@ class MockResponseBuilder:
 
     # -- content generators ---------------------------------------------------
 
+    @staticmethod
+    def _as_list(value: Any) -> list[str]:
+        if value is None:
+            return []
+        if isinstance(value, str):
+            return [value]
+        return list(value)
+
     def _generate_content(
         self,
         parser: dict[str, Any] | None,
@@ -141,15 +149,15 @@ class MockResponseBuilder:
         if btype == "TagParserBlock":
             return self._tag_content(cfg, filt)
         if btype == "JSONParserBlock":
-            return self._json_content(cfg)
+            return self._json_content(cfg, filt)
         if btype == "RegexParserBlock":
-            return self._regex_content(cfg)
+            return self._regex_content(cfg, filt)
         return "mock response text"
 
     def _tag_content(self, cfg: dict[str, Any], filt: dict[str, Any] | None) -> str:
-        start_tags: list[str] = cfg.get("start_tags", [])
-        end_tags: list[str] = cfg.get("end_tags", [])
-        output_cols: list[str] = cfg.get("output_cols", [])
+        start_tags = self._as_list(cfg.get("start_tags"))
+        end_tags = self._as_list(cfg.get("end_tags"))
+        output_cols = self._as_list(cfg.get("output_cols"))
 
         if not start_tags:
             return "mock text content"
@@ -201,20 +209,38 @@ class MockResponseBuilder:
         return str(val)
 
     @staticmethod
-    def _json_content(cfg: dict[str, Any]) -> str:
-        output_cols: list[str] = cfg.get("output_cols", [])
-        if not output_cols:
-            return json.dumps({"result": "mock value", "score": 5})
-        return json.dumps({col: f"mock {col}" for col in output_cols})
+    def _filter_col(filt: dict[str, Any]) -> str:
+        """Return the column name a ColumnValueFilterBlock reads from."""
+        fcfg = filt.get("block_config", {})
+        finput = fcfg.get("input_cols", [])
+        if isinstance(finput, list) and finput:
+            return str(finput[0])
+        if isinstance(finput, dict) and finput:
+            return str(next(iter(finput)))
+        return ""
 
-    @staticmethod
-    def _regex_content(cfg: dict[str, Any]) -> str:
+    def _json_content(self, cfg: dict[str, Any], filt: dict[str, Any] | None) -> str:
+        output_cols: list[str] = self._as_list(cfg.get("output_cols"))
+        if not output_cols:
+            data: dict[str, Any] = {"result": "mock value", "score": 5}
+        else:
+            data = {col: f"mock {col}" for col in output_cols}
+        if filt:
+            fcol = self._filter_col(filt)
+            if fcol in data or not output_cols:
+                data[fcol] = self._filter_passing_value(filt)
+        return json.dumps(data)
+
+    def _regex_content(self, cfg: dict[str, Any], filt: dict[str, Any] | None) -> str:
         pattern: str = cfg.get("parsing_pattern", "")
         if r"\d+" in pattern and r"\." in pattern:
             return "1. mock fact one\n2. mock fact two"
         if "Question" in pattern or "QUESTION" in pattern:
             return "[Question] mock question [Answer] mock answer"
-        return "mock regex content"
+        raise ValueError(
+            f"Unrecognized regex pattern in RegexParserBlock, "
+            f"add a handler in MockResponseBuilder._regex_content: {pattern!r}"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -229,6 +255,8 @@ def build_seed_dataset(flow: Flow, num_rows: int = 2) -> pd.DataFrame:
         req = flow.metadata.dataset_requirements
         cols.extend(req.required_columns or [])
         cols.extend(getattr(req, "optional_columns", None) or [])
+        min_samples = getattr(req, "min_samples", 1) or 1
+        num_rows = max(num_rows, min_samples)
 
     if not cols:
         cols = ["text"]
@@ -261,12 +289,19 @@ def mock_litellm():
     def set_responses(mapping: dict[str, str]) -> None:
         response_map.update(mapping)
 
+    def _content_for(block_name: str) -> str:
+        if block_name not in response_map:
+            raise AssertionError(
+                f"No mock response configured for LLMChatBlock '{block_name}'"
+            )
+        return response_map[block_name]
+
     def _patched_sync(
         self: LLMChatBlock,
         messages_list: list[list[dict[str, Any]]],
         completion_kwargs: dict[str, Any],
     ) -> list[list[dict[str, Any]]]:
-        content = response_map.get(self.block_name, "mock fallback")
+        content = _content_for(self.block_name)
         return [[{"content": content}] for _ in messages_list]
 
     def _patched_async(
@@ -275,7 +310,7 @@ def mock_litellm():
         completion_kwargs: dict[str, Any],
         flow_max_concurrency: int | None = None,
     ) -> list[list[dict[str, Any]]]:
-        content = response_map.get(self.block_name, "mock fallback")
+        content = _content_for(self.block_name)
         return [[{"content": content}] for _ in messages_list]
 
     with (

--- a/tests/flow/regression/conftest.py
+++ b/tests/flow/regression/conftest.py
@@ -1,0 +1,271 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Infrastructure for flow regression tests.
+
+Provides auto-discovery of flow YAMLs, mock LLM response generation
+that satisfies downstream parsers, and seed dataset generation from
+flow metadata.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+import json
+
+import pandas as pd
+import pytest
+import yaml
+
+from sdg_hub.core.blocks.llm.llm_chat_block import LLMChatBlock
+from sdg_hub.core.flow.base import Flow
+
+FLOWS_DIR = Path(__file__).resolve().parents[3] / "src" / "sdg_hub" / "flows"
+
+SKIP_BLOCK_TYPES = frozenset(
+    {
+        "AgentBlock",
+        "AgentResponseExtractorBlock",
+        "PythonInterpreterBlock",
+        "MCPAgentBlock",
+    }
+)
+
+_PARSER_TYPES = frozenset({"TagParserBlock", "JSONParserBlock", "RegexParserBlock"})
+
+_CHAIN_BREAKERS = frozenset({"LLMChatBlock", "PromptBuilderBlock"})
+
+
+# ---------------------------------------------------------------------------
+# Flow discovery
+# ---------------------------------------------------------------------------
+
+
+def discover_flow_yamls() -> list[Path]:
+    """Auto-discover all flow YAML files, excluding unsupported block types."""
+    all_yamls = sorted(FLOWS_DIR.rglob("flow.yaml"))
+    return [y for y in all_yamls if not _has_unsupported_blocks(y)]
+
+
+def flow_id(yaml_path: Path) -> str:
+    """Generate a readable test ID from a flow YAML path."""
+    return (
+        str(yaml_path.relative_to(FLOWS_DIR))
+        .replace("/flow.yaml", "")
+        .replace("/", "::")
+    )
+
+
+def _has_unsupported_blocks(yaml_path: Path) -> bool:
+    with open(yaml_path) as f:
+        data = yaml.safe_load(f)
+    block_types = {b["block_type"] for b in data.get("blocks", [])}
+    return bool(block_types & SKIP_BLOCK_TYPES)
+
+
+# ---------------------------------------------------------------------------
+# MockResponseBuilder
+# ---------------------------------------------------------------------------
+
+
+class MockResponseBuilder:
+    """Reads a flow YAML and builds mock LLM responses satisfying downstream parsers.
+
+    Walks the block list to find each ``LLMChatBlock -> LLMResponseExtractorBlock
+    -> [Parser] -> [ColumnValueFilterBlock]`` chain and generates text content
+    that the parser will accept and that will pass any downstream filter.
+    """
+
+    def __init__(self, yaml_path: Path) -> None:
+        with open(yaml_path) as f:
+            self.flow_data = yaml.safe_load(f)
+        self.blocks: list[dict[str, Any]] = self.flow_data.get("blocks", [])
+
+    def build(self) -> dict[str, str]:
+        """Return ``{llm_block_name: mock_content}`` for every LLMChatBlock."""
+        response_map: dict[str, str] = {}
+        for i, block in enumerate(self.blocks):
+            if block["block_type"] != "LLMChatBlock":
+                continue
+            block_name = block["block_config"]["block_name"]
+            parser = self._find_downstream_parser(i)
+            filt = self._find_downstream_filter(i, parser)
+            response_map[block_name] = self._generate_content(parser, filt)
+        return response_map
+
+    # -- chain walking helpers ------------------------------------------------
+
+    def _find_downstream_parser(self, llm_idx: int) -> dict[str, Any] | None:
+        for j in range(llm_idx + 1, min(llm_idx + 5, len(self.blocks))):
+            btype = self.blocks[j]["block_type"]
+            if btype in _PARSER_TYPES:
+                return self.blocks[j]
+            if btype == "LLMChatBlock":
+                break
+        return None
+
+    def _find_downstream_filter(
+        self, llm_idx: int, parser: dict[str, Any] | None
+    ) -> dict[str, Any] | None:
+        start = self.blocks.index(parser) + 1 if parser is not None else llm_idx + 1
+        for j in range(start, min(start + 4, len(self.blocks))):
+            btype = self.blocks[j]["block_type"]
+            if btype == "ColumnValueFilterBlock":
+                return self.blocks[j]
+            if btype in _CHAIN_BREAKERS:
+                break
+        return None
+
+    # -- content generators ---------------------------------------------------
+
+    def _generate_content(
+        self,
+        parser: dict[str, Any] | None,
+        filt: dict[str, Any] | None,
+    ) -> str:
+        if parser is None:
+            if filt:
+                return self._filter_passing_value(filt)
+            return "mock response text"
+
+        btype = parser["block_type"]
+        cfg = parser.get("block_config", {})
+
+        if btype == "TagParserBlock":
+            return self._tag_content(cfg, filt)
+        if btype == "JSONParserBlock":
+            return self._json_content(cfg)
+        if btype == "RegexParserBlock":
+            return self._regex_content(cfg)
+        return "mock response text"
+
+    def _tag_content(self, cfg: dict[str, Any], filt: dict[str, Any] | None) -> str:
+        start_tags: list[str] = cfg.get("start_tags", [])
+        end_tags: list[str] = cfg.get("end_tags", [])
+        output_cols: list[str] = cfg.get("output_cols", [])
+
+        if not start_tags:
+            return "mock text content"
+
+        parts: list[str] = []
+        for i, (start, end) in enumerate(zip(start_tags, end_tags)):
+            col = output_cols[i] if i < len(output_cols) else f"field_{i}"
+            value = self._tag_value(col, filt, start)
+
+            if start == "" and end == "":
+                parts.append(value)
+            elif start.startswith("###"):
+                parts.append(f"{start}\n1. mock fact one\n2. mock fact two")
+            else:
+                parts.append(f"{start}{value}{end}")
+
+        return "\n".join(parts)
+
+    def _tag_value(
+        self, col: str, filt: dict[str, Any] | None, start_tag: str = ""
+    ) -> str:
+        if filt:
+            fcfg = filt.get("block_config", {})
+            finput = fcfg.get("input_cols", [])
+            fcol = (
+                finput[0]
+                if isinstance(finput, list) and finput
+                else next(iter(finput), "")
+                if isinstance(finput, dict)
+                else ""
+            )
+            if fcol == col:
+                return self._filter_passing_value(filt)
+        return f"mock {col}"
+
+    @staticmethod
+    def _filter_passing_value(filt: dict[str, Any]) -> str:
+        cfg = filt.get("block_config", {})
+        val = cfg.get("filter_value")
+        if isinstance(val, list):
+            return str(val[0])
+        return str(val)
+
+    @staticmethod
+    def _json_content(cfg: dict[str, Any]) -> str:
+        output_cols: list[str] = cfg.get("output_cols", [])
+        if not output_cols:
+            return json.dumps({"result": "mock value", "score": 5})
+        return json.dumps({col: f"mock {col}" for col in output_cols})
+
+    @staticmethod
+    def _regex_content(cfg: dict[str, Any]) -> str:
+        pattern: str = cfg.get("parsing_pattern", "")
+        if r"\d+" in pattern and r"\." in pattern:
+            return "1. mock fact one\n2. mock fact two"
+        if "Question" in pattern or "QUESTION" in pattern:
+            return "[Question] mock question [Answer] mock answer"
+        return "mock regex content"
+
+
+# ---------------------------------------------------------------------------
+# Seed dataset factory
+# ---------------------------------------------------------------------------
+
+
+def build_seed_dataset(flow: Flow, num_rows: int = 2) -> pd.DataFrame:
+    """Auto-generate a minimal test dataset from the flow's dataset_requirements."""
+    cols: list[str] = []
+    if flow.metadata and flow.metadata.dataset_requirements:
+        req = flow.metadata.dataset_requirements
+        cols.extend(req.required_columns or [])
+        cols.extend(getattr(req, "optional_columns", None) or [])
+
+    if not cols:
+        cols = ["text"]
+
+    data: dict[str, Any] = {}
+    for col in cols:
+        if "pool" in col.lower():
+            data[col] = [["item_a", "item_b", "item_c"]] * num_rows
+        else:
+            data[col] = [f"sample {col} text row {i}" for i in range(num_rows)]
+
+    return pd.DataFrame(data)
+
+
+# ---------------------------------------------------------------------------
+# mock_litellm fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def mock_litellm():
+    """Patch LLMChatBlock internals so no real LLM calls are made.
+
+    Yields a callable ``set_responses(mapping)`` where *mapping* is
+    ``{block_name: content_text}``.  Each LLMChatBlock looks up its own
+    ``block_name`` and returns the corresponding content for every row.
+    """
+    response_map: dict[str, str] = {}
+
+    def set_responses(mapping: dict[str, str]) -> None:
+        response_map.update(mapping)
+
+    def _patched_sync(
+        self: LLMChatBlock,
+        messages_list: list[list[dict[str, Any]]],
+        completion_kwargs: dict[str, Any],
+    ) -> list[list[dict[str, Any]]]:
+        content = response_map.get(self.block_name, "mock fallback")
+        return [[{"content": content}] for _ in messages_list]
+
+    def _patched_async(
+        self: LLMChatBlock,
+        messages_list: list[list[dict[str, Any]]],
+        completion_kwargs: dict[str, Any],
+        flow_max_concurrency: int | None = None,
+    ) -> list[list[dict[str, Any]]]:
+        content = response_map.get(self.block_name, "mock fallback")
+        return [[{"content": content}] for _ in messages_list]
+
+    with (
+        patch.object(LLMChatBlock, "_generate_sync", _patched_sync),
+        patch.object(LLMChatBlock, "_run_async_generation", _patched_async),
+    ):
+        yield set_responses

--- a/tests/flow/regression/conftest.py
+++ b/tests/flow/regression/conftest.py
@@ -171,6 +171,12 @@ class MockResponseBuilder:
         if not start_tags:
             return "mock text content"
 
+        if len(start_tags) != len(end_tags):
+            raise ValueError(
+                f"TagParserBlock has mismatched start_tags ({len(start_tags)}) "
+                f"and end_tags ({len(end_tags)})"
+            )
+
         parts: list[str] = []
         for i, (start, end) in enumerate(zip(start_tags, end_tags)):
             col = output_cols[i] if i < len(output_cols) else f"field_{i}"
@@ -226,7 +232,7 @@ class MockResponseBuilder:
             data = {col: f"mock {col}" for col in output_cols}
         if filt:
             fcol = self._filter_col(filt)
-            if fcol in data or not output_cols:
+            if fcol:
                 data[fcol] = self._filter_passing_value(filt)
         return json.dumps(data)
 
@@ -263,7 +269,7 @@ def build_seed_dataset(flow: Flow, num_rows: int = 2) -> pd.DataFrame:
     data: dict[str, Any] = {}
     for col in cols:
         if "pool" in col.lower():
-            data[col] = [["item_a", "item_b", "item_c"]] * num_rows
+            data[col] = [["item_a", "item_b", "item_c"] for _ in range(num_rows)]
         else:
             data[col] = [f"sample {col} text row {i}" for i in range(num_rows)]
 
@@ -308,7 +314,7 @@ def mock_litellm():
         self: LLMChatBlock,
         messages_list: list[list[dict[str, Any]]],
         completion_kwargs: dict[str, Any],
-        flow_max_concurrency: int | None = None,
+        flow_max_concurrency: int | None,
     ) -> list[list[dict[str, Any]]]:
         content = _content_for(self.block_name)
         return [[{"content": content}] for _ in messages_list]

--- a/tests/flow/regression/conftest.py
+++ b/tests/flow/regression/conftest.py
@@ -60,7 +60,12 @@ def flow_id(yaml_path: Path) -> str:
 def _has_unsupported_blocks(yaml_path: Path) -> bool:
     with open(yaml_path) as f:
         data = yaml.safe_load(f)
-    block_types = {b["block_type"] for b in data.get("blocks", [])}
+    if not isinstance(data, dict):
+        raise ValueError(f"Malformed flow YAML (expected mapping): {yaml_path}")
+    try:
+        block_types = {b["block_type"] for b in data.get("blocks", [])}
+    except (KeyError, TypeError) as exc:
+        raise ValueError(f"Malformed block entry in {yaml_path}: {exc}") from exc
     return bool(block_types & SKIP_BLOCK_TYPES)
 
 
@@ -72,15 +77,17 @@ def _has_unsupported_blocks(yaml_path: Path) -> bool:
 class MockResponseBuilder:
     """Reads a flow YAML and builds mock LLM responses satisfying downstream parsers.
 
-    Walks the block list to find each ``LLMChatBlock -> LLMResponseExtractorBlock
-    -> [Parser] -> [ColumnValueFilterBlock]`` chain and generates text content
-    that the parser will accept and that will pass any downstream filter.
+    Walks the block list to find each LLMChatBlock and its downstream parser
+    and optional filter, skipping intermediate blocks like
+    LLMResponseExtractorBlock that don't affect content shape.
     """
 
     def __init__(self, yaml_path: Path) -> None:
         with open(yaml_path) as f:
-            self.flow_data = yaml.safe_load(f)
-        self.blocks: list[dict[str, Any]] = self.flow_data.get("blocks", [])
+            data = yaml.safe_load(f)
+        if not isinstance(data, dict):
+            raise ValueError(f"Malformed flow YAML (expected mapping): {yaml_path}")
+        self.blocks: list[dict[str, Any]] = data.get("blocks", [])
 
     def build(self) -> dict[str, str]:
         """Return ``{llm_block_name: mock_content}`` for every LLMChatBlock."""
@@ -103,19 +110,21 @@ class MockResponseBuilder:
     def _find_downstream_parser(
         self, llm_idx: int
     ) -> tuple[dict[str, Any], int] | None:
-        for j in range(llm_idx + 1, min(llm_idx + 5, len(self.blocks))):
+        """Scan forward from *llm_idx* until a parser or chain-breaker is found."""
+        for j in range(llm_idx + 1, len(self.blocks)):
             btype = self.blocks[j]["block_type"]
             if btype in _PARSER_TYPES:
                 return self.blocks[j], j
-            if btype == "LLMChatBlock":
+            if btype in _CHAIN_BREAKERS:
                 break
         return None
 
     def _find_downstream_filter(
         self, llm_idx: int, parser_idx: int | None
     ) -> dict[str, Any] | None:
+        """Scan forward from *parser_idx* (or *llm_idx*) for a filter block."""
         start = (parser_idx + 1) if parser_idx is not None else (llm_idx + 1)
-        for j in range(start, min(start + 4, len(self.blocks))):
+        for j in range(start, len(self.blocks)):
             btype = self.blocks[j]["block_type"]
             if btype == "ColumnValueFilterBlock":
                 return self.blocks[j]
@@ -152,7 +161,7 @@ class MockResponseBuilder:
             return self._json_content(cfg, filt)
         if btype == "RegexParserBlock":
             return self._regex_content(cfg, filt)
-        return "mock response text"
+        raise ValueError(f"Unrecognized parser type: {btype!r}")
 
     def _tag_content(self, cfg: dict[str, Any], filt: dict[str, Any] | None) -> str:
         start_tags = self._as_list(cfg.get("start_tags"))
@@ -179,18 +188,8 @@ class MockResponseBuilder:
     def _tag_value(
         self, col: str, filt: dict[str, Any] | None, start_tag: str = ""
     ) -> str:
-        if filt:
-            fcfg = filt.get("block_config", {})
-            finput = fcfg.get("input_cols", [])
-            fcol = (
-                finput[0]
-                if isinstance(finput, list) and finput
-                else next(iter(finput), "")
-                if isinstance(finput, dict)
-                else ""
-            )
-            if fcol == col:
-                return self._filter_passing_value(filt)
+        if filt and self._filter_col(filt) == col:
+            return self._filter_passing_value(filt)
         return f"mock {col}"
 
     @staticmethod
@@ -278,7 +277,8 @@ def build_seed_dataset(flow: Flow, num_rows: int = 2) -> pd.DataFrame:
 
 @pytest.fixture()
 def mock_litellm():
-    """Patch LLMChatBlock internals so no real LLM calls are made.
+    """Patch ``LLMChatBlock._generate_sync`` and ``_run_async_generation``
+    so no real LLM calls are made.
 
     Yields a callable ``set_responses(mapping)`` where *mapping* is
     ``{block_name: content_text}``.  Each LLMChatBlock looks up its own

--- a/tests/flow/regression/conftest.py
+++ b/tests/flow/regression/conftest.py
@@ -218,6 +218,8 @@ class MockResponseBuilder:
         """Return the column name a ColumnValueFilterBlock reads from."""
         fcfg = filt.get("block_config", {})
         finput = fcfg.get("input_cols", [])
+        if isinstance(finput, str):
+            return finput
         if isinstance(finput, list) and finput:
             return str(finput[0])
         if isinstance(finput, dict) and finput:

--- a/tests/flow/regression/test_flow_regression.py
+++ b/tests/flow/regression/test_flow_regression.py
@@ -9,6 +9,7 @@ not output correctness.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
@@ -22,13 +23,21 @@ from .conftest import (
     flow_id,
 )
 
+_DISCOVERED_FLOWS = discover_flow_yamls()
+assert _DISCOVERED_FLOWS, (
+    "No flow YAMLs discovered; check FLOWS_DIR resolution and SKIP_BLOCK_TYPES."
+)
+
 
 @pytest.mark.parametrize(
     "flow_yaml",
-    discover_flow_yamls(),
+    _DISCOVERED_FLOWS,
     ids=lambda p: flow_id(p),
 )
-def test_flow_runs_without_error(flow_yaml: Path, mock_litellm: ...) -> None:
+def test_flow_runs_without_error(
+    flow_yaml: Path,
+    mock_litellm: Callable[[dict[str, str]], None],
+) -> None:
     """Regression: flow loads, generates, and produces non-empty output."""
     response_map = MockResponseBuilder(flow_yaml).build()
     mock_litellm(response_map)
@@ -42,3 +51,9 @@ def test_flow_runs_without_error(flow_yaml: Path, mock_litellm: ...) -> None:
     assert len(result) > 0, f"Flow produced empty output: {flow_yaml.name}"
     new_cols = set(result.columns) - set(dataset.columns)
     assert new_cols, f"Flow did not add any columns: {flow_yaml.name}"
+
+    if flow.metadata and flow.metadata.output_columns:
+        expected = set(flow.metadata.output_columns)
+        assert expected.issubset(set(result.columns)), (
+            f"Missing declared output_columns: {expected - set(result.columns)}"
+        )

--- a/tests/flow/regression/test_flow_regression.py
+++ b/tests/flow/regression/test_flow_regression.py
@@ -46,6 +46,7 @@ def test_flow_runs_without_error(
     dataset = build_seed_dataset(flow)
     flow.set_model_config(model="mock/model", api_key="mock-key")
 
+    flow.dry_run(dataset)
     result = flow.generate(dataset)
 
     assert len(result) > 0, f"Flow produced empty output: {flow_yaml.name}"

--- a/tests/flow/regression/test_flow_regression.py
+++ b/tests/flow/regression/test_flow_regression.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Parametrized regression tests for all shipped flow YAMLs.
+
+Each flow is loaded via ``Flow.from_yaml()``, fed an auto-generated seed
+dataset, and run end-to-end with mocked LLM responses.  The assertions
+verify structural invariants (no crash, rows produced, columns added) --
+not output correctness.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sdg_hub.core.flow.base import Flow
+
+from .conftest import (
+    MockResponseBuilder,
+    build_seed_dataset,
+    discover_flow_yamls,
+    flow_id,
+)
+
+
+@pytest.mark.parametrize(
+    "flow_yaml",
+    discover_flow_yamls(),
+    ids=lambda p: flow_id(p),
+)
+def test_flow_runs_without_error(flow_yaml: Path, mock_litellm: ...) -> None:
+    """Regression: flow loads, generates, and produces non-empty output."""
+    response_map = MockResponseBuilder(flow_yaml).build()
+    mock_litellm(response_map)
+
+    flow = Flow.from_yaml(str(flow_yaml))
+    dataset = build_seed_dataset(flow)
+    flow.set_model_config(model="mock/model", api_key="mock-key")
+
+    result = flow.generate(dataset)
+
+    assert len(result) > 0, f"Flow produced empty output: {flow_yaml.name}"
+    new_cols = set(result.columns) - set(dataset.columns)
+    assert new_cols, f"Flow did not add any columns: {flow_yaml.name}"

--- a/tests/flow/regression/test_flow_regression.py
+++ b/tests/flow/regression/test_flow_regression.py
@@ -24,9 +24,10 @@ from .conftest import (
 )
 
 _DISCOVERED_FLOWS = discover_flow_yamls()
-assert _DISCOVERED_FLOWS, (
-    "No flow YAMLs discovered; check FLOWS_DIR resolution and SKIP_BLOCK_TYPES."
-)
+if not _DISCOVERED_FLOWS:
+    raise RuntimeError(
+        "No flow YAMLs discovered; check FLOWS_DIR resolution and SKIP_BLOCK_TYPES."
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Closes #736 (Phase 1)

- Add parametrized regression test suite that auto-discovers all flow YAMLs and runs them end-to-end with auto-generated mock data
- `MockResponseBuilder` reads each flow's YAML, walks the `LLMChatBlock -> Parser` chain, and generates mock LLM responses that satisfy downstream parsers (TagParser tags, JSONParser schemas, RegexParser patterns, ColumnValueFilter values)
- `build_seed_dataset` auto-generates minimal test datasets from each flow's `dataset_requirements` metadata
- `mock_litellm` fixture patches LLMChatBlock internals with per-block mock responses keyed by `block_name`
- Single parametrized test (~30 lines) that auto-discovers new flows -- adding a flow YAML automatically adds a regression test
- Add missing `DuplicateColumnsBlock` unit tests (used in 8 flows, previously untested)
- 14 LLM-only flows covered across 8 categories; MCP distillation (AgentBlock) and domain code eval (PythonInterpreterBlock) are Phase 2

## Test plan

- [x] 14 parametrized flow regression tests pass (0.5s total)
- [x] 8 DuplicateColumnsBlock unit tests pass
- [x] Full test suite: 977 tests pass with no regressions
- [x] `ruff check` and `ruff format` clean
- [x] `mypy` clean
- [x] All pre-commit hooks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests for duplicate-column behavior: single/multiple mappings, preserving unrelated inputs, non-mutation of inputs, overwrite behavior, and error cases.
  * Added a flow regression suite that auto-discovers flows, builds seed datasets, mocks model responses, and validates generation and declared output columns.
  * Added regression test support utilities and an SPDX license marker.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->