### PR TITLE
docs: add documentation for code interpreter and domain code evaluation flow

### DIFF
--- a/docs/blocks/code-blocks.md
+++ b/docs/blocks/code-blocks.md
@@ -1,0 +1,129 @@
+# Code Blocks
+
+Code blocks execute Python code from dataset rows in sandboxed interpreters and capture structured results. They are designed for validating synthetic code datasets by testing whether generated code runs successfully.
+
+!!! note "Optional dependency"
+    Code blocks require the `code` optional dependency group. Install with:
+    `uv pip install sdg-hub[code]` or `pip install sdg-hub[code]`
+
+---
+
+## PythonInterpreterBlock
+
+Executes Python code stored in a DataFrame column using a sandboxed code interpreter connector. Each row's code is executed independently with configurable timeouts and concurrency. Results are written as structured dicts containing success status, captured output, errors, and execution timing.
+
+The block reads code from a single input column and writes a `CodeExecutionResult` dict to a single output column. It also creates a flat boolean column `{output_col}_success` for convenient downstream filtering (e.g., with `ColumnValueFilterBlock`).
+
+### Configuration
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `block_name` | `str` | required | Unique identifier for this block instance |
+| `input_cols` | `list[str]` | required | Single-element list with the column containing code to execute |
+| `output_cols` | `list[str]` | required | Single-element list with the column name for execution results |
+| `interpreter_framework` | `str` | `"monty"` | Code interpreter connector to use (registered in `ConnectorRegistry`) |
+| `timeout` | `float` | `30.0` | Maximum execution time per code snippet in seconds (must be > 0) |
+| `max_concurrency` | `int` | `10` | Maximum concurrent executions (must be > 0) |
+
+### Input/Output Contract
+
+- **Input:** Exactly one column (`input_cols` must be a single-element list) containing Python code as strings.
+- **Output:** Exactly one column (`output_cols` must be a single-element list) containing `CodeExecutionResult` dicts, plus a flat boolean column `{output_col}_success`.
+
+### Output Format
+
+Each row receives a `CodeExecutionResult` dict in the output column:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `success` | `bool` | Whether the code executed without errors |
+| `output` | `str` or `null` | Captured stdout/print output |
+| `error` | `str` or `null` | Error message if execution failed |
+| `return_value` | `Any` or `null` | Return value from execution |
+| `execution_time_ms` | `float` or `null` | Execution time in milliseconds |
+
+The additional `{output_col}_success` boolean column allows direct use with `ColumnValueFilterBlock` to filter out failed executions without inspecting the result dict.
+
+### Python Example
+
+```python
+from sdg_hub.core.blocks import PythonInterpreterBlock
+import pandas as pd
+
+block = PythonInterpreterBlock(
+    block_name="validate_code",
+    input_cols=["code"],
+    output_cols=["result"],
+    timeout=5.0,
+)
+
+df = pd.DataFrame({
+    "code": [
+        "print('Hello, world!')",
+        "1 / 0",
+        "x = sum(range(10))\nprint(x)",
+    ],
+})
+
+result = block(df)
+
+# Successful execution
+print(result["result"].iloc[0])
+# {'success': True, 'output': 'Hello, world!\n', 'error': None,
+#  'return_value': None, 'execution_time_ms': 1.23}
+
+# Failed execution
+print(result["result"].iloc[1])
+# {'success': False, 'output': None, 'error': 'ZeroDivisionError: ...',
+#  'return_value': None, 'execution_time_ms': 0.45}
+
+# Filter to only successful executions
+print(result["result_success"].tolist())
+# [True, False, True]
+```
+
+### YAML Example
+
+```yaml
+- block_type: PythonInterpreterBlock
+  block_config:
+    block_name: validate_generated_code
+    interpreter_framework: monty
+    input_cols:
+      - generated_code
+    output_cols:
+      - execution_result
+    timeout: 10.0
+    max_concurrency: 5
+```
+
+### Combining with ColumnValueFilterBlock
+
+A common pattern is to execute code and then filter out rows where execution failed:
+
+```yaml
+- block_type: PythonInterpreterBlock
+  block_config:
+    block_name: verify_execution
+    interpreter_framework: monty
+    input_cols:
+      - executable_code
+    output_cols:
+      - execution_result
+    timeout: 10.0
+
+- block_type: ColumnValueFilterBlock
+  block_config:
+    block_name: filter_failed
+    input_cols:
+      - execution_result_success
+    filter_value: true
+    operation: "eq"
+```
+
+### Execution Model
+
+- Code snippets are executed concurrently using `asyncio.Semaphore` with `max_concurrency` controlling the parallelism.
+- Empty, `NaN`, or non-string code values produce an error result without calling the interpreter.
+- The block handles both sync and async event loop contexts automatically via `ThreadPoolExecutor`.
+- Progress is tracked with a `tqdm` progress bar during execution.

--- a/docs/blocks/index.md
+++ b/docs/blocks/index.md
@@ -79,7 +79,7 @@ that execution.
 
 ## Block Categories
 
-SDG Hub ships with blocks organized into six categories. Each category has a
+SDG Hub ships with blocks organized into seven categories. Each category has a
 dedicated documentation page.
 
 | Category | Blocks | Doc Page |
@@ -90,6 +90,7 @@ dedicated documentation page.
 | **filtering** | `ColumnValueFilterBlock` | [Filtering Blocks](filtering-blocks.md) |
 | **agent** | `AgentBlock`, `AgentResponseExtractorBlock` | [Agent Blocks](agent-blocks.md) |
 | **mcp** | `MCPAgentBlock` | [Agent Blocks](agent-blocks.md) |
+| **code** | `PythonInterpreterBlock` | [Code Blocks](code-blocks.md) |
 
 `TextParserBlock` is deprecated -- use `TagParserBlock` or `RegexParserBlock`
 instead.
@@ -260,4 +261,5 @@ class BlockMetadata:
 - [Transform Blocks](transform-blocks.md) -- reshape and manipulate columns
 - [Filtering Blocks](filtering-blocks.md) -- filter rows by column values
 - [Agent Blocks](agent-blocks.md) -- integrate external agent frameworks
+- [Code Blocks](code-blocks.md) -- execute code in sandboxed interpreters
 - [Custom Blocks](custom-blocks.md) -- build your own blocks

--- a/docs/blocks/index.md
+++ b/docs/blocks/index.md
@@ -236,8 +236,8 @@ Returns registered block names. Behavior depends on arguments:
 def categories(cls) -> list[str]:
 ```
 
-Returns a sorted list of all category names (e.g. `["agent", "filtering", "llm",
-"mcp", "parsing", "transform"]`).
+Returns a sorted list of all category names (e.g. `["agent", "code", "filtering",
+"llm", "mcp", "parsing", "transform"]`).
 
 ### `BlockMetadata` dataclass
 

--- a/docs/connectors/index.md
+++ b/docs/connectors/index.md
@@ -1,22 +1,27 @@
 # Connector System
 
-The connector system provides a pluggable interface for communicating with external agent frameworks. Connectors handle request formatting, HTTP transport, response parsing, and error handling for each supported framework.
+The connector system provides a pluggable interface for communicating with external services. There are two connector families:
 
-Connectors are used by `AgentBlock` and `AgentResponseExtractorBlock` to integrate agent frameworks (Langflow, LangGraph, etc.) into data generation pipelines.
+- **Agent connectors** handle request formatting, HTTP transport, response parsing, and error handling for agent frameworks (Langflow, LangGraph, etc.). Used by `AgentBlock` and `AgentResponseExtractorBlock`.
+- **Code interpreter connectors** execute Python code in sandboxed environments and return structured results. Used by `PythonInterpreterBlock`.
 
 ## Architecture Overview
 
-The connector system has four layers:
+The connector system branches into two families under `BaseConnector`:
 
 ```
-ConnectorRegistry          # Discovery and lookup by name
+ConnectorRegistry                    # Discovery and lookup by name
     |
-BaseConnector              # Abstract base with execute() / aexecute()
+BaseConnector                        # Abstract base with execute() / aexecute()
     |
-BaseAgentConnector         # Agent-specific: build_request(), parse_response(), send()
+    +-- BaseAgentConnector           # Agent-specific: build_request(), parse_response(), send()
+    |       |
+    |       +-- LangflowConnector    # Framework-specific implementation
+    |       +-- LangGraphConnector
     |
-LangflowConnector          # Framework-specific implementation
-LangGraphConnector
+    +-- BaseCodeInterpreterConnector # Code execution: execute_code() / aexecute_code()
+            |
+            +-- MontyConnector       # Rust-based sandbox (pydantic-monty)
 ```
 
 All classes are importable from the top-level connectors package:
@@ -32,6 +37,13 @@ from sdg_hub.core.connectors import (
     HttpClient,
     ConnectorError,
     ConnectorHTTPError,
+)
+
+# Code interpreter connectors (requires the [code] extra)
+from sdg_hub.core.connectors.code_interpreter import (
+    BaseCodeInterpreterConnector,
+    CodeExecutionResult,
+    MontyConnector,
 )
 ```
 
@@ -805,5 +817,256 @@ block = AgentBlock(
     agent_api_key="your-api-key",
     input_cols={"messages": "question"},
     output_cols=["response"],
+)
+```
+
+---
+
+## Code Interpreter Connectors
+
+Code interpreter connectors execute Python code in sandboxed environments and return structured `CodeExecutionResult` objects. They are used by `PythonInterpreterBlock` to validate synthetic code datasets.
+
+!!! note "Optional dependency"
+    Code interpreter connectors require the `code` optional dependency group. Install with:
+    `uv pip install sdg-hub[code]` or `pip install sdg-hub[code]`
+
+Source: `src/sdg_hub/core/connectors/code_interpreter/`
+
+### CodeExecutionResult
+
+`CodeExecutionResult` is a Pydantic `BaseModel` that standardizes execution output across all code interpreter backends. It is defined in `src/sdg_hub/core/connectors/code_interpreter/base.py`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `success` | `bool` | Whether the code executed successfully without errors |
+| `output` | `Optional[str]` | Captured stdout/stderr output |
+| `error` | `Optional[str]` | Error message if execution failed |
+| `return_value` | `Any` | Return value from execution |
+| `execution_time_ms` | `Optional[float]` | Execution time in milliseconds |
+
+```python
+from sdg_hub.core.connectors.code_interpreter import CodeExecutionResult
+
+result = CodeExecutionResult(
+    success=True,
+    output="Hello, world!\n",
+    error=None,
+    return_value=42,
+    execution_time_ms=1.23,
+)
+```
+
+### BaseCodeInterpreterConnector
+
+`BaseCodeInterpreterConnector` extends `BaseConnector` with a code execution interface. It is defined in `src/sdg_hub/core/connectors/code_interpreter/base.py`.
+
+#### Abstract Methods
+
+Subclasses must implement:
+
+```python
+@abstractmethod
+def execute_code(
+    self,
+    code: str,
+    inputs: Optional[dict[str, Any]] = None,
+    timeout: Optional[float] = None,
+) -> CodeExecutionResult:
+    """Execute code and return structured result.
+
+    Parameters
+    ----------
+    code : str
+        The Python code to execute.
+    inputs : dict, optional
+        Input variables to make available to the code.
+    timeout : float, optional
+        Maximum execution time in seconds.
+
+    Returns
+    -------
+    CodeExecutionResult
+        Structured result with success status, output, and errors.
+    """
+```
+
+#### Concrete Methods
+
+```python
+async def aexecute_code(
+    self,
+    code: str,
+    inputs: Optional[dict[str, Any]] = None,
+    timeout: Optional[float] = None,
+) -> CodeExecutionResult:
+    """Execute code asynchronously.
+
+    Default implementation wraps execute_code() via asyncio.to_thread().
+    Subclasses should override for native async support.
+    """
+```
+
+The `execute()` and `aexecute()` methods from `BaseConnector` are implemented to delegate to `execute_code()` / `aexecute_code()`, accepting a dict with a `code` key and optional `inputs` and `timeout` keys.
+
+---
+
+### MontyConnector
+
+Registered name: `"monty"`
+
+Source: `src/sdg_hub/core/connectors/code_interpreter/monty.py`
+
+Connector for [Monty](https://github.com/pydantic/monty), a secure Python interpreter from the Pydantic team, implemented in Rust. Provides sandboxed execution with configurable resource limits.
+
+#### Security Model
+
+Monty enforces strict isolation by default:
+
+| Resource | Access |
+|----------|--------|
+| Filesystem | Blocked (no file I/O) |
+| Network | Blocked (no network access) |
+| Environment variables | Blocked |
+| Standard library | Limited subset (`sys`, `typing`, `asyncio`, `json`) |
+| Third-party libraries | Not available |
+| External functions | None registered (pure computation only) |
+
+#### How It Works
+
+MontyConnector captures stdout separately from return values using Monty's `print_callback` parameter. This means `print()` output goes to `result.output`, while the final expression value goes to `result.return_value`.
+
+Resource limits (execution timeout) are configured via `pydantic_monty.ResourceLimits`. The timeout cascades: `PythonInterpreterBlock.timeout` > `ConnectorConfig.timeout` > default (120s).
+
+#### Configuration Example
+
+```python
+from sdg_hub.core.connectors.code_interpreter import MontyConnector
+from sdg_hub.core.connectors import ConnectorConfig
+
+connector = MontyConnector(config=ConnectorConfig())
+
+# Simple execution
+result = connector.execute_code("x = 1 + 1\nprint(x)")
+print(result.success)  # True
+print(result.output)   # "2\n"
+
+# With input variables
+result = connector.execute_code(
+    "result = x + y\nprint(result)",
+    inputs={"x": 10, "y": 20},
+)
+print(result.output)  # "30\n"
+
+# Async execution (native, not thread-wrapped)
+import asyncio
+
+async def main():
+    result = await connector.aexecute_code("print('async!')")
+    print(result.output)  # "async!\n"
+
+asyncio.run(main())
+```
+
+#### YAML Usage (via PythonInterpreterBlock)
+
+MontyConnector is used indirectly through `PythonInterpreterBlock`:
+
+```yaml
+- block_type: PythonInterpreterBlock
+  block_config:
+    block_name: validate_code
+    interpreter_framework: monty
+    input_cols:
+      - generated_code
+    output_cols:
+      - execution_result
+    timeout: 10.0
+```
+
+---
+
+### Creating Custom Code Interpreter Connectors
+
+To add a new code interpreter backend:
+
+1. Create a new file in `src/sdg_hub/core/connectors/code_interpreter/`.
+2. Inherit from `BaseCodeInterpreterConnector`.
+3. Implement `execute_code()`.
+4. Optionally override `aexecute_code()` for native async support.
+5. Register with `@ConnectorRegistry.register("name")`.
+
+#### Complete Example
+
+```python
+# src/sdg_hub/core/connectors/code_interpreter/my_interpreter.py
+
+import time
+from typing import Any, Optional
+
+from sdg_hub.core.connectors.code_interpreter import (
+    BaseCodeInterpreterConnector,
+    CodeExecutionResult,
+)
+from sdg_hub.core.connectors import ConnectorConfig, ConnectorRegistry
+
+from pydantic import Field
+
+
+@ConnectorRegistry.register("my_interpreter")
+class MyInterpreterConnector(BaseCodeInterpreterConnector):
+    """Connector for a custom Python interpreter."""
+
+    config: ConnectorConfig = Field(
+        default_factory=lambda: ConnectorConfig(),
+        description="Connector configuration",
+    )
+
+    def execute_code(
+        self,
+        code: str,
+        inputs: Optional[dict[str, Any]] = None,
+        timeout: Optional[float] = None,
+    ) -> CodeExecutionResult:
+        """Execute code in the custom interpreter."""
+        start = time.perf_counter()
+        try:
+            # Your execution logic here
+            exec_globals = dict(inputs) if inputs else {}
+            exec(code, exec_globals)
+            elapsed = (time.perf_counter() - start) * 1000
+            return CodeExecutionResult(
+                success=True,
+                output=None,
+                error=None,
+                return_value=None,
+                execution_time_ms=elapsed,
+            )
+        except Exception as e:
+            elapsed = (time.perf_counter() - start) * 1000
+            return CodeExecutionResult(
+                success=False,
+                output=None,
+                error=str(e),
+                return_value=None,
+                execution_time_ms=elapsed,
+            )
+```
+
+After creating the file, add the import to `src/sdg_hub/core/connectors/code_interpreter/__init__.py`:
+
+```python
+from .my_interpreter import MyInterpreterConnector
+```
+
+The connector is then usable in `PythonInterpreterBlock`:
+
+```python
+from sdg_hub.core.blocks import PythonInterpreterBlock
+
+block = PythonInterpreterBlock(
+    block_name="validate_code",
+    interpreter_framework="my_interpreter",
+    input_cols=["code"],
+    output_cols=["result"],
 )
 ```

--- a/docs/connectors/index.md
+++ b/docs/connectors/index.md
@@ -1030,13 +1030,13 @@ class MyInterpreterConnector(BaseCodeInterpreterConnector):
         """Execute code in the custom interpreter."""
         start = time.perf_counter()
         try:
-            # Your execution logic here
-            exec_globals = dict(inputs) if inputs else {}
-            exec(code, exec_globals)
+            # Delegate to a sandboxed runtime (container, subprocess, etc.).
+            # Do NOT use raw exec() for untrusted code.
+            output = self._run_in_sandbox(code, inputs, timeout)
             elapsed = (time.perf_counter() - start) * 1000
             return CodeExecutionResult(
                 success=True,
-                output=None,
+                output=output,
                 error=None,
                 return_value=None,
                 execution_time_ms=elapsed,
@@ -1050,6 +1050,19 @@ class MyInterpreterConnector(BaseCodeInterpreterConnector):
                 return_value=None,
                 execution_time_ms=elapsed,
             )
+
+    def _run_in_sandbox(
+        self,
+        code: str,
+        inputs: Optional[dict[str, Any]] = None,
+        timeout: Optional[float] = None,
+    ) -> str:
+        """Execute code in an isolated sandbox.
+
+        Replace this with your sandbox backend (e.g. subprocess, container,
+        or remote execution service).
+        """
+        raise NotImplementedError("Implement your sandbox backend here")
 ```
 
 After creating the file, add the import to `src/sdg_hub/core/connectors/code_interpreter/__init__.py`:

--- a/docs/flows/built-in-flows.md
+++ b/docs/flows/built-in-flows.md
@@ -27,6 +27,7 @@ flow = Flow.from_yaml(flow_path)
 | text_analysis | Structured Text Insights Extraction | `green-clay-812` | openai/gpt-oss-120b | text |
 | red_team | Red Teaming Prompt Generation | `major-sage-742` | IlyaGusev/gemma-2-9b-it-abliterated | policy_concept, concept_definition |
 | agentic | MCP Server Distillation | `new-night-835` | openai/gpt-5.2 | tool_list, mcp_server_name, mcp_server_description |
+| code_evaluation | Domain Code Evaluation Benchmark Generator | `domain-code-eval` | gpt-5.1-codex-mini | domain, function_spec, difficulty, time_complexity |
 | evaluation | RAG Evaluation Dataset | `loud-dawn-245` | openai/gpt-oss-120b | document, document_outline |
 | evaluation | Agent Tool-Use Evaluation | `eager-path-837` | openai/gpt-4o | question, expert_answer_truncated, expert_trace_formatted, model_answer, model_trace_formatted |
 
@@ -316,6 +317,122 @@ seed = Dataset.from_dict({
 
 result = flow.generate(seed, max_concurrency=10)
 ```
+
+---
+
+## Code Evaluation Flows
+
+### Domain Code Evaluation Benchmark Generator (domain-code-eval)
+
+Location: `src/sdg_hub/flows/code_evaluation/domain_code_eval/`
+
+Generates execution-verified coding benchmarks for custom domains. Inspired by
+[AutoCodeBench](https://arxiv.org/abs/2503.08013) (Tencent, 2025) and
+[CRUXEval](https://arxiv.org/abs/2401.03065) (Meta, 2024), this flow generates
+domain-specific Python functions, verifies them via sandboxed execution, and
+reverse-generates problem descriptions. The output is a ready-to-use evaluation
+benchmark where every solution and test suite is execution-verified.
+
+!!! note "Optional dependency"
+    This flow uses `PythonInterpreterBlock`, which requires the `code` optional
+    dependency group: `uv pip install sdg-hub[code]` or `pip install sdg-hub[code]`
+
+Default model: `gpt-5.1-codex-mini`
+
+Compatible models: `openai/gpt-5.1-codex-mini`,
+`meta-llama/Llama-3.3-70B-Instruct`, `Qwen/Qwen2.5-Coder-32B-Instruct`
+
+Required columns: `domain`, `function_spec`, `difficulty`, `time_complexity`
+
+Output columns: `function_code`, `test_code`, `input_generator`,
+`problem_description`, `execution_result`, `execution_result_success`
+
+Tags: `code-evaluation`, `benchmark-generation`, `code-verification`,
+`domain-specific`, `synthetic-data`
+
+#### 4-Phase Pipeline
+
+```
+Phase 1: Generate Function
+  PromptBuilderBlock → LLMChatBlock → LLMResponseExtractorBlock → TagParserBlock
+  Input: domain, function_spec, difficulty, time_complexity
+  Output: function_code
+
+Phase 2: Generate Test Suite
+  PromptBuilderBlock → LLMChatBlock → LLMResponseExtractorBlock → TagParserBlock × 2
+  Input: function_code, domain
+  Output: test_code, input_generator
+
+Phase 3: Verify via Execution
+  TextConcatBlock → PythonInterpreterBlock → ColumnValueFilterBlock
+  Input: function_code + test_code → executable_code
+  Output: execution_result (rows where execution failed are filtered out)
+
+Phase 4: Reverse Problem Generation
+  PromptBuilderBlock → LLMChatBlock → LLMResponseExtractorBlock → TagParserBlock
+  Input: function_code, test_code, domain, time_complexity
+  Output: problem_description
+```
+
+**Phase 1** generates a domain-specific Python function based on the spec and
+constraints. The prompt enforces sandbox-safe code: no imports, no I/O, no
+randomness, JSON-serializable return values.
+
+**Phase 2** generates a test suite (`test()` function with assertions) and an
+input generator (`generate_input(n)` function) for the generated function.
+
+**Phase 3** combines the function and tests into a single executable script,
+runs it in the Monty sandbox, and filters out rows where execution failed.
+This ensures every benchmark entry in the output is verified.
+
+**Phase 4** reverse-generates a problem description from the verified function
+and tests, producing a natural-language problem statement that does not reveal
+the implementation.
+
+#### Usage Example
+
+```python
+from datasets import Dataset
+from sdg_hub import Flow
+from sdg_hub import FlowRegistry
+
+FlowRegistry.discover_flows()
+flow = Flow.from_yaml(
+    FlowRegistry.get_flow_path_safe("domain-code-eval")
+)
+
+flow.set_model_config(
+    model="openai/gpt-5.1-codex-mini",
+    api_key="your-key",
+)
+
+dataset = Dataset.from_dict({
+    "domain": ["financial calculations"],
+    "function_spec": ["Calculate compound interest given principal, rate, and time"],
+    "difficulty": ["intermediate"],
+    "time_complexity": ["O(1)"],
+})
+
+result = flow.generate(dataset, max_concurrency=5)
+# result contains only rows where execution verification passed
+```
+
+#### Input Column Requirements
+
+| Column | Description | Example |
+|--------|-------------|---------|
+| `domain` | Problem domain | `"financial calculations"` |
+| `function_spec` | What the function should do | `"Calculate compound interest"` |
+| `difficulty` | Difficulty level | `"beginner"`, `"intermediate"`, `"advanced"` |
+| `time_complexity` | Expected time complexity | `"O(1)"`, `"O(n)"`, `"O(n log n)"` |
+
+#### Example Notebooks
+
+Two example notebooks are available under `examples/code_interpreter/`:
+
+- `domain_code_eval.ipynb` -- end-to-end benchmark generation
+- `model_evaluation.ipynb` -- LeetCode-style model evaluation with timing
+  verification
 
 ---
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -46,6 +46,24 @@ pip install sdg-hub[examples]
 uv pip install sdg-hub[examples]
 ```
 
+### code
+
+Dependencies for code execution blocks (`PythonInterpreterBlock`) and the domain-code-eval flow. Required when using code interpreter connectors for sandboxed Python execution.
+
+Includes: pydantic-monty.
+
+**pip:**
+
+```bash
+pip install sdg-hub[code]
+```
+
+**uv:**
+
+```bash
+uv pip install sdg-hub[code]
+```
+
 ### integration
 
 Minimal dependencies for integration testing.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,6 +61,7 @@ plugins:
           - blocks/transform-blocks.md
           - blocks/filtering-blocks.md
           - blocks/agent-blocks.md
+          - blocks/code-blocks.md
           - blocks/custom-blocks.md
         Flows:
           - flows/index.md
@@ -104,6 +105,7 @@ nav:
     - Transform Blocks: blocks/transform-blocks.md
     - Filtering Blocks: blocks/filtering-blocks.md
     - Agent Blocks: blocks/agent-blocks.md
+    - Code Blocks: blocks/code-blocks.md
     - Custom Blocks: blocks/custom-blocks.md
   - Flows:
     - Overview: flows/index.md


### PR DESCRIPTION
Closes #719

## Summary

- New `docs/blocks/code-blocks.md` page documenting `PythonInterpreterBlock`
- Updated `docs/connectors/index.md` with `BaseCodeInterpreterConnector`, `MontyConnector`, and custom connector guide
- Updated `docs/flows/built-in-flows.md` with domain-code-eval flow section
- Updated `docs/installation.md` with `[code]` optional dependency group
- Updated `mkdocs.yml` navigation

## Test plan

- [ ] Verify markdownlint passes
- [ ] Verify mkdocs builds successfully
- [ ] Review rendered pages for accuracy

Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Code Blocks docs: configuration, execution model, result schema, and examples (Python/YAML)
  * Added a new "Code" block category and linked Code Blocks in navigation
  * Documented domain-code-eval built-in flow for execution-verified benchmark generation
  * Expanded connector docs with code interpreter connector behavior and registration guidance
  * Updated installation notes with new optional "code" dependency requirements
<!-- end of auto-generated comment: release notes by coderabbit.ai -->