### PR TITLE
feat(flows): add chatbot evaluation flows and context extraction support

### DIFF
--- a/src/sdg_hub/core/connectors/agent/generic_http.py
+++ b/src/sdg_hub/core/connectors/agent/generic_http.py
@@ -2,6 +2,7 @@
 """Generic HTTP agent connector for arbitrary REST chat endpoints."""
 
 from typing import Any, Optional
+import json
 
 from pydantic import Field, field_validator
 
@@ -223,7 +224,12 @@ class GenericHTTPConnector(BaseAgentConnector):
         if self.response_context_path:
             context = _get_nested(parsed, self.response_context_path)
             if context is not None:
-                parsed["_extracted_context"] = str(context)
+                if isinstance(context, (dict, list)):
+                    parsed["_extracted_context"] = json.dumps(
+                        context, ensure_ascii=False
+                    )
+                else:
+                    parsed["_extracted_context"] = str(context)
 
         return parsed
 

--- a/src/sdg_hub/core/connectors/agent/generic_http.py
+++ b/src/sdg_hub/core/connectors/agent/generic_http.py
@@ -99,12 +99,20 @@ class GenericHTTPConnector(BaseAgentConnector):
         None,
         description="Dot-notation path where session ID is placed in the request body.",
     )
+    response_context_path: Optional[str] = Field(
+        None,
+        description=(
+            "Dot-notation path to extract retrieved context from the response "
+            "(e.g., 'output.context'). Useful for RAG evaluation."
+        ),
+    )
 
     @field_validator(
         "request_message_path",
         "response_text_path",
         "request_session_id_path",
         "response_session_id_path",
+        "response_context_path",
     )
     @classmethod
     def validate_path_format(cls, v: str | None) -> str | None:
@@ -183,7 +191,7 @@ class GenericHTTPConnector(BaseAgentConnector):
         -------
         dict
             Response dict with ``_extracted_text`` (and optionally
-            ``_extracted_session_id``) injected.
+            ``_extracted_session_id`` and ``_extracted_context``) injected.
 
         Raises
         ------
@@ -201,6 +209,7 @@ class GenericHTTPConnector(BaseAgentConnector):
         # Remove reserved keys so upstream values can't leak through
         parsed.pop("_extracted_text", None)
         parsed.pop("_extracted_session_id", None)
+        parsed.pop("_extracted_context", None)
 
         text = _get_nested(parsed, self.response_text_path)
         if text is not None:
@@ -210,6 +219,11 @@ class GenericHTTPConnector(BaseAgentConnector):
             session_id = _get_nested(parsed, self.response_session_id_path)
             if session_id is not None:
                 parsed["_extracted_session_id"] = str(session_id)
+
+        if self.response_context_path:
+            context = _get_nested(parsed, self.response_context_path)
+            if context is not None:
+                parsed["_extracted_context"] = str(context)
 
         return parsed
 

--- a/src/sdg_hub/flows/evaluation/chatbot_benchmark/flow.yaml
+++ b/src/sdg_hub/flows/evaluation/chatbot_benchmark/flow.yaml
@@ -28,7 +28,7 @@ blocks:
   block_config:
     block_name: send_to_chatbot
     agent_framework: generic_http
-    agent_url: http://localhost:8000/api/chat
+    agent_url: http://chatbot.example.com/api/chat
     input_cols:
     - question
     output_cols:

--- a/src/sdg_hub/flows/evaluation/chatbot_benchmark/flow.yaml
+++ b/src/sdg_hub/flows/evaluation/chatbot_benchmark/flow.yaml
@@ -1,0 +1,84 @@
+metadata:
+  name: Chatbot Benchmark
+  description: Evaluates a live chatbot endpoint by sending questions, collecting responses, and scoring them against expected answers using LLM-as-judge. Scores correctness, faithfulness, context recall, and relevance. Works with any REST chat
+    endpoint via the generic_http connector. Use the RAG Evaluation flow to generate the input dataset.
+  version: 1.0.0
+  author: SDG Hub Contributors
+  license: Apache-2.0
+  recommended_models:
+    default: openai/gpt-4o
+    compatible:
+    - openai/gpt-5-mini
+    - meta-llama/Llama-3.3-70B-Instruct
+  tags:
+  - evaluation
+  - chatbot
+  - rag
+  - llm-as-judge
+  - benchmark
+  dataset_requirements:
+    required_columns:
+    - question
+    - expected_answer
+    - ground_truth_context
+    description: Input dataset with questions, expected answers, and ground truth context. Use one of the RAG Evaluation flows to generate this dataset from your documents.
+  id: short-field-718
+blocks:
+- block_type: AgentBlock
+  block_config:
+    block_name: send_to_chatbot
+    agent_framework: generic_http
+    agent_url: http://localhost:8000/api/chat
+    input_cols:
+    - question
+    output_cols:
+    - chatbot_raw_response
+    connector_kwargs:
+      request_message_path: input.query
+      response_text_path: output.result
+      response_context_path: output.context
+- block_type: AgentResponseExtractorBlock
+  block_config:
+    block_name: extract_chatbot_answer
+    agent_framework: generic_http
+    input_cols: chatbot_raw_response
+    extract_text: true
+    field_prefix: chatbot_
+- block_type: PromptBuilderBlock
+  block_config:
+    block_name: build_judge_prompt
+    input_cols:
+      question: question
+      expected_answer: expected_answer
+      chatbot_text: chatbot_response
+      chatbot_raw_response: chatbot_context
+      ground_truth_context: ground_truth_context
+    output_cols: judge_messages
+    prompt_config_path: prompts/judge.yaml
+- block_type: LLMChatBlock
+  block_config:
+    block_name: run_judge
+    input_cols: judge_messages
+    output_cols: judge_response
+    async_mode: true
+    temperature: 0.0
+    max_tokens: 1024
+    response_format:
+      type: json_object
+- block_type: LLMResponseExtractorBlock
+  block_config:
+    block_name: extract_judge
+    input_cols: judge_response
+    field_prefix: judge_
+    extract_content: true
+- block_type: JSONParserBlock
+  block_config:
+    block_name: parse_judge_scores
+    input_cols: judge_content
+    output_cols:
+    - correctness
+    - faithfulness
+    - context_recall
+    - relevance
+    - rationale
+    expand_fields: true

--- a/src/sdg_hub/flows/evaluation/chatbot_benchmark/prompts/judge.yaml
+++ b/src/sdg_hub/flows/evaluation/chatbot_benchmark/prompts/judge.yaml
@@ -1,0 +1,67 @@
+- role: system
+  content: |
+    You are an expert evaluator for RAG-based conversational AI systems. Score the
+    chatbot's response strictly and objectively across multiple dimensions.
+
+    ## Scoring Rubric
+
+    Scores use a 1-10 scale:
+    - **9-10**: Excellent. Near-perfect performance on this dimension.
+    - **7-8**: Good. Minor issues only.
+    - **5-6**: Partial. Notable gaps or inaccuracies.
+    - **3-4**: Poor. Significant problems.
+    - **1-2**: Failed. Fundamentally incorrect or missing.
+
+    ## Calibration
+    - Do NOT inflate scores for verbose but inaccurate responses.
+    - Chatbots may have a system prompt that adds structure, formatting, or
+      boilerplate to their responses. Judge based on the factual content about
+      the topic itself, not on presentation style or static elements added by
+      the system prompt.
+    - Do NOT penalize responses for including additional correct information
+      beyond what the expected answer contains.
+
+- role: user
+  content: |
+    Evaluate the chatbot's response.
+
+    ## Question
+    {{question}}
+
+    ## Expected Answer
+    {{expected_answer}}
+
+    ## Chatbot Response
+    {{chatbot_response}}
+
+    ## Chatbot Retrieved Context
+    {{chatbot_context._extracted_context}}
+
+    ## Ground Truth Context
+    {{ground_truth_context}}
+
+    ---
+
+    Score the chatbot on these 4 dimensions (1-10 each):
+
+    1. **correctness**: Does the chatbot's response contain the key facts from
+       the expected answer? Is the information factually accurate?
+    2. **faithfulness**: Are the factual claims about the topic in the chatbot's
+       response grounded in the context it retrieved? Is the chatbot hallucinating
+       information not present in its context?
+    3. **context_recall**: Does the chatbot's retrieved context cover the same
+       key information as the ground truth context? Did the retriever find the
+       right documents?
+    4. **relevance**: Does the response directly address the question asked?
+
+    Respond with JSON only:
+
+    ```json
+    {
+      "correctness": <1-10>,
+      "faithfulness": <1-10>,
+      "context_recall": <1-10>,
+      "relevance": <1-10>,
+      "rationale": "Brief explanation referencing specific findings for each dimension."
+    }
+    ```

--- a/src/sdg_hub/flows/evaluation/chatbot_quality_check/flow.yaml
+++ b/src/sdg_hub/flows/evaluation/chatbot_quality_check/flow.yaml
@@ -1,0 +1,78 @@
+metadata:
+  name: Chatbot Quality Check
+  description: "Evaluates a live chatbot endpoint for faithfulness and relevance using LLM-as-judge. Requires only questions as input \u2014 no expected answers or ground truth context needed. Ideal for CI deployment gates to catch hallucination\
+    \ and retrieval regressions."
+  version: 1.0.0
+  author: SDG Hub Contributors
+  license: Apache-2.0
+  recommended_models:
+    default: openai/gpt-4o
+    compatible:
+    - openai/gpt-5-mini
+    - meta-llama/Llama-3.3-70B-Instruct
+  tags:
+  - evaluation
+  - chatbot
+  - rag
+  - llm-as-judge
+  - ci
+  dataset_requirements:
+    required_columns:
+    - question
+    description: Input dataset with questions to send to the chatbot.
+  id: safe-iris-41
+blocks:
+- block_type: AgentBlock
+  block_config:
+    block_name: send_to_chatbot
+    agent_framework: generic_http
+    agent_url: http://localhost:8000/api/chat
+    input_cols:
+    - question
+    output_cols:
+    - chatbot_raw_response
+    connector_kwargs:
+      request_message_path: input.query
+      response_text_path: output.result
+      response_context_path: output.context
+- block_type: AgentResponseExtractorBlock
+  block_config:
+    block_name: extract_chatbot_answer
+    agent_framework: generic_http
+    input_cols: chatbot_raw_response
+    extract_text: true
+    field_prefix: chatbot_
+- block_type: PromptBuilderBlock
+  block_config:
+    block_name: build_judge_prompt
+    input_cols:
+      question: question
+      chatbot_text: chatbot_response
+      chatbot_raw_response: chatbot_context
+    output_cols: judge_messages
+    prompt_config_path: prompts/judge.yaml
+- block_type: LLMChatBlock
+  block_config:
+    block_name: run_judge
+    input_cols: judge_messages
+    output_cols: judge_response
+    async_mode: true
+    temperature: 0.0
+    max_tokens: 1024
+    response_format:
+      type: json_object
+- block_type: LLMResponseExtractorBlock
+  block_config:
+    block_name: extract_judge
+    input_cols: judge_response
+    field_prefix: judge_
+    extract_content: true
+- block_type: JSONParserBlock
+  block_config:
+    block_name: parse_judge_scores
+    input_cols: judge_content
+    output_cols:
+    - faithfulness
+    - relevance
+    - rationale
+    expand_fields: true

--- a/src/sdg_hub/flows/evaluation/chatbot_quality_check/flow.yaml
+++ b/src/sdg_hub/flows/evaluation/chatbot_quality_check/flow.yaml
@@ -26,7 +26,7 @@ blocks:
   block_config:
     block_name: send_to_chatbot
     agent_framework: generic_http
-    agent_url: http://localhost:8000/api/chat
+    agent_url: http://chatbot.example.com/api/chat
     input_cols:
     - question
     output_cols:

--- a/src/sdg_hub/flows/evaluation/chatbot_quality_check/prompts/judge.yaml
+++ b/src/sdg_hub/flows/evaluation/chatbot_quality_check/prompts/judge.yaml
@@ -1,0 +1,52 @@
+- role: system
+  content: |
+    You are an expert evaluator for RAG-based conversational AI systems. Score the
+    chatbot's response strictly and objectively.
+
+    ## Scoring Rubric
+
+    Scores use a 1-10 scale:
+    - **9-10**: Excellent. Near-perfect performance on this dimension.
+    - **7-8**: Good. Minor issues only.
+    - **5-6**: Partial. Notable gaps or inaccuracies.
+    - **3-4**: Poor. Significant problems.
+    - **1-2**: Failed. Fundamentally incorrect or missing.
+
+    ## Calibration
+    - Do NOT inflate scores for verbose but inaccurate responses.
+    - Chatbots may have a system prompt that adds structure, formatting, or
+      boilerplate to their responses. Judge based on the factual content about
+      the topic itself, not on presentation style or static elements added by
+      the system prompt.
+
+- role: user
+  content: |
+    Evaluate the chatbot's response.
+
+    ## Question
+    {{question}}
+
+    ## Chatbot Response
+    {{chatbot_response}}
+
+    ## Chatbot Retrieved Context
+    {{chatbot_context._extracted_context}}
+
+    ---
+
+    Score the chatbot on these 2 dimensions (1-10 each):
+
+    1. **faithfulness**: Are the factual claims about the topic in the chatbot's
+       response grounded in the context it retrieved? Is the chatbot hallucinating
+       information not present in its context?
+    2. **relevance**: Does the response directly address the question asked?
+
+    Respond with JSON only:
+
+    ```json
+    {
+      "faithfulness": <1-10>,
+      "relevance": <1-10>,
+      "rationale": "Brief explanation referencing specific findings for each dimension."
+    }
+    ```

--- a/tests/connectors/agent/test_generic_http.py
+++ b/tests/connectors/agent/test_generic_http.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for GenericHTTPConnector."""
 
+import json
+
 import pytest
 
 from sdg_hub.core.connectors.agent.generic_http import (
@@ -234,27 +236,44 @@ class TestGenericHTTPConnector:
         assert parsed["_extracted_text"] == "hi"
         assert parsed["_extracted_session_id"] == "s-1"
 
-    def test_parse_response_extracts_context(self):
-        """Test parse_response extracts context as string."""
+    def test_parse_response_extracts_context_as_json(self):
+        """Test parse_response extracts list context as JSON string."""
         connector = self._make_connector(
             response_context_path="output.context",
         )
         response = {
             "output": {
                 "answer": "hello",
-                "context": [{"page_content": "doc1"}, {"page_content": "doc2"}],
+                "context": [{"text": "doc1"}, {"text": "doc2"}],
             }
         }
         parsed = connector.parse_response(response)
 
         assert parsed["_extracted_text"] == "hello"
-        assert "_extracted_context" in parsed
-        assert "page_content" in parsed["_extracted_context"]
+        ctx = json.loads(parsed["_extracted_context"])
+        assert isinstance(ctx, list)
+        assert len(ctx) == 2
+        assert ctx[0]["text"] == "doc1"
+
+    def test_parse_response_extracts_context_non_list(self):
+        """Test parse_response extracts non-list context as string."""
+        connector = self._make_connector(
+            response_context_path="output.context",
+        )
+        response = {
+            "output": {
+                "answer": "hello",
+                "context": "plain text context",
+            }
+        }
+        parsed = connector.parse_response(response)
+
+        assert parsed["_extracted_context"] == "plain text context"
 
     def test_parse_response_no_context_without_path(self):
         """Test parse_response does not extract context when path is not configured."""
         connector = self._make_connector()
-        response = {"output": {"answer": "hello", "context": [{"page_content": "doc"}]}}
+        response = {"output": {"answer": "hello", "context": [{"text": "doc"}]}}
         parsed = connector.parse_response(response)
 
         assert "_extracted_context" not in parsed

--- a/tests/connectors/agent/test_generic_http.py
+++ b/tests/connectors/agent/test_generic_http.py
@@ -234,18 +234,45 @@ class TestGenericHTTPConnector:
         assert parsed["_extracted_text"] == "hi"
         assert parsed["_extracted_session_id"] == "s-1"
 
+    def test_parse_response_extracts_context(self):
+        """Test parse_response extracts context as string."""
+        connector = self._make_connector(
+            response_context_path="output.context",
+        )
+        response = {
+            "output": {
+                "answer": "hello",
+                "context": [{"page_content": "doc1"}, {"page_content": "doc2"}],
+            }
+        }
+        parsed = connector.parse_response(response)
+
+        assert parsed["_extracted_text"] == "hello"
+        assert "_extracted_context" in parsed
+        assert "page_content" in parsed["_extracted_context"]
+
+    def test_parse_response_no_context_without_path(self):
+        """Test parse_response does not extract context when path is not configured."""
+        connector = self._make_connector()
+        response = {"output": {"answer": "hello", "context": [{"page_content": "doc"}]}}
+        parsed = connector.parse_response(response)
+
+        assert "_extracted_context" not in parsed
+
     def test_parse_response_strips_upstream_reserved_keys(self):
-        """Test that upstream _extracted_text/_extracted_session_id are stripped."""
+        """Test that upstream reserved keys are stripped."""
         connector = self._make_connector()
         response = {
             "output": {"answer": "real"},
             "_extracted_text": "spoofed",
             "_extracted_session_id": "spoofed-sid",
+            "_extracted_context": "spoofed-ctx",
         }
         parsed = connector.parse_response(response)
 
         assert parsed["_extracted_text"] == "real"
         assert "_extracted_session_id" not in parsed
+        assert "_extracted_context" not in parsed
 
     def test_parse_response_non_dict_raises(self):
         """Test non-dict raises error."""

--- a/tests/connectors/agent/test_generic_http.py
+++ b/tests/connectors/agent/test_generic_http.py
@@ -270,6 +270,33 @@ class TestGenericHTTPConnector:
 
         assert parsed["_extracted_context"] == "plain text context"
 
+    def test_parse_response_context_as_dict(self):
+        """Test parse_response extracts dict context as JSON string."""
+        connector = self._make_connector(
+            response_context_path="output.context",
+        )
+        response = {
+            "output": {
+                "answer": "hello",
+                "context": {"id": "d1", "text": "single doc"},
+            }
+        }
+        parsed = connector.parse_response(response)
+
+        ctx = json.loads(parsed["_extracted_context"])
+        assert isinstance(ctx, dict)
+        assert ctx["text"] == "single doc"
+
+    def test_parse_response_context_path_missing(self):
+        """Test parse_response skips context when configured path is missing."""
+        connector = self._make_connector(
+            response_context_path="output.context",
+        )
+        response = {"output": {"answer": "hello"}}
+        parsed = connector.parse_response(response)
+
+        assert "_extracted_context" not in parsed
+
     def test_parse_response_no_context_without_path(self):
         """Test parse_response does not extract context when path is not configured."""
         connector = self._make_connector()

--- a/tests/integration/evaluation/test_chatbot_benchmark.py
+++ b/tests/integration/evaluation/test_chatbot_benchmark.py
@@ -1,0 +1,199 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the Chatbot Benchmark flow."""
+
+# Standard
+from pathlib import Path
+
+# Third Party
+import pytest
+import yaml
+
+# First Party
+from sdg_hub import Flow, FlowRegistry, FlowValidator
+
+
+def _find_repo_root() -> Path:
+    """Find repository root by locating pyproject.toml."""
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        if (current / "pyproject.toml").exists():
+            return current
+        current = current.parent
+    raise RuntimeError("Could not find repository root")
+
+
+FLOW_DIR = (
+    _find_repo_root() / "src" / "sdg_hub" / "flows" / "evaluation" / "chatbot_benchmark"
+)
+FLOW_YAML = FLOW_DIR / "flow.yaml"
+
+EXPECTED_BLOCK_NAMES = [
+    "send_to_chatbot",
+    "extract_chatbot_answer",
+    "build_judge_prompt",
+    "run_judge",
+    "extract_judge",
+    "parse_judge_scores",
+]
+
+
+@pytest.fixture()
+def clean_registry():
+    """Reset FlowRegistry to clean state for test isolation."""
+    original_entries = FlowRegistry._entries.copy()
+    original_paths = FlowRegistry._search_paths.copy()
+    original_init = FlowRegistry._initialized
+
+    FlowRegistry._entries.clear()
+    FlowRegistry._search_paths.clear()
+    FlowRegistry._initialized = False
+
+    flows_dir = str(FLOW_DIR.parents[1])
+    FlowRegistry.register_search_path(flows_dir)
+    FlowRegistry._discover_flows(force_refresh=True)
+
+    yield
+
+    FlowRegistry._entries = original_entries
+    FlowRegistry._search_paths = original_paths
+    FlowRegistry._initialized = original_init
+
+
+class TestChatbotBenchmarkFlowStructure:
+    """Test the Chatbot Benchmark flow YAML structure and configuration."""
+
+    def test_flow_yaml_exists(self):
+        """Test that the flow YAML file exists."""
+        assert FLOW_YAML.exists(), f"Flow YAML not found at {FLOW_YAML}"
+
+    def test_flow_loads_successfully(self):
+        """Test that the flow loads from YAML without errors."""
+        flow = Flow.from_yaml(str(FLOW_YAML))
+        assert flow is not None
+        assert flow.metadata.name == "Chatbot Benchmark"
+
+    def test_flow_metadata(self):
+        """Test that flow metadata is complete."""
+        flow = Flow.from_yaml(str(FLOW_YAML))
+        assert flow.metadata.version == "1.0.0"
+        assert flow.metadata.author == "SDG Hub Contributors"
+        assert flow.metadata.license == "Apache-2.0"
+        assert "evaluation" in flow.metadata.tags
+        assert "chatbot" in flow.metadata.tags
+        assert "llm-as-judge" in flow.metadata.tags
+        assert "benchmark" in flow.metadata.tags
+
+    def test_flow_block_count(self):
+        """Test that the flow has the expected number of blocks."""
+        flow = Flow.from_yaml(str(FLOW_YAML))
+        assert len(flow.blocks) == len(EXPECTED_BLOCK_NAMES)
+
+    def test_flow_block_names_unique(self):
+        """Test that all block names are unique."""
+        flow = Flow.from_yaml(str(FLOW_YAML))
+        block_names = [b.block_name for b in flow.blocks]
+        assert len(block_names) == len(set(block_names)), (
+            f"Duplicate block names found: "
+            f"{[n for n in block_names if block_names.count(n) > 1]}"
+        )
+
+    def test_flow_block_names(self):
+        """Test that the flow contains the expected blocks in order."""
+        flow = Flow.from_yaml(str(FLOW_YAML))
+        actual_names = [b.block_name for b in flow.blocks]
+        assert actual_names == EXPECTED_BLOCK_NAMES
+
+    def test_dataset_requirements(self):
+        """Test that dataset requirements specify required columns."""
+        flow = Flow.from_yaml(str(FLOW_YAML))
+        reqs = flow.get_dataset_requirements()
+        assert reqs is not None
+        assert reqs.required_columns == [
+            "question",
+            "expected_answer",
+            "ground_truth_context",
+        ]
+
+    def test_flow_yaml_validates(self):
+        """Test that the flow YAML passes structural validation."""
+        with open(FLOW_YAML, encoding="utf-8") as f:
+            flow_config = yaml.safe_load(f)
+
+        validator = FlowValidator()
+        errors = validator.validate_yaml_structure(flow_config)
+        assert errors == [], f"Validation errors: {errors}"
+
+
+class TestChatbotBenchmarkPrompts:
+    """Test that all prompt YAML files are valid."""
+
+    PROMPTS_DIR = FLOW_DIR / "prompts"
+    EXPECTED_PROMPTS = ["judge.yaml"]
+
+    def test_prompts_directory_exists(self):
+        """Test that the prompts directory exists."""
+        assert self.PROMPTS_DIR.exists()
+
+    @pytest.mark.parametrize("prompt_file", EXPECTED_PROMPTS)
+    def test_prompt_file_exists(self, prompt_file):
+        """Test that each expected prompt file exists."""
+        path = self.PROMPTS_DIR / prompt_file
+        assert path.exists(), f"Prompt file not found: {path}"
+
+    @pytest.mark.parametrize("prompt_file", EXPECTED_PROMPTS)
+    def test_prompt_file_valid_yaml(self, prompt_file):
+        """Test that each prompt file is valid YAML."""
+        path = self.PROMPTS_DIR / prompt_file
+        with open(path, encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+        assert isinstance(data, list), f"{prompt_file} should be a list of messages"
+
+    @pytest.mark.parametrize("prompt_file", EXPECTED_PROMPTS)
+    def test_prompt_messages_have_role_and_content(self, prompt_file):
+        """Test that each message in a prompt has both role and content."""
+        path = self.PROMPTS_DIR / prompt_file
+        with open(path, encoding="utf-8") as f:
+            messages = yaml.safe_load(f)
+
+        for i, msg in enumerate(messages):
+            assert isinstance(msg, dict), (
+                f"{prompt_file} message {i} must be a dict, got {type(msg).__name__}"
+            )
+            assert "role" in msg, (
+                f"{prompt_file} message {i} is a dict but missing 'role'"
+            )
+            assert "content" in msg, (
+                f"{prompt_file} message {i} has 'role' but missing 'content'"
+            )
+
+    @pytest.mark.parametrize("prompt_file", EXPECTED_PROMPTS)
+    def test_prompt_last_message_is_user(self, prompt_file):
+        """Test that the last message in each prompt has user role."""
+        path = self.PROMPTS_DIR / prompt_file
+        with open(path, encoding="utf-8") as f:
+            messages = yaml.safe_load(f)
+
+        last_msg = messages[-1]
+        assert isinstance(last_msg, dict), (
+            f"{prompt_file}: last entry must be a dict, got {type(last_msg).__name__}"
+        )
+        assert last_msg.get("role") == "user", (
+            f"{prompt_file}: last message should have role 'user', "
+            f"got '{last_msg.get('role')}'"
+        )
+
+
+class TestChatbotBenchmarkFlowDiscovery:
+    """Test that the flow is discoverable by FlowRegistry."""
+
+    def test_flow_discoverable(self, clean_registry):
+        """Test that the flow is found by FlowRegistry."""
+        flows = FlowRegistry.list_flows()
+        flow_names = [f["name"] for f in flows]
+        assert "Chatbot Benchmark" in flow_names
+
+    def test_flow_path_retrievable(self, clean_registry):
+        """Test that the flow path can be retrieved by name."""
+        path = FlowRegistry.get_flow_path("Chatbot Benchmark")
+        assert path is not None
+        assert "chatbot_benchmark" in path

--- a/tests/integration/evaluation/test_chatbot_quality_check.py
+++ b/tests/integration/evaluation/test_chatbot_quality_check.py
@@ -1,0 +1,199 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the Chatbot Quality Check flow."""
+
+# Standard
+from pathlib import Path
+
+# Third Party
+import pytest
+import yaml
+
+# First Party
+from sdg_hub import Flow, FlowRegistry, FlowValidator
+
+
+def _find_repo_root() -> Path:
+    """Find repository root by locating pyproject.toml."""
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        if (current / "pyproject.toml").exists():
+            return current
+        current = current.parent
+    raise RuntimeError("Could not find repository root")
+
+
+FLOW_DIR = (
+    _find_repo_root()
+    / "src"
+    / "sdg_hub"
+    / "flows"
+    / "evaluation"
+    / "chatbot_quality_check"
+)
+FLOW_YAML = FLOW_DIR / "flow.yaml"
+
+EXPECTED_BLOCK_NAMES = [
+    "send_to_chatbot",
+    "extract_chatbot_answer",
+    "build_judge_prompt",
+    "run_judge",
+    "extract_judge",
+    "parse_judge_scores",
+]
+
+
+@pytest.fixture()
+def clean_registry():
+    """Reset FlowRegistry to clean state for test isolation."""
+    original_entries = FlowRegistry._entries.copy()
+    original_paths = FlowRegistry._search_paths.copy()
+    original_init = FlowRegistry._initialized
+
+    FlowRegistry._entries.clear()
+    FlowRegistry._search_paths.clear()
+    FlowRegistry._initialized = False
+
+    flows_dir = str(FLOW_DIR.parents[1])
+    FlowRegistry.register_search_path(flows_dir)
+    FlowRegistry._discover_flows(force_refresh=True)
+
+    yield
+
+    FlowRegistry._entries = original_entries
+    FlowRegistry._search_paths = original_paths
+    FlowRegistry._initialized = original_init
+
+
+class TestChatbotQualityCheckFlowStructure:
+    """Test the Chatbot Quality Check flow YAML structure and configuration."""
+
+    def test_flow_yaml_exists(self):
+        """Test that the flow YAML file exists."""
+        assert FLOW_YAML.exists(), f"Flow YAML not found at {FLOW_YAML}"
+
+    def test_flow_loads_successfully(self):
+        """Test that the flow loads from YAML without errors."""
+        flow = Flow.from_yaml(str(FLOW_YAML))
+        assert flow is not None
+        assert flow.metadata.name == "Chatbot Quality Check"
+
+    def test_flow_metadata(self):
+        """Test that flow metadata is complete."""
+        flow = Flow.from_yaml(str(FLOW_YAML))
+        assert flow.metadata.version == "1.0.0"
+        assert flow.metadata.author == "SDG Hub Contributors"
+        assert flow.metadata.license == "Apache-2.0"
+        assert "evaluation" in flow.metadata.tags
+        assert "chatbot" in flow.metadata.tags
+        assert "llm-as-judge" in flow.metadata.tags
+
+    def test_flow_block_count(self):
+        """Test that the flow has the expected number of blocks."""
+        flow = Flow.from_yaml(str(FLOW_YAML))
+        assert len(flow.blocks) == len(EXPECTED_BLOCK_NAMES)
+
+    def test_flow_block_names_unique(self):
+        """Test that all block names are unique."""
+        flow = Flow.from_yaml(str(FLOW_YAML))
+        block_names = [b.block_name for b in flow.blocks]
+        assert len(block_names) == len(set(block_names)), (
+            f"Duplicate block names found: "
+            f"{[n for n in block_names if block_names.count(n) > 1]}"
+        )
+
+    def test_flow_block_names(self):
+        """Test that the flow contains the expected blocks in order."""
+        flow = Flow.from_yaml(str(FLOW_YAML))
+        actual_names = [b.block_name for b in flow.blocks]
+        assert actual_names == EXPECTED_BLOCK_NAMES
+
+    def test_dataset_requirements(self):
+        """Test that dataset requirements specify required columns."""
+        flow = Flow.from_yaml(str(FLOW_YAML))
+        reqs = flow.get_dataset_requirements()
+        assert reqs is not None
+        assert reqs.required_columns == ["question"]
+
+    def test_flow_yaml_validates(self):
+        """Test that the flow YAML passes structural validation."""
+        with open(FLOW_YAML, encoding="utf-8") as f:
+            flow_config = yaml.safe_load(f)
+
+        validator = FlowValidator()
+        errors = validator.validate_yaml_structure(flow_config)
+        assert errors == [], f"Validation errors: {errors}"
+
+
+class TestChatbotQualityCheckPrompts:
+    """Test that all prompt YAML files are valid."""
+
+    PROMPTS_DIR = FLOW_DIR / "prompts"
+    EXPECTED_PROMPTS = ["judge.yaml"]
+
+    def test_prompts_directory_exists(self):
+        """Test that the prompts directory exists."""
+        assert self.PROMPTS_DIR.exists()
+
+    @pytest.mark.parametrize("prompt_file", EXPECTED_PROMPTS)
+    def test_prompt_file_exists(self, prompt_file):
+        """Test that each expected prompt file exists."""
+        path = self.PROMPTS_DIR / prompt_file
+        assert path.exists(), f"Prompt file not found: {path}"
+
+    @pytest.mark.parametrize("prompt_file", EXPECTED_PROMPTS)
+    def test_prompt_file_valid_yaml(self, prompt_file):
+        """Test that each prompt file is valid YAML."""
+        path = self.PROMPTS_DIR / prompt_file
+        with open(path, encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+        assert isinstance(data, list), f"{prompt_file} should be a list of messages"
+
+    @pytest.mark.parametrize("prompt_file", EXPECTED_PROMPTS)
+    def test_prompt_messages_have_role_and_content(self, prompt_file):
+        """Test that each message in a prompt has both role and content."""
+        path = self.PROMPTS_DIR / prompt_file
+        with open(path, encoding="utf-8") as f:
+            messages = yaml.safe_load(f)
+
+        for i, msg in enumerate(messages):
+            assert isinstance(msg, dict), (
+                f"{prompt_file} message {i} must be a dict, got {type(msg).__name__}"
+            )
+            assert "role" in msg, (
+                f"{prompt_file} message {i} is a dict but missing 'role'"
+            )
+            assert "content" in msg, (
+                f"{prompt_file} message {i} has 'role' but missing 'content'"
+            )
+
+    @pytest.mark.parametrize("prompt_file", EXPECTED_PROMPTS)
+    def test_prompt_last_message_is_user(self, prompt_file):
+        """Test that the last message in each prompt has user role."""
+        path = self.PROMPTS_DIR / prompt_file
+        with open(path, encoding="utf-8") as f:
+            messages = yaml.safe_load(f)
+
+        last_msg = messages[-1]
+        assert isinstance(last_msg, dict), (
+            f"{prompt_file}: last entry must be a dict, got {type(last_msg).__name__}"
+        )
+        assert last_msg.get("role") == "user", (
+            f"{prompt_file}: last message should have role 'user', "
+            f"got '{last_msg.get('role')}'"
+        )
+
+
+class TestChatbotQualityCheckFlowDiscovery:
+    """Test that the flow is discoverable by FlowRegistry."""
+
+    def test_flow_discoverable(self, clean_registry):
+        """Test that the flow is found by FlowRegistry."""
+        flows = FlowRegistry.list_flows()
+        flow_names = [f["name"] for f in flows]
+        assert "Chatbot Quality Check" in flow_names
+
+    def test_flow_path_retrievable(self, clean_registry):
+        """Test that the flow path can be retrieved by name."""
+        path = FlowRegistry.get_flow_path("Chatbot Quality Check")
+        assert path is not None
+        assert "chatbot_quality_check" in path


### PR DESCRIPTION
Add two chatbot evaluation flows that send questions to a live chatbot endpoint via the generic_http connector, collect responses, and score them using LLM-as-judge. Also adds `response_context_path` to GenericHTTPConnector for extracting retrieved context from chatbot responses, enabling faithfulness evaluation.

**Chatbot Quality Check** — Lightweight flow that scores faithfulness and relevance. Requires only questions as input, no expected answers needed. Designed for CI deployment gates to catch hallucination and retrieval regressions.

**Chatbot Benchmark** — Full evaluation flow that scores correctness, faithfulness, context recall, and relevance. Takes input from the RAG Evaluation flows (question, expected answer, ground truth context) and compares against the chatbot's actual response and retrieved context.

Both flows use only existing blocks (AgentBlock, AgentResponseExtractorBlock, PromptBuilderBlock, LLMChatBlock, LLMResponseExtractorBlock, JSONParserBlock) — no new blocks introduced. The connector change (`response_context_path`) is backwards compatible and follows the same declarative dot-notation pattern as the existing path fields.

Tested end-to-end against a live chatbot endpoint.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Chatbot Benchmark flow producing correctness, faithfulness, context_recall, relevance and rationale fields with JSON judge output
  * Added Chatbot Quality Check flow for streamlined faithfulness/relevance evaluation
  * Connector enhancement to optionally extract and attach response context to chatbot responses

* **Tests**
  * Integration tests for both new evaluation flows and their prompts/structure
  * Unit tests covering response-context extraction behavior and reserved-key handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->