### PR TITLE
fix: rename output columns to comply with column rename history rules

### DIFF
--- a/src/sdg_hub/flows/knowledge_infusion/enhanced_multi_summary_qa/detailed_summary/flow.yaml
+++ b/src/sdg_hub/flows/knowledge_infusion/enhanced_multi_summary_qa/detailed_summary/flow.yaml
@@ -29,7 +29,7 @@ metadata:
     description: 'Input dataset should contain documents with text content and domain classification. Each document should be substantial enough for meaningful question generation (minimum 100 words recommended). The flow generates three types
       of summaries: detailed (n=20), extractive (n=10), and key facts (n=50), each producing corresponding QA pairs designed to help LLMs internalize document knowledge for knowledge tuning.'
   output_columns:
-  - document
+  - summarized_document
   - question
   - response
   - raw_document
@@ -84,13 +84,13 @@ blocks:
   block_config:
     block_name: rename_to_document_column
     input_cols:
-      summary: document
+      summary: summarized_document
 - block_type: PromptBuilderBlock
   block_config:
     block_name: question_generation_prompt
     input_cols:
     - domain
-    - document
+    - summarized_document
     - document_outline
     - icl_document
     - icl_query_1
@@ -128,7 +128,7 @@ blocks:
     block_name: answer_generation_prompt
     input_cols:
     - question
-    - document
+    - summarized_document
     - document_outline
     output_cols: answer_generation_prompt
     prompt_config_path: prompts/generate_answers.yaml
@@ -162,7 +162,7 @@ blocks:
   block_config:
     block_name: eval_faithful_prompt
     input_cols:
-    - document
+    - summarized_document
     - response
     output_cols: eval_faithful_prompt
     prompt_config_path: prompts/evaluate_faithfulness.yaml

--- a/src/sdg_hub/flows/knowledge_infusion/enhanced_multi_summary_qa/detailed_summary/prompts/evaluate_faithfulness.yaml
+++ b/src/sdg_hub/flows/knowledge_infusion/enhanced_multi_summary_qa/detailed_summary/prompts/evaluate_faithfulness.yaml
@@ -60,7 +60,7 @@
     * Return the answer between [Start of Answer] and [End of Answer] tags.
 
     [Start of Context]
-    {{document}}
+    {{summarized_document}}
     [End of Context]
     [Start of Response]
     {{response}}

--- a/src/sdg_hub/flows/knowledge_infusion/enhanced_multi_summary_qa/detailed_summary/prompts/generate_answers.yaml
+++ b/src/sdg_hub/flows/knowledge_infusion/enhanced_multi_summary_qa/detailed_summary/prompts/generate_answers.yaml
@@ -12,7 +12,7 @@
 
     Document:
     {{document_outline}}
-    {{document}}
+    {{summarized_document}}
 
     Question:
     {{question}}

--- a/src/sdg_hub/flows/knowledge_infusion/enhanced_multi_summary_qa/detailed_summary/prompts/generate_question_list.yaml
+++ b/src/sdg_hub/flows/knowledge_infusion/enhanced_multi_summary_qa/detailed_summary/prompts/generate_question_list.yaml
@@ -44,4 +44,4 @@
     Now, here is the document:
     [DOCUMENT]
     {{document_outline}}
-    {{document}}
+    {{summarized_document}}

--- a/src/sdg_hub/flows/knowledge_infusion/enhanced_multi_summary_qa/extractive_summary/flow.yaml
+++ b/src/sdg_hub/flows/knowledge_infusion/enhanced_multi_summary_qa/extractive_summary/flow.yaml
@@ -31,7 +31,7 @@ metadata:
     description: 'Input dataset should contain documents with text content and domain classification. Each document should be substantial enough for meaningful question generation (minimum 100 words recommended). The flow generates three types
       of summaries: detailed (n=20), extractive (n=10), and key facts (n=50), each producing corresponding QA pairs designed to help LLMs internalize document knowledge for knowledge tuning.'
   output_columns:
-  - document
+  - summarized_document
   - question
   - response
   - raw_document
@@ -86,13 +86,13 @@ blocks:
   block_config:
     block_name: rename_to_document_column
     input_cols:
-      summary: document
+      summary: summarized_document
 - block_type: PromptBuilderBlock
   block_config:
     block_name: question_generation_prompt
     input_cols:
     - domain
-    - document
+    - summarized_document
     - document_outline
     - icl_document
     - icl_query_1
@@ -130,7 +130,7 @@ blocks:
     block_name: answer_generation_prompt
     input_cols:
     - question
-    - document
+    - summarized_document
     - document_outline
     output_cols: answer_generation_prompt
     prompt_config_path: prompts/generate_answers.yaml
@@ -164,7 +164,7 @@ blocks:
   block_config:
     block_name: eval_faithful_prompt
     input_cols:
-    - document
+    - summarized_document
     - response
     output_cols: eval_faithful_prompt
     prompt_config_path: prompts/evaluate_faithfulness.yaml

--- a/src/sdg_hub/flows/knowledge_infusion/enhanced_multi_summary_qa/extractive_summary/prompts/evaluate_faithfulness.yaml
+++ b/src/sdg_hub/flows/knowledge_infusion/enhanced_multi_summary_qa/extractive_summary/prompts/evaluate_faithfulness.yaml
@@ -60,7 +60,7 @@
     * Return the answer between [Start of Answer] and [End of Answer] tags.
 
     [Start of Context]
-    {{document}}
+    {{summarized_document}}
     [End of Context]
     [Start of Response]
     {{response}}

--- a/src/sdg_hub/flows/knowledge_infusion/enhanced_multi_summary_qa/extractive_summary/prompts/generate_answers.yaml
+++ b/src/sdg_hub/flows/knowledge_infusion/enhanced_multi_summary_qa/extractive_summary/prompts/generate_answers.yaml
@@ -12,7 +12,7 @@
 
     Document:
     {{document_outline}}
-    {{document}}
+    {{summarized_document}}
 
     Question:
     {{question}}

--- a/src/sdg_hub/flows/knowledge_infusion/enhanced_multi_summary_qa/extractive_summary/prompts/generate_question_list.yaml
+++ b/src/sdg_hub/flows/knowledge_infusion/enhanced_multi_summary_qa/extractive_summary/prompts/generate_question_list.yaml
@@ -44,4 +44,4 @@
     Now, here is the document:
     [DOCUMENT]
     {{document_outline}}
-    {{document}}
+    {{summarized_document}}

--- a/src/sdg_hub/flows/knowledge_infusion/enhanced_multi_summary_qa/key_facts/flow.yaml
+++ b/src/sdg_hub/flows/knowledge_infusion/enhanced_multi_summary_qa/key_facts/flow.yaml
@@ -73,11 +73,11 @@ blocks:
   block_config:
     block_name: rename_to_document_column
     input_cols:
-      atomic_facts: document
+      atomic_facts: key_facts_content
 - block_type: RegexParserBlock
   block_config:
     block_name: parse_atomic_facts_to_individual_facts
-    input_cols: document
+    input_cols: key_facts_content
     output_cols: key_fact
     parsing_pattern: '(?:^|\n)\s*\d+\.\s+(.*?)(?=\n\s*\d+\.\s+|\Z)'
 - block_type: PromptBuilderBlock

--- a/src/sdg_hub/flows/knowledge_infusion/enhanced_multi_summary_qa_es/detailed_summary/flow.yaml
+++ b/src/sdg_hub/flows/knowledge_infusion/enhanced_multi_summary_qa_es/detailed_summary/flow.yaml
@@ -29,7 +29,7 @@ metadata:
     - icl_query_3
     description: 'Input dataset should contain Spanish documents with text content and domain classification. Each document should be substantial enough for meaningful question generation (minimum 100 words recommended). The flow generates detailed summaries and corresponding QA pairs in Spanish designed to help LLMs internalize document knowledge for knowledge tuning.'
   output_columns:
-  - document
+  - summarized_document
   - question
   - response
   - raw_document
@@ -84,13 +84,13 @@ blocks:
   block_config:
     block_name: rename_to_document_column
     input_cols:
-      summary: document
+      summary: summarized_document
 - block_type: PromptBuilderBlock
   block_config:
     block_name: question_generation_prompt
     input_cols:
     - domain
-    - document
+    - summarized_document
     - document_outline
     - icl_document
     - icl_query_1
@@ -128,7 +128,7 @@ blocks:
     block_name: answer_generation_prompt
     input_cols:
     - question
-    - document
+    - summarized_document
     - document_outline
     output_cols: answer_generation_prompt
     prompt_config_path: prompts/generate_answers_es.yaml
@@ -162,7 +162,7 @@ blocks:
   block_config:
     block_name: eval_faithful_prompt
     input_cols:
-    - document
+    - summarized_document
     - response
     output_cols: eval_faithful_prompt
     prompt_config_path: prompts/evaluate_faithfulness_es.yaml

--- a/src/sdg_hub/flows/knowledge_infusion/enhanced_multi_summary_qa_es/detailed_summary/prompts/evaluate_faithfulness_es.yaml
+++ b/src/sdg_hub/flows/knowledge_infusion/enhanced_multi_summary_qa_es/detailed_summary/prompts/evaluate_faithfulness_es.yaml
@@ -60,7 +60,7 @@
     * Devuelve la respuesta entre las etiquetas [Start of Answer] y [End of Answer].
 
     [Start of Context]
-    {{document}}
+    {{summarized_document}}
     [End of Context]
     [Start of Response]
     {{response}}

--- a/src/sdg_hub/flows/knowledge_infusion/enhanced_multi_summary_qa_es/detailed_summary/prompts/generate_answers_es.yaml
+++ b/src/sdg_hub/flows/knowledge_infusion/enhanced_multi_summary_qa_es/detailed_summary/prompts/generate_answers_es.yaml
@@ -12,7 +12,7 @@
 
     Documento:
     {{document_outline}}
-    {{document}}
+    {{summarized_document}}
 
     Pregunta:
     {{question}}

--- a/src/sdg_hub/flows/knowledge_infusion/enhanced_multi_summary_qa_es/detailed_summary/prompts/generate_question_list_es.yaml
+++ b/src/sdg_hub/flows/knowledge_infusion/enhanced_multi_summary_qa_es/detailed_summary/prompts/generate_question_list_es.yaml
@@ -44,4 +44,4 @@
     Ahora, aquí está el documento:
     [DOCUMENT]
     {{document_outline}}
-    {{document}}
+    {{summarized_document}}

--- a/src/sdg_hub/flows/knowledge_infusion/enhanced_multi_summary_qa_es/extractive_summary/flow.yaml
+++ b/src/sdg_hub/flows/knowledge_infusion/enhanced_multi_summary_qa_es/extractive_summary/flow.yaml
@@ -31,7 +31,7 @@ metadata:
     - icl_query_3
     description: 'Input dataset should contain Spanish documents with text content and domain classification. Each document should be substantial enough for meaningful question generation (minimum 100 words recommended). The flow generates extractive summaries and corresponding QA pairs in Spanish designed to help LLMs internalize document knowledge for knowledge tuning.'
   output_columns:
-  - document
+  - summarized_document
   - question
   - response
   - raw_document
@@ -86,13 +86,13 @@ blocks:
   block_config:
     block_name: rename_to_document_column
     input_cols:
-      summary: document
+      summary: summarized_document
 - block_type: PromptBuilderBlock
   block_config:
     block_name: question_generation_prompt
     input_cols:
     - domain
-    - document
+    - summarized_document
     - document_outline
     - icl_document
     - icl_query_1
@@ -130,7 +130,7 @@ blocks:
     block_name: answer_generation_prompt
     input_cols:
     - question
-    - document
+    - summarized_document
     - document_outline
     output_cols: answer_generation_prompt
     prompt_config_path: prompts/generate_answers_es.yaml
@@ -164,7 +164,7 @@ blocks:
   block_config:
     block_name: eval_faithful_prompt
     input_cols:
-    - document
+    - summarized_document
     - response
     output_cols: eval_faithful_prompt
     prompt_config_path: prompts/evaluate_faithfulness_es.yaml

--- a/src/sdg_hub/flows/knowledge_infusion/enhanced_multi_summary_qa_es/extractive_summary/prompts/evaluate_faithfulness_es.yaml
+++ b/src/sdg_hub/flows/knowledge_infusion/enhanced_multi_summary_qa_es/extractive_summary/prompts/evaluate_faithfulness_es.yaml
@@ -60,7 +60,7 @@
     * Devuelve la respuesta entre las etiquetas [Start of Answer] y [End of Answer].
 
     [Start of Context]
-    {{document}}
+    {{summarized_document}}
     [End of Context]
     [Start of Response]
     {{response}}

--- a/src/sdg_hub/flows/knowledge_infusion/enhanced_multi_summary_qa_es/extractive_summary/prompts/generate_answers_es.yaml
+++ b/src/sdg_hub/flows/knowledge_infusion/enhanced_multi_summary_qa_es/extractive_summary/prompts/generate_answers_es.yaml
@@ -12,7 +12,7 @@
 
     Documento:
     {{document_outline}}
-    {{document}}
+    {{summarized_document}}
 
     Pregunta:
     {{question}}

--- a/src/sdg_hub/flows/knowledge_infusion/enhanced_multi_summary_qa_es/extractive_summary/prompts/generate_question_list_es.yaml
+++ b/src/sdg_hub/flows/knowledge_infusion/enhanced_multi_summary_qa_es/extractive_summary/prompts/generate_question_list_es.yaml
@@ -44,4 +44,4 @@
     Ahora, aquí está el documento:
     [DOCUMENT]
     {{document_outline}}
-    {{document}}
+    {{summarized_document}}

--- a/src/sdg_hub/flows/knowledge_infusion/enhanced_multi_summary_qa_es/key_facts/flow.yaml
+++ b/src/sdg_hub/flows/knowledge_infusion/enhanced_multi_summary_qa_es/key_facts/flow.yaml
@@ -74,11 +74,11 @@ blocks:
   block_config:
     block_name: rename_to_document_column
     input_cols:
-      atomic_facts: document
+      atomic_facts: key_facts_content
 - block_type: RegexParserBlock
   block_config:
     block_name: parse_atomic_facts_to_individual_facts
-    input_cols: document
+    input_cols: key_facts_content
     output_cols: key_fact
     parsing_pattern: '(?:^|\n)\s*\d+\.\s+(.*?)(?=\n\s*\d+\.\s+|\Z)'
 - block_type: PromptBuilderBlock

--- a/src/sdg_hub/flows/knowledge_infusion/japanese_multi_summary_qa/flow.yaml
+++ b/src/sdg_hub/flows/knowledge_infusion/japanese_multi_summary_qa/flow.yaml
@@ -143,12 +143,12 @@ blocks:
   - block_type: RenameColumnsBlock
     block_config:
       block_name: rename_to_document_column
-      input_cols: {summary: document}
+      input_cols: {summary: summarized_document}
 
   - block_type: PromptBuilderBlock
     block_config:
       block_name: knowledge_generation_prompt
-      input_cols: [domain, document, document_outline, icl_document, icl_query_1, icl_response_1, icl_query_2, icl_response_2, icl_query_3, icl_response_3]
+      input_cols: [domain, summarized_document, document_outline, icl_document, icl_query_1, icl_response_1, icl_query_2, icl_response_2, icl_query_3, icl_response_3]
       output_cols: knowledge_generation_prompt
       prompt_config_path: prompts/generate_questions_responses_ja.yaml
 
@@ -178,7 +178,7 @@ blocks:
   - block_type: PromptBuilderBlock
     block_config:
       block_name: eval_faithful_prompt
-      input_cols: [document, response]
+      input_cols: [summarized_document, response]
       output_cols: eval_faithful_prompt
       prompt_config_path: prompts/evaluate_faithfulness_ja.yaml
       format_as_messages: true

--- a/src/sdg_hub/flows/knowledge_infusion/japanese_multi_summary_qa/prompts/evaluate_faithfulness_ja.yaml
+++ b/src/sdg_hub/flows/knowledge_infusion/japanese_multi_summary_qa/prompts/evaluate_faithfulness_ja.yaml
@@ -58,7 +58,7 @@
     * Return the answer between [Start of Answer] and [End of Answer] tags.
 
     [Start of Context]
-    {{document}}
+    {{summarized_document}}
     [End of Context]
     [Start of Response]
     {{response}}

--- a/src/sdg_hub/flows/knowledge_infusion/japanese_multi_summary_qa/prompts/generate_questions_responses_ja.yaml
+++ b/src/sdg_hub/flows/knowledge_infusion/japanese_multi_summary_qa/prompts/generate_questions_responses_ja.yaml
@@ -52,4 +52,4 @@
     Now, here is the document:
     [DOCUMENT]
     {{document_outline}}
-    {{document}}
+    {{summarized_document}}


### PR DESCRIPTION
## Summary

- Rename `summary` → `summarized_document` (was `summary` → `document`) in 5 knowledge_infusion flows (EN/ES detailed+extractive, Japanese) to avoid reusing the historical column name `document`
- Rename `atomic_facts` → `key_facts_content` (was `atomic_facts` → `document`) in 2 key_facts flows (EN/ES) found during audit
- Update all downstream `input_cols` references and 14 prompt templates to match the new column names

Closes #598

**BREAKING CHANGE:** Output column `document` (which contained summary data, not the original document) is renamed to `summarized_document` in enhanced_multi_summary_qa, enhanced_multi_summary_qa_es, and japanese_multi_summary_qa flows. The `key_facts` flows rename to `key_facts_content`. Downstream consumers referencing the `document` output column will need to update.

### Files changed (21 total)

**Flow YAMLs (7):**
- `enhanced_multi_summary_qa/detailed_summary/flow.yaml`
- `enhanced_multi_summary_qa/extractive_summary/flow.yaml`
- `enhanced_multi_summary_qa/key_facts/flow.yaml`
- `enhanced_multi_summary_qa_es/detailed_summary/flow.yaml`
- `enhanced_multi_summary_qa_es/extractive_summary/flow.yaml`
- `enhanced_multi_summary_qa_es/key_facts/flow.yaml`
- `japanese_multi_summary_qa/flow.yaml`

**Prompt templates (14):**
- `generate_question_list[_es].yaml` (4 files)
- `generate_answers[_es].yaml` (4 files)
- `evaluate_faithfulness[_es|_ja].yaml` (5 files)
- `generate_questions_responses_ja.yaml` (1 file)

## Test plan

- [x] YAML structure validates for all 7 updated flows
- [x] No remaining `summary: document` or `atomic_facts: document` rename patterns
- [x] All downstream `input_cols` references updated from `document` to `summarized_document`/`key_facts_content`
- [x] Prompt templates use `{{summarized_document}}` matching the new column names
- [x] Full audit confirms no other flows have historical column name reuse violations
- [ ] `FlowValidator.validate_yaml_structure()` passes (requires Python 3.10+ environment)
- [ ] `flow.dry_run()` succeeds with representative datasets

🤖 Generated with [Claude Code](https://claude.com/claude-code)