### PR TITLE
feat: add column rename history validation and output_columns fast-fail

### DIFF
--- a/src/sdg_hub/core/blocks/transform/rename_columns.py
+++ b/src/sdg_hub/core/blocks/transform/rename_columns.py
@@ -66,6 +66,9 @@ class RenameColumnsBlock(BaseBlock):
         if not self.output_cols:
             self.output_cols = list(input_cols_dict.values())
 
+    def _validate_output_columns(self, df: pd.DataFrame) -> None:
+        """Skip base collision check — RenameColumnsBlock handles this in generate()."""
+
     def generate(self, samples: pd.DataFrame, **kwargs: Any) -> pd.DataFrame:
         """Generate a dataset with renamed columns.
 
@@ -97,12 +100,13 @@ class RenameColumnsBlock(BaseBlock):
                 f"Original column names {sorted(missing_cols)} not in the dataset"
             )
 
-        # Check for column name collisions
-        # Strict validation: no target column name can be an existing column name
-        # This prevents chained/circular renames which can be confusing
+        # Check for column name collisions — target names must not already
+        # exist in the dataset UNLESS the existing column is itself being
+        # renamed away in the same block (pandas rename is atomic).
         target_cols = set(input_cols_dict.values())
+        source_cols = set(input_cols_dict.keys())
 
-        collision = target_cols & existing_cols
+        collision = target_cols & (existing_cols - source_cols)
         if collision:
             raise ValueError(
                 f"Cannot rename to existing column names: {sorted(collision)}. "

--- a/src/sdg_hub/core/flow/execution.py
+++ b/src/sdg_hub/core/flow/execution.py
@@ -4,6 +4,7 @@
 # Standard
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Optional, Union
+import difflib
 import logging
 import time
 import uuid
@@ -54,6 +55,87 @@ def _validate_max_concurrency(max_concurrency: Optional[int]) -> None:
         if max_concurrency <= 0:
             raise FlowValidationError(
                 f"max_concurrency must be greater than 0, got {max_concurrency}"
+            )
+
+
+def _validate_column_lifecycle(flow: "Flow", input_columns: set[str]) -> None:
+    """Validate column rename history and output_columns reachability at runtime.
+
+    Walks the instantiated block chain, tracking all column names ever seen.
+    Raises FlowValidationError if:
+    - A RenameColumnsBlock targets a name that previously existed but was
+      renamed/dropped (rename history violation).
+    - Any declared output_columns cannot be produced by the block chain.
+
+    Parameters
+    ----------
+    flow : Flow
+        The flow instance with instantiated blocks.
+    input_columns : set[str]
+        Column names from the input dataset.
+
+    Raises
+    ------
+    FlowValidationError
+        If rename history violations or unreachable output_columns are detected.
+    """
+    from ..blocks.transform.rename_columns import RenameColumnsBlock
+
+    available_columns = set(input_columns)
+    column_history = set(input_columns)
+
+    for block in flow.blocks:
+        if isinstance(block, RenameColumnsBlock) and isinstance(block.input_cols, dict):
+            # Check all targets atomically against current state
+            # (pandas rename applies all mappings simultaneously)
+            for old_name, new_name in block.input_cols.items():
+                if (
+                    isinstance(new_name, str)
+                    and new_name in column_history
+                    and new_name not in available_columns
+                ):
+                    raise FlowValidationError(
+                        f"Block '{block.block_name}' renames '{old_name}' to "
+                        f"'{new_name}', but '{new_name}' previously existed and "
+                        f"was renamed or dropped. "
+                        f"Available columns: {sorted(available_columns)}"
+                    )
+            # Update state after all checks
+            for old_name, new_name in block.input_cols.items():
+                column_history.add(old_name)
+                available_columns.discard(old_name)
+                if isinstance(new_name, str):
+                    available_columns.add(new_name)
+                    column_history.add(new_name)
+        else:
+            if hasattr(block, "output_cols") and block.output_cols:
+                if isinstance(block.output_cols, list):
+                    available_columns.update(block.output_cols)
+                    column_history.update(block.output_cols)
+                elif isinstance(block.output_cols, str):
+                    available_columns.add(block.output_cols)
+                    column_history.add(block.output_cols)
+                elif isinstance(block.output_cols, dict):
+                    available_columns.update(block.output_cols.keys())
+                    column_history.update(block.output_cols.keys())
+
+    if flow.metadata.output_columns:
+        output_cols_set = set(flow.metadata.output_columns)
+        missing = output_cols_set - available_columns
+        if missing:
+            msgs: list[str] = []
+            for col in sorted(missing):
+                suggestions = difflib.get_close_matches(
+                    col, sorted(available_columns), n=3, cutoff=0.6
+                )
+                msg = f"output_column '{col}' cannot be produced by the block chain."
+                if suggestions:
+                    msg += f" Did you mean: {suggestions}?"
+                msgs.append(msg)
+            raise FlowValidationError(
+                "Unreachable output_columns detected before execution:\n"
+                + "\n".join(msgs)
+                + f"\nAvailable columns: {sorted(available_columns)}"
             )
 
 
@@ -908,6 +990,7 @@ def execute_flow(
     runtime_params = runtime_params or {}
 
     _validate_flow_preconditions(flow, dataset, save_freq, max_concurrency)
+    _validate_column_lifecycle(flow, set(dataset.columns))
 
     flow_logger, timestamp, flow_name = _setup_flow_logger(
         log_dir,
@@ -1188,6 +1271,7 @@ def run_dry_run(
     """
     dataset, _ = convert_to_dataframe(dataset)
     _validate_dry_run_preconditions(flow, dataset, max_concurrency)
+    _validate_column_lifecycle(flow, set(dataset.columns))
 
     actual_sample_size = min(sample_size, len(dataset))
     runtime_params = runtime_params or {}

--- a/src/sdg_hub/core/flow/validation.py
+++ b/src/sdg_hub/core/flow/validation.py
@@ -3,6 +3,7 @@
 
 # Standard
 from typing import TYPE_CHECKING, Any
+import difflib
 
 # Third Party
 import pandas as pd
@@ -67,6 +68,15 @@ class FlowValidator:
                         metadata=metadata,
                     )
                     errors.extend(oc_errors)
+
+            # Validate rename history: block renaming to a previously-existing
+            # column name that is no longer available
+            if isinstance(metadata, dict):
+                rh_errors = self._validate_rename_history(
+                    flow_config.get("blocks", []),
+                    metadata,
+                )
+                errors.extend(rh_errors)
 
         # Validate parameters if present
         if "parameters" in flow_config:
@@ -333,13 +343,105 @@ class FlowValidator:
 
         missing = [col for col in output_columns if col not in available_columns]
         if missing:
-            return [
-                f"Declared output_columns {missing} cannot be traced to any "
-                f"block output or dataset requirement. "
-                f"Available columns: {sorted(available_columns)}"
-            ]
+            errors: list[str] = []
+            for col in missing:
+                suggestions = difflib.get_close_matches(
+                    col, sorted(available_columns), n=3, cutoff=0.6
+                )
+                msg = (
+                    f"Declared output_column '{col}' cannot be traced to any "
+                    f"block output or dataset requirement."
+                )
+                if suggestions:
+                    msg += f" Did you mean: {suggestions}?"
+                errors.append(msg)
+            errors.append(f"Available columns: {sorted(available_columns)}")
+            return errors
 
         return []
+
+    def _validate_rename_history(
+        self,
+        block_configs: list[dict[str, Any]],
+        metadata: dict[str, Any],
+    ) -> list[str]:
+        """Validate that RenameColumnsBlock does not rename to a previously-existing name.
+
+        Tracks all column names ever seen through the block chain. If a rename
+        target matches a name that existed earlier but is no longer available,
+        this is likely a bug (the author intended to reference the original
+        column but it was already renamed/dropped).
+
+        Parameters
+        ----------
+        block_configs : list[dict[str, Any]]
+            Raw block configurations from YAML.
+        metadata : dict[str, Any]
+            Full metadata dict, used to read dataset_requirements.
+
+        Returns
+        -------
+        list[str]
+            Validation error messages.
+        """
+        available_columns: set[str] = set()
+        column_history: set[str] = set()
+
+        dataset_req = metadata.get("dataset_requirements", {})
+        if isinstance(dataset_req, dict):
+            for key in ("required_columns", "optional_columns"):
+                cols = dataset_req.get(key, [])
+                if isinstance(cols, list):
+                    for c in cols:
+                        if isinstance(c, str):
+                            available_columns.add(c)
+                            column_history.add(c)
+
+        errors: list[str] = []
+
+        for block_config in block_configs:
+            if not isinstance(block_config, dict):
+                continue
+
+            block_type = block_config.get("block_type", "")
+            config = block_config.get("block_config", {})
+            if not isinstance(config, dict):
+                continue
+
+            block_name = config.get("block_name", f"<unnamed {block_type}>")
+
+            if block_type == "RenameColumnsBlock":
+                input_cols = config.get("input_cols")
+                if isinstance(input_cols, dict):
+                    # Check all targets atomically against current state
+                    # (pandas rename applies all mappings simultaneously)
+                    for old_name, new_name in input_cols.items():
+                        if (
+                            isinstance(new_name, str)
+                            and new_name in column_history
+                            and new_name not in available_columns
+                        ):
+                            errors.append(
+                                f"Block '{block_name}' renames '{old_name}' to "
+                                f"'{new_name}', but '{new_name}' previously existed "
+                                f"and was renamed or dropped. This is likely a bug. "
+                                f"Available columns: {sorted(available_columns)}"
+                            )
+                    # Update state after all checks
+                    for old_name, new_name in input_cols.items():
+                        column_history.add(old_name)
+                        available_columns.discard(old_name)
+                        if isinstance(new_name, str):
+                            available_columns.add(new_name)
+                            column_history.add(new_name)
+            else:
+                output_cols = config.get("output_cols")
+                if output_cols:
+                    new_cols = self._extract_column_names(output_cols)
+                    available_columns.update(new_cols)
+                    column_history.update(new_cols)
+
+        return errors
 
     def validate_block_chain(self, blocks: list[Any]) -> list[str]:
         """Validate that blocks can be chained together.

--- a/src/sdg_hub/flows/knowledge_infusion/enhanced_multi_summary_qa/detailed_summary/flow.yaml
+++ b/src/sdg_hub/flows/knowledge_infusion/enhanced_multi_summary_qa/detailed_summary/flow.yaml
@@ -77,13 +77,9 @@ blocks:
     - ''
 - block_type: RenameColumnsBlock
   block_config:
-    block_name: rename_to_raw_document_column
+    block_name: rename_document_columns
     input_cols:
       document: raw_document
-- block_type: RenameColumnsBlock
-  block_config:
-    block_name: rename_to_document_column
-    input_cols:
       summary: document
 - block_type: PromptBuilderBlock
   block_config:

--- a/src/sdg_hub/flows/knowledge_infusion/enhanced_multi_summary_qa/extractive_summary/flow.yaml
+++ b/src/sdg_hub/flows/knowledge_infusion/enhanced_multi_summary_qa/extractive_summary/flow.yaml
@@ -79,13 +79,9 @@ blocks:
     - ''
 - block_type: RenameColumnsBlock
   block_config:
-    block_name: rename_to_raw_document_column
+    block_name: rename_document_columns
     input_cols:
       document: raw_document
-- block_type: RenameColumnsBlock
-  block_config:
-    block_name: rename_to_document_column
-    input_cols:
       summary: document
 - block_type: PromptBuilderBlock
   block_config:

--- a/src/sdg_hub/flows/knowledge_infusion/enhanced_multi_summary_qa/key_facts/flow.yaml
+++ b/src/sdg_hub/flows/knowledge_infusion/enhanced_multi_summary_qa/key_facts/flow.yaml
@@ -66,13 +66,9 @@ blocks:
     - ''
 - block_type: RenameColumnsBlock
   block_config:
-    block_name: rename_to_raw_document_column
+    block_name: rename_document_columns
     input_cols:
       document: raw_document
-- block_type: RenameColumnsBlock
-  block_config:
-    block_name: rename_to_document_column
-    input_cols:
       atomic_facts: document
 - block_type: RegexParserBlock
   block_config:

--- a/src/sdg_hub/flows/knowledge_infusion/enhanced_multi_summary_qa_es/detailed_summary/flow.yaml
+++ b/src/sdg_hub/flows/knowledge_infusion/enhanced_multi_summary_qa_es/detailed_summary/flow.yaml
@@ -77,13 +77,9 @@ blocks:
     - ''
 - block_type: RenameColumnsBlock
   block_config:
-    block_name: rename_to_raw_document_column
+    block_name: rename_document_columns
     input_cols:
       document: raw_document
-- block_type: RenameColumnsBlock
-  block_config:
-    block_name: rename_to_document_column
-    input_cols:
       summary: document
 - block_type: PromptBuilderBlock
   block_config:

--- a/src/sdg_hub/flows/knowledge_infusion/enhanced_multi_summary_qa_es/extractive_summary/flow.yaml
+++ b/src/sdg_hub/flows/knowledge_infusion/enhanced_multi_summary_qa_es/extractive_summary/flow.yaml
@@ -79,13 +79,9 @@ blocks:
     - ''
 - block_type: RenameColumnsBlock
   block_config:
-    block_name: rename_to_raw_document_column
+    block_name: rename_document_columns
     input_cols:
       document: raw_document
-- block_type: RenameColumnsBlock
-  block_config:
-    block_name: rename_to_document_column
-    input_cols:
       summary: document
 - block_type: PromptBuilderBlock
   block_config:

--- a/src/sdg_hub/flows/knowledge_infusion/enhanced_multi_summary_qa_es/key_facts/flow.yaml
+++ b/src/sdg_hub/flows/knowledge_infusion/enhanced_multi_summary_qa_es/key_facts/flow.yaml
@@ -67,13 +67,9 @@ blocks:
     - ''
 - block_type: RenameColumnsBlock
   block_config:
-    block_name: rename_to_raw_document_column
+    block_name: rename_document_columns
     input_cols:
       document: raw_document
-- block_type: RenameColumnsBlock
-  block_config:
-    block_name: rename_to_document_column
-    input_cols:
       atomic_facts: document
 - block_type: RegexParserBlock
   block_config:

--- a/src/sdg_hub/flows/knowledge_infusion/japanese_multi_summary_qa/flow.yaml
+++ b/src/sdg_hub/flows/knowledge_infusion/japanese_multi_summary_qa/flow.yaml
@@ -138,12 +138,8 @@ blocks:
 
   - block_type: RenameColumnsBlock
     block_config:
-      block_name: rename_to_raw_document_column
-      input_cols: {document: raw_document}
-  - block_type: RenameColumnsBlock
-    block_config:
-      block_name: rename_to_document_column
-      input_cols: {summary: document}
+      block_name: rename_document_columns
+      input_cols: {document: raw_document, summary: document}
 
   - block_type: PromptBuilderBlock
     block_config:

--- a/tests/flow/test_column_cleanup.py
+++ b/tests/flow/test_column_cleanup.py
@@ -7,10 +7,12 @@ import pandas as pd
 import pytest
 
 from sdg_hub.core.blocks.transform.duplicate_columns import DuplicateColumnsBlock
+from sdg_hub.core.blocks.transform.rename_columns import RenameColumnsBlock
 from sdg_hub.core.blocks.transform.text_concat import TextConcatBlock
 from sdg_hub.core.flow.base import Flow
 from sdg_hub.core.flow.column_tracker import ColumnDependencyTracker
 from sdg_hub.core.flow.metadata import FlowMetadata
+from sdg_hub.core.utils.error_handling import FlowValidationError
 
 
 class TestFlowMetadataColumnCleanup:
@@ -299,7 +301,7 @@ class TestFlowColumnCleanup:
         )
 
         dataset = pd.DataFrame({"a": ["1"], "b": ["2"]})
-        with pytest.raises(FlowValidationError, match="output_columns not found"):
+        with pytest.raises(FlowValidationError, match="Unreachable output_columns"):
             flow.generate(dataset)
 
     def test_flow_early_drop_verified_mid_execution(self):
@@ -437,3 +439,137 @@ class TestCheckpointColumnCleanup:
         assert "b" in result.columns
         assert "output" in result.columns
         assert "intermediate" not in result.columns
+
+
+class TestColumnLifecycleValidation:
+    """Tests for runtime _validate_column_lifecycle fast-fail."""
+
+    def test_generate_rejects_unreachable_output_columns(self):
+        """flow.generate() raises before execution if output_columns are unreachable."""
+        flow = Flow(
+            metadata=FlowMetadata(
+                name="test",
+                output_columns=["nonexistent"],
+            ),
+            blocks=[
+                TextConcatBlock(
+                    block_name="concat",
+                    input_cols=["a", "b"],
+                    output_cols="ab",
+                ),
+            ],
+        )
+        dataset = pd.DataFrame({"a": ["1"], "b": ["2"]})
+        with pytest.raises(FlowValidationError, match="Unreachable output_columns"):
+            flow.generate(dataset)
+
+    def test_dry_run_rejects_unreachable_output_columns(self):
+        """flow.dry_run() raises before execution if output_columns are unreachable."""
+        flow = Flow(
+            metadata=FlowMetadata(
+                name="test",
+                output_columns=["nonexistent"],
+            ),
+            blocks=[
+                TextConcatBlock(
+                    block_name="concat",
+                    input_cols=["a", "b"],
+                    output_cols="ab",
+                ),
+            ],
+        )
+        dataset = pd.DataFrame({"a": ["1"], "b": ["2"]})
+        with pytest.raises(FlowValidationError, match="Unreachable output_columns"):
+            flow.dry_run(dataset)
+
+    def test_output_columns_typo_shows_did_you_mean(self):
+        """Typos in output_columns produce did-you-mean suggestions."""
+        flow = Flow(
+            metadata=FlowMetadata(
+                name="test",
+                output_columns=["ab_concated"],
+            ),
+            blocks=[
+                TextConcatBlock(
+                    block_name="concat",
+                    input_cols=["a", "b"],
+                    output_cols="ab_concatenated",
+                ),
+            ],
+        )
+        dataset = pd.DataFrame({"a": ["1"], "b": ["2"]})
+        with pytest.raises(FlowValidationError, match="Did you mean"):
+            flow.generate(dataset)
+
+    def test_generate_rejects_rename_to_historical_column(self):
+        """flow.generate() raises if RenameColumnsBlock targets a historical column name."""
+        flow = Flow(
+            metadata=FlowMetadata(name="test"),
+            blocks=[
+                RenameColumnsBlock(
+                    block_name="rename1",
+                    input_cols={"a": "x"},
+                ),
+                RenameColumnsBlock(
+                    block_name="rename2",
+                    input_cols={"b": "a"},
+                ),
+            ],
+        )
+        dataset = pd.DataFrame({"a": ["1"], "b": ["2"]})
+        with pytest.raises(FlowValidationError, match="previously existed"):
+            flow.generate(dataset)
+
+    def test_dry_run_rejects_rename_to_historical_column(self):
+        """flow.dry_run() raises if RenameColumnsBlock targets a historical column name."""
+        flow = Flow(
+            metadata=FlowMetadata(name="test"),
+            blocks=[
+                RenameColumnsBlock(
+                    block_name="rename1",
+                    input_cols={"a": "x"},
+                ),
+                RenameColumnsBlock(
+                    block_name="rename2",
+                    input_cols={"b": "a"},
+                ),
+            ],
+        )
+        dataset = pd.DataFrame({"a": ["1"], "b": ["2"]})
+        with pytest.raises(FlowValidationError, match="previously existed"):
+            flow.dry_run(dataset)
+
+    def test_rename_to_fresh_name_succeeds(self):
+        """Renaming to a name that never existed is allowed."""
+        flow = Flow(
+            metadata=FlowMetadata(name="test"),
+            blocks=[
+                RenameColumnsBlock(
+                    block_name="rename",
+                    input_cols={"a": "alpha"},
+                ),
+            ],
+        )
+        dataset = pd.DataFrame({"a": ["1"], "b": ["2"]})
+        result = flow.generate(dataset)
+        assert "alpha" in result.columns
+        assert "a" not in result.columns
+
+    def test_valid_output_columns_pass_lifecycle_check(self):
+        """Reachable output_columns pass validation and flow completes normally."""
+        flow = Flow(
+            metadata=FlowMetadata(
+                name="test",
+                output_columns=["ab"],
+            ),
+            blocks=[
+                TextConcatBlock(
+                    block_name="concat",
+                    input_cols=["a", "b"],
+                    output_cols="ab",
+                ),
+            ],
+        )
+        dataset = pd.DataFrame({"a": ["1"], "b": ["2"]})
+        result = flow.generate(dataset)
+        assert "ab" in result.columns

--- a/tests/flow/test_validation.py
+++ b/tests/flow/test_validation.py
@@ -587,3 +587,166 @@ class TestOutputColumnsValidation:
         )
         errors = self.validator.validate_yaml_structure(config)
         assert errors == []
+
+    def test_output_columns_did_you_mean_suggestion(self):
+        """Test that typos in output_columns get did-you-mean suggestions."""
+        config = self._make_flow_config(
+            output_columns=["queston"],
+            blocks=[
+                {
+                    "block_type": "LLMChatBlock",
+                    "block_config": {
+                        "block_name": "gen_question",
+                        "input_cols": "text",
+                        "output_cols": "question",
+                    },
+                },
+            ],
+        )
+        errors = self.validator.validate_yaml_structure(config)
+        assert any("Did you mean" in e for e in errors)
+        assert any("question" in e for e in errors)
+
+
+class TestRenameHistoryValidation:
+    """Test static rename history validation in FlowValidator."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.validator = FlowValidator()
+
+    def _make_flow_config(self, blocks, metadata_extra=None):
+        """Build a minimal flow config dict for testing."""
+        metadata = {"name": "Test Flow"}
+        if metadata_extra:
+            metadata.update(metadata_extra)
+        return {"metadata": metadata, "blocks": blocks}
+
+    def test_rename_to_historical_column_errors(self):
+        """Renaming to a column name that previously existed but was renamed away is an error."""
+        config = self._make_flow_config(
+            metadata_extra={
+                "dataset_requirements": {"required_columns": ["document", "text"]},
+            },
+            blocks=[
+                {
+                    "block_type": "RenameColumnsBlock",
+                    "block_config": {
+                        "block_name": "rename_doc",
+                        "input_cols": {"document": "raw_doc"},
+                    },
+                },
+                {
+                    "block_type": "RenameColumnsBlock",
+                    "block_config": {
+                        "block_name": "rename_back",
+                        "input_cols": {"text": "document"},
+                    },
+                },
+            ],
+        )
+        errors = self.validator.validate_yaml_structure(config)
+        assert any("previously existed" in e for e in errors)
+        assert any("rename_back" in e for e in errors)
+
+    def test_rename_to_fresh_name_ok(self):
+        """Renaming to a name that never existed before is fine."""
+        config = self._make_flow_config(
+            metadata_extra={
+                "dataset_requirements": {"required_columns": ["document"]},
+            },
+            blocks=[
+                {
+                    "block_type": "RenameColumnsBlock",
+                    "block_config": {
+                        "block_name": "rename_doc",
+                        "input_cols": {"document": "raw_document"},
+                    },
+                },
+            ],
+        )
+        errors = self.validator.validate_yaml_structure(config)
+        assert errors == []
+
+    def test_rename_to_still_available_name_ok(self):
+        """Renaming to a name that still exists in available_columns is not flagged.
+
+        The RenameColumnsBlock runtime handles collision detection separately.
+        This validation only catches 'ghost' names that were renamed away.
+        """
+        config = self._make_flow_config(
+            metadata_extra={
+                "dataset_requirements": {"required_columns": ["a", "b"]},
+            },
+            blocks=[
+                {
+                    "block_type": "LLMChatBlock",
+                    "block_config": {
+                        "block_name": "gen",
+                        "input_cols": "a",
+                        "output_cols": "c",
+                    },
+                },
+                {
+                    "block_type": "RenameColumnsBlock",
+                    "block_config": {
+                        "block_name": "rename_to_b",
+                        "input_cols": {"c": "b"},
+                    },
+                },
+            ],
+        )
+        errors = self.validator.validate_yaml_structure(config)
+        rename_history_errors = [e for e in errors if "previously existed" in e]
+        assert rename_history_errors == []
+
+    def test_no_dataset_requirements_no_history(self):
+        """Without dataset_requirements, no column history is seeded."""
+        config = self._make_flow_config(
+            blocks=[
+                {
+                    "block_type": "LLMChatBlock",
+                    "block_config": {
+                        "block_name": "gen",
+                        "input_cols": "text",
+                        "output_cols": "summary",
+                    },
+                },
+                {
+                    "block_type": "RenameColumnsBlock",
+                    "block_config": {
+                        "block_name": "rename",
+                        "input_cols": {"summary": "result"},
+                    },
+                },
+            ],
+        )
+        errors = self.validator.validate_yaml_structure(config)
+        assert errors == []
+
+    def test_rename_chain_with_intermediate_history_error(self):
+        """A chain of renames where a later rename targets an intermediate name."""
+        config = self._make_flow_config(
+            metadata_extra={
+                "dataset_requirements": {"required_columns": ["col_a"]},
+            },
+            blocks=[
+                {
+                    "block_type": "RenameColumnsBlock",
+                    "block_config": {
+                        "block_name": "step1",
+                        "input_cols": {"col_a": "col_b"},
+                    },
+                },
+                {
+                    "block_type": "RenameColumnsBlock",
+                    "block_config": {
+                        "block_name": "step2",
+                        "input_cols": {"col_b": "col_a"},
+                    },
+                },
+            ],
+        )
+        errors = self.validator.validate_yaml_structure(config)
+        assert any("previously existed" in e for e in errors)
+        assert any("step2" in e for e in errors)


### PR DESCRIPTION
## Summary

- Adds static validation (`_validate_rename_history`) in `FlowValidator` that catches `RenameColumnsBlock` targeting previously-existing column names that were renamed/dropped
- Adds runtime validation (`_validate_column_lifecycle`) in `execution.py` called from both `execute_flow()` and `run_dry_run()` before any block executes, raising `FlowValidationError` with clear messages
- Adds did-you-mean suggestions (via `difflib.get_close_matches`) when `output_columns` reference unknown column names
- Updates 7 knowledge_infusion flows to combine split rename blocks into single atomic operations
- Fixes `RenameColumnsBlock` collision detection to allow atomic source/target swaps within a single block

Closes GH#598, GH#545

## Test plan

- [x] All 979 existing tests pass
- [x] New `TestRenameHistoryValidation` tests: rename-to-historical (error), rename-to-fresh (ok), rename-to-still-available (ok), chain with intermediate history (error)
- [x] New `TestColumnLifecycleValidation` tests: unreachable output_columns (error at generate & dry_run), typo with did-you-mean, rename-to-historical at runtime, valid flow succeeds
- [x] New `test_output_columns_did_you_mean_suggestion` for static validation
- [x] ruff check + format clean
- [x] mypy passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)