### PR TITLE
fix(examples): fix mcp eval example end-to-end

### DIFF
--- a/examples/agentic/mcp_distillation_evaluation/.gitignore
+++ b/examples/agentic/mcp_distillation_evaluation/.gitignore
@@ -1,0 +1,4 @@
+# Generated at runtime by start_agents.sh
+_langgraph_agent.py
+_agent_configs/
+.langgraph_api/

--- a/examples/agentic/mcp_distillation_evaluation/README.md
+++ b/examples/agentic/mcp_distillation_evaluation/README.md
@@ -46,6 +46,13 @@ Only the underlying LLM changes. This means you're evaluating your full agent st
 | `start_agents.sh` | Start/stop/check LangGraph agents with configurable model support |
 | `.env.example` | Template for API keys and agent URLs |
 
+## Prerequisites
+
+- **[uv](https://docs.astral.sh/uv/)** — sdg_hub uses `uv` for package management.
+  The server startup script installs MCP server dependencies via `uv pip install`.
+- **Node.js + npm** — only needed for the DEX Paprika server
+- **OPENAI_API_KEY** — for the frontier model (generation) and judge (evaluation)
+
 ## Quick start
 
 ```bash

--- a/examples/agentic/mcp_distillation_evaluation/README.md
+++ b/examples/agentic/mcp_distillation_evaluation/README.md
@@ -49,9 +49,14 @@ Only the underlying LLM changes. This means you're evaluating your full agent st
 ## Prerequisites
 
 - **[uv](https://docs.astral.sh/uv/)** — sdg_hub uses `uv` for package management.
-  The server startup script installs MCP server dependencies via `uv pip install`.
+  The startup scripts install dependencies via `uv pip install`.
 - **Node.js + npm** — only needed for the DEX Paprika server
 - **OPENAI_API_KEY** — for the frontier model (generation) and judge (evaluation)
+- **Agent dependencies** — install before starting agents:
+
+  ```bash
+  uv pip install langchain-mcp-adapters langchain-openai langgraph "langgraph-cli[inmem]"
+  ```
 
 ## Quick start
 

--- a/examples/agentic/mcp_distillation_evaluation/README.md
+++ b/examples/agentic/mcp_distillation_evaluation/README.md
@@ -55,8 +55,12 @@ Only the underlying LLM changes. This means you're evaluating your full agent st
 - **Agent dependencies** — install before starting agents:
 
   ```bash
-  uv pip install langchain-mcp-adapters langchain-openai langgraph "langgraph-cli[inmem]"
+  uv pip install "langchain-mcp-adapters>=0.2,<1" "langchain-openai>=1,<2" "langgraph>=1.1,<2" "langgraph-cli[inmem]>=0.4,<1"
   ```
+
+  > **Version note**: The agent script uses `langgraph.prebuilt.create_react_agent`
+  > which is deprecated in langgraph 1.x (replaced by `langchain.agents.create_agent`).
+  > Pin `langgraph<2` until the script is migrated.
 
 ## Quick start
 

--- a/examples/agentic/mcp_distillation_evaluation/start_agents.sh
+++ b/examples/agentic/mcp_distillation_evaluation/start_agents.sh
@@ -87,29 +87,6 @@ MCP_SERVER_NAME = os.environ.get("MCP_SERVER_NAME", "mcp-server")
 MCP_SERVER_URL = os.environ.get("MCP_SERVER_URL", "http://localhost:8001/mcp")
 DEFAULT_MODEL = os.environ.get("DEFAULT_MODEL", "gpt-5.2")
 
-def _get_model(state, config):
-    """Return the LLM, using configurable.model if provided at runtime."""
-    if hasattr(config, "configurable"):
-        configurable = config.configurable or {}
-    elif isinstance(config, dict):
-        configurable = config.get("configurable", {})
-    else:
-        configurable = {}
-    if isinstance(configurable, dict):
-        model_name = configurable.get("model", DEFAULT_MODEL)
-        api_base = configurable.get("api_base", None)
-        api_key = configurable.get("api_key", None)
-    else:
-        model_name = getattr(configurable, "model", DEFAULT_MODEL)
-        api_base = getattr(configurable, "api_base", None)
-        api_key = getattr(configurable, "api_key", None)
-    kwargs = {"model": model_name}
-    if api_base:
-        kwargs["base_url"] = api_base
-    if api_key:
-        kwargs["api_key"] = api_key
-    return ChatOpenAI(**kwargs)
-
 def _create_graph():
     client = MultiServerMCPClient({
         MCP_SERVER_NAME: {"transport": "streamable_http", "url": MCP_SERVER_URL},
@@ -118,7 +95,28 @@ def _create_graph():
     for tool in tools:
         tool.handle_tool_error = True
     print(f"[{MCP_SERVER_NAME}] Loaded {len(tools)} tools from {MCP_SERVER_URL}")
-    return create_react_agent(_get_model, tools)
+
+    def _get_model(state, config):
+        """Return the LLM with tools bound.
+
+        langgraph >=1.1 requires callable models to bind their own tools.
+        """
+        configurable = config.get("configurable", {}) if isinstance(config, dict) else getattr(config, "configurable", {}) or {}
+        model_name = configurable.get("model", DEFAULT_MODEL) if isinstance(configurable, dict) else getattr(configurable, "model", DEFAULT_MODEL)
+        api_base = configurable.get("api_base", None) if isinstance(configurable, dict) else getattr(configurable, "api_base", None)
+        api_key = configurable.get("api_key", None) if isinstance(configurable, dict) else getattr(configurable, "api_key", None)
+        kwargs = {"model": model_name}
+        if api_base:
+            kwargs["base_url"] = api_base
+        if api_key:
+            kwargs["api_key"] = api_key
+        return ChatOpenAI(**kwargs).bind_tools(tools)
+
+    return create_react_agent(
+        _get_model,
+        tools,
+        prompt="You MUST use the available tools to answer every question. Never answer from your own knowledge. Always call at least one tool before responding.",
+    )
 
 graph = _create_graph()
 PYEOF

--- a/examples/agentic/mcp_distillation_evaluation/start_agents.sh
+++ b/examples/agentic/mcp_distillation_evaluation/start_agents.sh
@@ -89,9 +89,20 @@ DEFAULT_MODEL = os.environ.get("DEFAULT_MODEL", "gpt-5.2")
 
 def _get_model(state, config):
     """Return the LLM, using configurable.model if provided at runtime."""
-    model_name = config.get("configurable", {}).get("model", DEFAULT_MODEL)
-    api_base = config.get("configurable", {}).get("api_base", None)
-    api_key = config.get("configurable", {}).get("api_key", None)
+    if hasattr(config, "configurable"):
+        configurable = config.configurable or {}
+    elif isinstance(config, dict):
+        configurable = config.get("configurable", {})
+    else:
+        configurable = {}
+    if isinstance(configurable, dict):
+        model_name = configurable.get("model", DEFAULT_MODEL)
+        api_base = configurable.get("api_base", None)
+        api_key = configurable.get("api_key", None)
+    else:
+        model_name = getattr(configurable, "model", DEFAULT_MODEL)
+        api_base = getattr(configurable, "api_base", None)
+        api_key = getattr(configurable, "api_key", None)
     kwargs = {"model": model_name}
     if api_base:
         kwargs["base_url"] = api_base

--- a/examples/agentic/mcp_distillation_evaluation/start_servers.sh
+++ b/examples/agentic/mcp_distillation_evaluation/start_servers.sh
@@ -87,7 +87,7 @@ fi
 
 # ── Install + Start ──────────────────────────────────────────────────
 echo "Installing shared dependencies..."
-$UV_PIP fastmcp -q 2>&1 | tail -1
+$UV_PIP 'fastmcp<2' -q 2>&1 | tail -1
 
 echo "Installing per-server dependencies..."
 install_failures=0

--- a/examples/agentic/mcp_distillation_evaluation/start_servers.sh
+++ b/examples/agentic/mcp_distillation_evaluation/start_servers.sh
@@ -23,6 +23,9 @@ MCP_SERVERS_DIR="${MCP_BENCH_DIR:-$SCRIPT_DIR/../../mcp-bench}/mcp_servers"
 PROJECT_ROOT="$SCRIPT_DIR/../../.."
 VENV_PYTHON="$PROJECT_ROOT/.venv/bin/python"
 
+# Use uv for installs (the project uses uv-managed venvs which don't bundle pip)
+UV_PIP="uv pip install --python $VENV_PYTHON"
+
 if [[ ! -d "$MCP_SERVERS_DIR" ]]; then
     echo "ERROR: mcp-bench not found at $MCP_SERVERS_DIR"
     echo "Clone it: git clone https://github.com/Accenture/mcp-bench.git $(dirname "$MCP_SERVERS_DIR")"
@@ -36,11 +39,11 @@ fi
 # instance and runs it with streamable-http transport on the given port.
 # The literal PORT is replaced with the actual port number at launch time.
 SERVERS=(
-    "weather-data|8001|weather_mcp|from server import mcp; mcp.settings.host='0.0.0.0'; mcp.settings.port=PORT; mcp.run(transport='streamable-http')|$VENV_PYTHON -m pip install -r requirements.txt -q|Weather Data"
-    "medical-calculator|8002|medcalc|from medcalc.__main__ import mcp; mcp.settings.host='0.0.0.0'; mcp.settings.port=PORT; mcp.run(transport='streamable-http')|$VENV_PYTHON -m pip install -e . -q|Medical Calculator"
-    "wikipedia|8003|wikipedia-mcp|from wikipedia_mcp.server import create_server; s=create_server(); s.settings.host='0.0.0.0'; s.settings.port=PORT; s.run(transport='streamable-http')|$VENV_PYTHON -m pip install -r requirements.txt -q|Wikipedia"
-    "car-price|8004|car-price-mcp-main|from server import mcp; mcp.settings.host='0.0.0.0'; mcp.settings.port=PORT; mcp.run(transport='streamable-http')|$VENV_PYTHON -m pip install -r requirements.txt -q|Car Price Evaluator"
-    "reddit|8005|mcp-reddit|from mcp_reddit.reddit_fetcher import mcp; mcp.settings.host='0.0.0.0'; mcp.settings.port=PORT; mcp.run(transport='streamable-http')|$VENV_PYTHON -m pip install -e . -q|Reddit"
+    "weather-data|8001|weather_mcp|from server import mcp; mcp.settings.host='0.0.0.0'; mcp.settings.port=PORT; mcp.run(transport='streamable-http')|$UV_PIP -r requirements.txt -q|Weather Data"
+    "medical-calculator|8002|medcalc|from medcalc.__main__ import mcp; mcp.settings.host='0.0.0.0'; mcp.settings.port=PORT; mcp.run(transport='streamable-http')|$UV_PIP -e . -q|Medical Calculator"
+    "wikipedia|8003|wikipedia-mcp|from wikipedia_mcp.server import create_server; s=create_server(); s.settings.host='0.0.0.0'; s.settings.port=PORT; s.run(transport='streamable-http')|$UV_PIP -r requirements.txt -q|Wikipedia"
+    "car-price|8004|car-price-mcp-main|from server import mcp; mcp.settings.host='0.0.0.0'; mcp.settings.port=PORT; mcp.run(transport='streamable-http')|$UV_PIP -r requirements.txt -q|Car Price Evaluator"
+    "reddit|8005|mcp-reddit|from mcp_reddit.reddit_fetcher import mcp; mcp.settings.host='0.0.0.0'; mcp.settings.port=PORT; mcp.run(transport='streamable-http')|$UV_PIP -e . -q|Reddit"
     "dex-paprika|8006|dexpaprika-mcp|NODE|npm install -q|DEX Paprika"
 )
 
@@ -84,7 +87,7 @@ fi
 
 # ── Install + Start ──────────────────────────────────────────────────
 echo "Installing shared dependencies..."
-$VENV_PYTHON -m pip install fastmcp -q 2>&1 | tail -1
+$UV_PIP fastmcp -q 2>&1 | tail -1
 
 echo "Installing per-server dependencies..."
 install_failures=0

--- a/examples/agentic/mcp_distillation_evaluation/start_servers.sh
+++ b/examples/agentic/mcp_distillation_evaluation/start_servers.sh
@@ -87,7 +87,7 @@ fi
 
 # ── Install + Start ──────────────────────────────────────────────────
 echo "Installing shared dependencies..."
-$UV_PIP 'fastmcp<2' -q 2>&1 | tail -1
+$UV_PIP 'fastmcp<2' --reinstall-package fastmcp -q 2>&1 | tail -1
 
 echo "Installing per-server dependencies..."
 install_failures=0

--- a/examples/agentic/mcp_distillation_evaluation/start_servers.sh
+++ b/examples/agentic/mcp_distillation_evaluation/start_servers.sh
@@ -83,14 +83,26 @@ if [[ "${1:-}" == "--stop" ]]; then
 fi
 
 # ── Install + Start ──────────────────────────────────────────────────
-echo "Installing dependencies..."
+echo "Installing shared dependencies..."
+$VENV_PYTHON -m pip install fastmcp -q 2>&1 | tail -1
+
+echo "Installing per-server dependencies..."
+install_failures=0
 for entry in "${SERVERS[@]}"; do
     IFS='|' read -r name port cwd cmd install display_name <<< "$entry"
     server_dir="$MCP_SERVERS_DIR/$cwd"
     [[ ! -d "$server_dir" ]] && continue
     echo "  ${display_name:-$name}..."
-    (cd "$server_dir" && eval "$install") 2>&1 | tail -1 || true
+    if ! (cd "$server_dir" && eval "$install") 2>&1; then
+        echo "    WARNING: install failed for ${display_name:-$name}"
+        install_failures=$((install_failures + 1))
+    fi
 done
+
+if [[ $install_failures -gt 0 ]]; then
+    echo ""
+    echo "WARNING: $install_failures server(s) had install failures (see above)"
+fi
 
 echo ""
 echo "Starting servers..."

--- a/examples/agentic/mcp_distillation_evaluation/start_servers.sh
+++ b/examples/agentic/mcp_distillation_evaluation/start_servers.sh
@@ -41,9 +41,9 @@ fi
 SERVERS=(
     "weather-data|8001|weather_mcp|from server import mcp; mcp.settings.host='0.0.0.0'; mcp.settings.port=PORT; mcp.run(transport='streamable-http')|$UV_PIP -r requirements.txt -q|Weather Data"
     "medical-calculator|8002|medcalc|from medcalc.__main__ import mcp; mcp.settings.host='0.0.0.0'; mcp.settings.port=PORT; mcp.run(transport='streamable-http')|$UV_PIP -e . -q|Medical Calculator"
-    "wikipedia|8003|wikipedia-mcp|from wikipedia_mcp.server import create_server; s=create_server(); s.settings.host='0.0.0.0'; s.settings.port=PORT; s.run(transport='streamable-http')|$UV_PIP -r requirements.txt -q|Wikipedia"
+    "wikipedia|8003|wikipedia-mcp|from wikipedia_mcp.server import create_server; s=create_server(); s.run(transport='streamable-http', host='0.0.0.0', port=PORT)|$UV_PIP -r requirements.txt -q|Wikipedia"
     "car-price|8004|car-price-mcp-main|from server import mcp; mcp.settings.host='0.0.0.0'; mcp.settings.port=PORT; mcp.run(transport='streamable-http')|$UV_PIP -r requirements.txt -q|Car Price Evaluator"
-    "reddit|8005|mcp-reddit|from mcp_reddit.reddit_fetcher import mcp; mcp.settings.host='0.0.0.0'; mcp.settings.port=PORT; mcp.run(transport='streamable-http')|$UV_PIP -e . -q|Reddit"
+    "reddit|8005|mcp-reddit|from mcp_reddit.reddit_fetcher import mcp; mcp.run(transport='streamable-http', host='0.0.0.0', port=PORT)|$UV_PIP -e . -q|Reddit"
     "dex-paprika|8006|dexpaprika-mcp|NODE|npm install -q|DEX Paprika"
 )
 
@@ -87,7 +87,7 @@ fi
 
 # ── Install + Start ──────────────────────────────────────────────────
 echo "Installing shared dependencies..."
-$UV_PIP 'fastmcp<2' --reinstall-package fastmcp -q 2>&1 | tail -1
+$UV_PIP fastmcp -q 2>&1 | tail -1
 
 echo "Installing per-server dependencies..."
 install_failures=0


### PR DESCRIPTION
## Summary

Fixes the MCP distillation evaluation example so it works end-to-end with
current dependency versions on a fresh environment.

### Server fixes (`start_servers.sh`)
- Install `fastmcp` as a shared dependency before per-server installs
- Switch from `python -m pip` to `uv pip install` (uv-managed venvs don't bundle pip)
- Use fastmcp 2.x `run()` API for Wikipedia and Reddit servers (pass host/port as
  args instead of via removed `settings` attribute)
- Surface install errors instead of silently swallowing them

### Agent fixes (`start_agents.sh`)
- **Bind tools to the model** — `langgraph >=1.1` no longer auto-binds tools when
  the model is a callable. The `_get_model` function must call `.bind_tools(tools)`
  on the `ChatOpenAI` instance it returns, otherwise the LLM receives zero tool
  schemas and cannot invoke any MCP tools
- Move `_get_model` inside `_create_graph` as a closure so it has access to the
  tools list
- Handle both dict and `Runtime` object for the `config` parameter (langgraph 1.1+
  passes a `Runtime` object instead of a plain dict)
- Add system prompt requiring tool use

### Dependency pinning
- Pin `langgraph>=1.1,<2` — `create_react_agent` is deprecated in 1.x and may be
  removed in 2.x
- Pin `langchain-mcp-adapters>=0.2,<1` — `streamable_http` transport added in 0.2
- Pin `langchain-openai>=1,<2` and `langgraph-cli[inmem]>=0.4,<1`

### Docs & housekeeping
- Add prerequisites section to README with pinned dependency versions
- Add `.gitignore` for runtime-generated files (`_langgraph_agent.py`,
  `_agent_configs/`, `.langgraph_api/`)

## Root cause

The critical bug: `create_react_agent` in `langgraph >=1.1` documents that callable
models must bind their own tools:

> **Dynamic Model Requirements**: Ensure returned models have appropriate tools
> bound via `.bind_tools()`.

The `_get_model` callable returned `ChatOpenAI(**kwargs)` bare — tools were loaded
from MCP at startup (visible in logs as "Loaded 4 tools") but never sent to OpenAI
in the API call (confirmed: 46 prompt tokens = zero tool schemas).

## Test plan

- [x] MCP servers start and respond on ports 8001-8006
- [x] LangGraph agents start, load tools from MCP, and bind them to the model
- [x] Agent invocation returns tool calls (weather: `get_current_weather_tool`,
  wikipedia: search)
- [x] Model swapping via `configurable` works end-to-end
- [x] Judge flow (`Agent Tool-Use Evaluation`) runs successfully
- [x] Full generate → evaluate pipeline completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)