### PR TITLE
fix(examples): enforce tool usage in MCP eval agent

### DIFF
--- a/examples/agentic/mcp_distillation_evaluation/start_agents.sh
+++ b/examples/agentic/mcp_distillation_evaluation/start_agents.sh
@@ -107,7 +107,13 @@ def _create_graph():
     for tool in tools:
         tool.handle_tool_error = True
     print(f"[{MCP_SERVER_NAME}] Loaded {len(tools)} tools from {MCP_SERVER_URL}")
-    return create_react_agent(_get_model, tools)
+    return create_react_agent(
+        _get_model,
+        tools,
+        prompt="You MUST use the available tools to answer every question. "
+        "Never answer from your own knowledge. "
+        "Always call at least one tool before responding.",
+    )
 
 graph = _create_graph()
 PYEOF


### PR DESCRIPTION
## Summary

- Adds a system prompt to `create_react_agent` in `start_agents.sh` that forces the LLM to always call MCP tools instead of answering from its own knowledge
- Fixes empty tool traces and downstream flow failures when using capable frontier models (e.g. GPT-5.2) that tend to answer directly

Closes #742

## Test plan

- [ ] Start MCP servers and agents with `start_agents.sh`
- [ ] Send queries to an agent and verify tool calls appear in every response
- [ ] Run the full generate notebook and confirm `_tool_trace` columns are populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)