### PR TITLE
chore: remove 9 orphaned test fixtures

### DIFF
--- a/tests/flow/conftest.py
+++ b/tests/flow/conftest.py
@@ -2,18 +2,14 @@
 """Shared test fixtures for flow tests."""
 
 # Standard
-from pathlib import Path
-from unittest.mock import Mock
 import tempfile
 
 # Third Party
 import pandas as pd
 import pytest
-import yaml
 
 # First Party
-from sdg_hub import BaseBlock, FlowMetadata
-from sdg_hub.core.flow.metadata import ModelCompatibility, ModelOption
+from sdg_hub import BaseBlock
 
 
 @pytest.fixture
@@ -27,26 +23,6 @@ def temp_dir():
     import shutil
 
     shutil.rmtree(temp_dir)
-
-
-@pytest.fixture
-def sample_metadata():
-    """Create sample flow metadata."""
-    return FlowMetadata(
-        name="Test Flow",
-        description="A test flow for testing",
-        version="1.0.0",
-        author="Test Author",
-        recommended_models=[
-            ModelOption(name="test-model", compatibility=ModelCompatibility.REQUIRED),
-            ModelOption(
-                name="fallback-model", compatibility=ModelCompatibility.COMPATIBLE
-            ),
-        ],
-        tags=["test", "example"],
-        estimated_cost="low",
-        estimated_duration="1-2 minutes",
-    )
 
 
 @pytest.fixture
@@ -113,85 +89,3 @@ def mock_block():
         )
 
     return _create_mock_block
-
-
-@pytest.fixture
-def sample_flow_yaml(temp_dir):
-    """Create a sample flow YAML file."""
-
-    def _create_flow_yaml(name="Test Flow", **kwargs):
-        flow_config = {
-            "metadata": {
-                "name": name,
-                "description": f"Test flow: {name}",
-                "version": "1.0.0",
-                "author": "Test Author",
-                "recommended_models": [
-                    {"name": "test-model", "compatibility": "required"}
-                ],
-                "tags": ["test"],
-                **kwargs,
-            },
-            "blocks": [
-                {
-                    "block_type": "LLMChatBlock",
-                    "block_config": {
-                        "block_name": "test_block",
-                        "input_cols": "input",
-                        "output_cols": "output",
-                        "model": "test/model",
-                    },
-                }
-            ],
-        }
-
-        file_path = Path(temp_dir) / f"{name.lower().replace(' ', '_')}.yaml"
-        with open(file_path, "w") as f:
-            yaml.dump(flow_config, f)
-
-        return str(file_path)
-
-    return _create_flow_yaml
-
-
-@pytest.fixture
-def flow_registry_setup(temp_dir):
-    """Set up flow registry for testing."""
-    # First Party
-    from src.sdg_hub.flow.registry import FlowRegistry
-
-    # Clear existing state
-    FlowRegistry._entries.clear()
-    FlowRegistry._search_paths.clear()
-
-    # Create test flows directory
-    flows_dir = Path(temp_dir) / "test_flows"
-    flows_dir.mkdir()
-
-    yield flows_dir
-
-    # Cleanup
-    FlowRegistry._entries.clear()
-    FlowRegistry._search_paths.clear()
-
-
-@pytest.fixture
-def mock_block_registry():
-    """Mock the BlockRegistry for testing."""
-    # Standard
-    from unittest.mock import patch
-
-    with patch("src.sdg_hub.flow.base.BlockRegistry") as mock_registry:
-        # Mock the get method to return a mock block class
-        def mock_get(block_type):
-            mock_class = Mock()
-            mock_instance = Mock()
-            mock_instance.block_name = "test_block"
-            mock_instance.__class__.__name__ = block_type
-            mock_class.return_value = mock_instance
-            return mock_class
-
-        mock_registry._get.side_effect = mock_get
-        mock_registry.list_blocks.return_value = ["LLMChatBlock", "MockBlock"]
-
-        yield mock_registry

--- a/tests/integration/knowledge_tuning/enhanced_summary_knowledge_tuning/conftest.py
+++ b/tests/integration/knowledge_tuning/enhanced_summary_knowledge_tuning/conftest.py
@@ -52,13 +52,3 @@ def notebook_path():
     )
 
 
-@pytest.fixture(scope="session")
-def converted_script_dir(tmp_path_factory):
-    """Directory for converted notebook scripts."""
-    return tmp_path_factory.mktemp("converted_scripts")
-
-
-@pytest.fixture(scope="session")
-def test_output_dir(tmp_path_factory):
-    """Directory for test outputs."""
-    return tmp_path_factory.mktemp("test_outputs")

--- a/ui/tests/backend/conftest.py
+++ b/ui/tests/backend/conftest.py
@@ -336,21 +336,6 @@ def temp_dir() -> Generator[str, None, None]:
 
 
 @pytest.fixture
-def sample_dataset() -> pd.DataFrame:
-    """Create a sample dataset for testing."""
-    return pd.DataFrame({
-        "input": ["test input 1", "test input 2", "test input 3"],
-        "label": ["label1", "label2", "label3"],
-    })
-
-
-@pytest.fixture
-def empty_dataset() -> pd.DataFrame:
-    """Create an empty dataset for testing."""
-    return pd.DataFrame({"input": [], "label": []})
-
-
-@pytest.fixture
 def sample_jsonl_file(temp_dir) -> str:
     """Create a sample JSONL file."""
     file_path = Path(temp_dir) / "test_data.jsonl"
@@ -362,18 +347,6 @@ def sample_jsonl_file(temp_dir) -> str:
     with open(file_path, "w") as f:
         for item in data:
             f.write(json.dumps(item) + "\n")
-    return str(file_path)
-
-
-@pytest.fixture
-def sample_csv_file(temp_dir) -> str:
-    """Create a sample CSV file."""
-    file_path = Path(temp_dir) / "test_data.csv"
-    df = pd.DataFrame({
-        "input": ["test 1", "test 2", "test 3"],
-        "label": ["a", "b", "c"],
-    })
-    df.to_csv(file_path, index=False)
     return str(file_path)
 
 


### PR DESCRIPTION
## Summary

- Removed 9 orphaned test fixtures (autouse=False, never referenced by any test or fixture chain) from 3 conftest.py files
- Cleaned up imports that were only used by the deleted fixtures
- All structural tests (135), unit tests (971), ruff, and mypy pass cleanly

### Fixtures removed

| File | Fixtures |
|------|----------|
| `tests/flow/conftest.py` | `sample_metadata`, `sample_flow_yaml`, `flow_registry_setup`, `mock_block_registry` |
| `tests/integration/.../enhanced_summary_knowledge_tuning/conftest.py` | `converted_script_dir`, `test_output_dir` |
| `ui/tests/backend/conftest.py` | `sample_dataset`, `empty_dataset`, `sample_csv_file` |

## Tracking

- **Multica Issue:** SDG-58
- **Parent Issue:** SDG-57 (dead code scan 2026-05-11)

## Test plan

- [x] Verified each fixture is unused via codebase-wide grep
- [x] `uv run pytest tests/structural/` — 135 passed
- [x] `uv run ruff check src/ tests/` — all checks passed
- [x] `uv run mypy src/sdg_hub` — no issues
- [x] `uv run pytest tests/blocks tests/connectors tests/flow tests/utils -m "not (examples or slow)"` — 971 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified test configurations by removing unused dataset, metadata, registry and mock fixtures and trimming environment/setup helpers, resulting in a leaner, easier-to-maintain test suite with reduced complexity and faster test runs.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Red-Hat-AI-Innovation-Team/sdg_hub/pull/768)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->