### PR TITLE
Add AI Research Skills plugins to Claude Code action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -87,8 +87,32 @@ jobs:
             feature-dev@claude-plugins-official
             huggingface-skills@claude-plugins-official
             frontend-design@claude-plugins-official
+            model-architecture@ai-research-skills
+            tokenization@ai-research-skills
+            fine-tuning@ai-research-skills
+            mechanistic-interpretability@ai-research-skills
+            data-processing@ai-research-skills
+            post-training@ai-research-skills
+            safety-alignment@ai-research-skills
+            distributed-training@ai-research-skills
+            infrastructure@ai-research-skills
+            optimization@ai-research-skills
+            evaluation@ai-research-skills
+            inference-serving@ai-research-skills
+            mlops@ai-research-skills
+            agents@ai-research-skills
+            rag@ai-research-skills
+            prompt-engineering@ai-research-skills
+            observability@ai-research-skills
+            multimodal@ai-research-skills
+            emerging-techniques@ai-research-skills
+            autoresearch@ai-research-skills
+            ml-paper-writing@ai-research-skills
+            ideation@ai-research-skills
+            agent-native-research-artifact@ai-research-skills
           plugin_marketplaces: |
             https://github.com/anthropics/claude-plugins-official.git
+            https://github.com/Orchestra-Research/AI-research-SKILLs.git
         env:
           ANTHROPIC_VERTEX_PROJECT_ID: ${{ secrets.GCP_PROJECT }}
           CLOUD_ML_REGION: ${{ secrets.GCP_REGION }}


### PR DESCRIPTION
## Summary

- Adds 23 AI Research Skills plugin categories (98 total skills) from [Orchestra Research](https://github.com/Orchestra-Research/AI-research-SKILLs) to the Claude Code GitHub Action
- Adds the Orchestra Research marketplace URL to `plugin_marketplaces`
- Existing plugins from `claude-plugins-official` are unchanged

### Plugin categories added

`model-architecture`, `tokenization`, `fine-tuning`, `mechanistic-interpretability`, `data-processing`, `post-training`, `safety-alignment`, `distributed-training`, `infrastructure`, `optimization`, `evaluation`, `inference-serving`, `mlops`, `agents`, `rag`, `prompt-engineering`, `observability`, `multimodal`, `emerging-techniques`, `autoresearch`, `ml-paper-writing`, `ideation`, `agent-native-research-artifact`

These skills give Claude Code deep domain expertise across the full ML/AI research and engineering stack -- from model architecture and training to evaluation, deployment, and paper writing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to expand development tooling and plugin integrations for the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->