### PR TITLE
feat(filtering): add SimilarityFilterBlock for near-duplicate removal

### DIFF
--- a/src/sdg_hub/core/blocks/__init__.py
+++ b/src/sdg_hub/core/blocks/__init__.py
@@ -7,7 +7,7 @@ This package provides various block implementations for data generation, process
 from .agent import AgentBlock, AgentResponseExtractorBlock
 from .base import BaseBlock
 from .code import PythonInterpreterBlock
-from .filtering import ColumnValueFilterBlock
+from .filtering import ColumnValueFilterBlock, SimilarityFilterBlock
 from .llm import (
     LLMChatBlock,
     LLMResponseExtractorBlock,
@@ -34,6 +34,7 @@ __all__ = [
     "BaseBlock",
     "BlockRegistry",
     "ColumnValueFilterBlock",
+    "SimilarityFilterBlock",
     "DuplicateColumnsBlock",
     "IndexBasedMapperBlock",
     "JSONParserBlock",

--- a/src/sdg_hub/core/blocks/filtering/__init__.py
+++ b/src/sdg_hub/core/blocks/filtering/__init__.py
@@ -6,7 +6,9 @@ This module provides blocks for filtering datasets based on various criteria.
 
 # Local
 from .column_value_filter import ColumnValueFilterBlock
+from .similarity_filter import SimilarityFilterBlock
 
 __all__ = [
     "ColumnValueFilterBlock",
+    "SimilarityFilterBlock",
 ]

--- a/src/sdg_hub/core/blocks/filtering/similarity_filter.py
+++ b/src/sdg_hub/core/blocks/filtering/similarity_filter.py
@@ -68,9 +68,7 @@ class SimilarityFilterBlock(BaseBlock):
     def validate_input_cols_not_empty(cls, v: list[str]) -> list[str]:
         """Validate that we have at least one input column."""
         if not v or len(v) == 0:
-            raise ValueError(
-                "SimilarityFilterBlock requires at least one input column"
-            )
+            raise ValueError("SimilarityFilterBlock requires at least one input column")
         return v
 
     def model_post_init(self, __context: Any) -> None:

--- a/src/sdg_hub/core/blocks/filtering/similarity_filter.py
+++ b/src/sdg_hub/core/blocks/filtering/similarity_filter.py
@@ -1,0 +1,163 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Similarity filter block for removing near-duplicate rows.
+
+This module provides a block that performs greedy sequential deduplication
+based on text similarity, comparing each row against previously retained
+rows and dropping entries whose similarity exceeds a configurable threshold.
+"""
+
+# Standard
+from difflib import SequenceMatcher
+from typing import Any, Optional, cast
+
+from pydantic import Field, field_validator
+
+# Third Party
+import pandas as pd
+
+# Local
+from ...utils.logger_config import setup_logger
+from ..base import BaseBlock
+from ..registry import BlockRegistry
+
+logger = setup_logger(__name__)
+
+
+@BlockRegistry.register(
+    "SimilarityFilterBlock",
+    "filtering",
+    "Filters near-duplicate rows based on text similarity within optional groups",
+)
+class SimilarityFilterBlock(BaseBlock):
+    """A block that removes near-duplicate rows based on text similarity.
+
+    Performs greedy sequential deduplication within optional groups
+    (e.g., per document). Each row is compared against previously
+    retained rows and dropped if similarity exceeds the threshold.
+
+    Attributes
+    ----------
+    block_name : str
+        Name of the block.
+    input_cols : Union[str, List[str]]
+        Column(s) to compare for similarity. The first column is used
+        for comparison.
+    threshold : float
+        Similarity threshold (0.0 to 1.0). Rows with similarity above
+        this value to any kept row are dropped. Default 0.85.
+    group_by : Optional[str]
+        Column to group by before deduplication. If set, similarity is
+        only compared within each group.
+    """
+
+    block_type: str = "filtering"
+
+    threshold: float = Field(
+        0.85,
+        description="Similarity threshold (0-1). Rows above this are dropped.",
+        ge=0.0,
+        le=1.0,
+    )
+    group_by: Optional[str] = Field(
+        None,
+        description="Column to group by before comparing similarity.",
+    )
+
+    @field_validator("input_cols", mode="after")
+    @classmethod
+    def validate_input_cols_not_empty(cls, v: list[str]) -> list[str]:
+        """Validate that we have at least one input column."""
+        if not v or len(v) == 0:
+            raise ValueError(
+                "SimilarityFilterBlock requires at least one input column"
+            )
+        return v
+
+    def model_post_init(self, __context: Any) -> None:
+        """Initialize derived attributes after Pydantic validation."""
+        super().model_post_init(__context)
+        if self.output_cols is None:
+            self.output_cols = []
+
+    @staticmethod
+    def _similarity(a: str, b: str) -> float:
+        """Compute similarity ratio between two strings."""
+        if not a and not b:
+            return 1.0
+        if not a or not b:
+            return 0.0
+        return SequenceMatcher(None, a, b).ratio()
+
+    def _deduplicate_group(self, group: pd.DataFrame, col: str) -> pd.DataFrame:
+        """Remove near-duplicate rows within a single group."""
+        kept_indices: list[Any] = []
+        kept_texts: list[str] = []
+
+        for idx, row in group.iterrows():
+            text = str(row[col])
+            is_duplicate = any(
+                self._similarity(text, kept) > self.threshold for kept in kept_texts
+            )
+            if not is_duplicate:
+                kept_indices.append(idx)
+                kept_texts.append(text)
+
+        return group.loc[kept_indices]
+
+    def generate(self, samples: pd.DataFrame, **_kwargs: Any) -> pd.DataFrame:
+        """Filter near-duplicate rows based on text similarity.
+
+        Parameters
+        ----------
+        samples : pd.DataFrame
+            The input dataset.
+
+        Returns
+        -------
+        pd.DataFrame
+            Dataset with near-duplicates removed.
+        """
+        input_cols = cast(list[str], self.input_cols)
+        compare_col = input_cols[0]
+
+        original_len = len(samples)
+
+        if self.group_by and self.group_by not in samples.columns:
+            logger.warning(
+                "SimilarityFilterBlock '%s': group_by column '%s' not found, "
+                "applying global deduplication",
+                self.block_name,
+                self.group_by,
+            )
+
+        if self.group_by and self.group_by in samples.columns:
+            groups = []
+            for _, group in samples.groupby(self.group_by, dropna=False):
+                groups.append(self._deduplicate_group(group, compare_col))
+            result = (
+                pd.concat(groups, ignore_index=True) if groups else samples.iloc[:0]
+            )
+        else:
+            result = self._deduplicate_group(samples, compare_col)
+
+        removed = original_len - len(result)
+        if removed > 0:
+            logger.info(
+                "SimilarityFilterBlock '%s': removed %d near-duplicates "
+                "(threshold=%.2f), %d -> %d rows",
+                self.block_name,
+                removed,
+                self.threshold,
+                original_len,
+                len(result),
+            )
+        else:
+            logger.info(
+                "SimilarityFilterBlock '%s': no near-duplicates found "
+                "(threshold=%.2f, %d rows examined)",
+                self.block_name,
+                self.threshold,
+                original_len,
+            )
+
+        return result.reset_index(drop=True)

--- a/tests/blocks/filtering/test_similarity_filter.py
+++ b/tests/blocks/filtering/test_similarity_filter.py
@@ -1,0 +1,211 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for SimilarityFilterBlock."""
+
+# Third Party
+import numpy as np
+import pandas as pd
+import pytest
+
+# Local
+from sdg_hub.core.blocks.filtering.similarity_filter import SimilarityFilterBlock
+from sdg_hub.core.utils.error_handling import EmptyDatasetError, MissingColumnError
+
+
+@pytest.fixture
+def make_block():
+    """Factory fixture for creating SimilarityFilterBlock instances."""
+
+    def _make(**kwargs):
+        defaults = {
+            "block_name": "test_sim_filter",
+            "input_cols": ["text"],
+            "threshold": 0.85,
+        }
+        defaults.update(kwargs)
+        return SimilarityFilterBlock(**defaults)
+
+    return _make
+
+
+class TestSimilarityFilterBlock:
+    """Tests for similarity-based deduplication."""
+
+    def test_keeps_unique_rows(self, make_block):
+        """Completely different rows should all be kept."""
+        block = make_block()
+        df = pd.DataFrame(
+            {"text": ["alpha bravo charlie", "delta echo foxtrot", "golf hotel india"]}
+        )
+        result = block(df)
+        assert len(result) == 3
+
+    def test_removes_exact_duplicates(self, make_block):
+        """Identical rows should be deduplicated to one."""
+        block = make_block(threshold=0.8)
+        df = pd.DataFrame({"text": ["hello world", "hello world", "hello world"]})
+        result = block(df)
+        assert len(result) == 1
+
+    def test_removes_near_duplicates(self, make_block):
+        """Rows differing by a single word should be caught at high threshold."""
+        block = make_block(threshold=0.7)
+        df = pd.DataFrame(
+            {
+                "text": [
+                    "What is photosynthesis and how does it work?",
+                    "What is photosynthesis and how does it function?",
+                    "Explain the process of sourdough bread making.",
+                ]
+            }
+        )
+        result = block(df)
+        assert len(result) == 2
+
+    def test_group_by_isolates_groups(self, make_block):
+        """Duplicates in different groups should both be kept."""
+        block = make_block(threshold=0.8, group_by="doc_id")
+        df = pd.DataFrame(
+            {
+                "text": ["same text here", "same text here"],
+                "doc_id": ["doc_a", "doc_b"],
+            }
+        )
+        result = block(df)
+        assert len(result) == 2
+
+    def test_group_by_deduplicates_within_group(self, make_block):
+        """Duplicates within the same group should be removed."""
+        block = make_block(threshold=0.8, group_by="doc_id")
+        df = pd.DataFrame(
+            {
+                "text": ["same text here", "same text here"],
+                "doc_id": ["doc_a", "doc_a"],
+            }
+        )
+        result = block(df)
+        assert len(result) == 1
+
+    def test_empty_dataframe_raises(self, make_block):
+        """Empty input should raise EmptyDatasetError via __call__."""
+        block = make_block()
+        df = pd.DataFrame({"text": []})
+        with pytest.raises(EmptyDatasetError):
+            block(df)
+
+    def test_missing_column_raises(self, make_block):
+        """Should raise MissingColumnError when input column is missing."""
+        block = make_block(input_cols=["nonexistent"])
+        df = pd.DataFrame({"other_col": ["a", "b"]})
+        with pytest.raises(MissingColumnError):
+            block(df)
+
+    def test_low_threshold_removes_more(self, make_block):
+        """A lower threshold should be more aggressive."""
+        texts = [
+            "What is photosynthesis?",
+            "What is the process of photosynthesis?",
+            "Explain sourdough bread.",
+        ]
+        strict = make_block(threshold=0.5)
+        lenient = make_block(threshold=0.95)
+        df = pd.DataFrame({"text": texts})
+        assert len(strict(df)) <= len(lenient(df))
+
+    def test_threshold_zero_filters_any_similarity(self, make_block):
+        """Threshold of 0 filters any row with non-zero similarity to kept rows."""
+        df = pd.DataFrame({"text": ["aaa", "aaa!", "bbb"]})
+        block = make_block(threshold=0.0)
+        result = block(df)
+        assert len(result) == 2
+        assert list(result["text"]) == ["aaa", "bbb"]
+
+    def test_threshold_one_keeps_all(self, make_block):
+        """Threshold=1.0 keeps everything since similarity > 1.0 is impossible."""
+        block = make_block(threshold=1.0)
+        df = pd.DataFrame({"text": ["aaa", "aab", "aaa"]})
+        result = block(df)
+        assert len(result) == 3
+
+    def test_invalid_threshold_rejected(self):
+        """Threshold outside 0-1 should be rejected by Pydantic."""
+        with pytest.raises(ValueError):
+            SimilarityFilterBlock(
+                block_name="test",
+                input_cols=["text"],
+                threshold=1.5,
+            )
+
+    def test_empty_input_cols_rejected(self):
+        """Empty input_cols should be rejected by validator."""
+        with pytest.raises(ValueError, match="at least one input column"):
+            SimilarityFilterBlock(
+                block_name="test",
+                input_cols=[],
+            )
+
+    def test_empty_string_similarity(self, make_block):
+        """Two empty strings should be treated as identical and deduplicated."""
+        block = make_block(threshold=0.8)
+        df = pd.DataFrame({"text": ["", "", "actual content"]})
+        result = block(df)
+        assert len(result) == 2
+
+    def test_nan_in_group_by_column_preserved(self, make_block):
+        """Rows with NaN in group_by column should not be silently dropped."""
+        block = make_block(threshold=0.8, group_by="doc_id")
+        df = pd.DataFrame(
+            {
+                "text": ["hello world", "different text", "unique stuff"],
+                "doc_id": ["doc_a", np.nan, "doc_b"],
+            }
+        )
+        result = block(df)
+        assert len(result) == 3
+
+    def test_nan_in_comparison_column(self, make_block):
+        """NaN/None values in the comparison column are coerced via str()."""
+        block = make_block(threshold=0.8)
+        df = pd.DataFrame({"text": [None, None, "actual content"]})
+        result = block(df)
+        assert len(result) == 2
+
+    def test_first_occurrence_retained(self, make_block):
+        """When duplicates are found, the first occurrence should be kept."""
+        block = make_block(threshold=0.8)
+        df = pd.DataFrame(
+            {
+                "text": ["hello world", "hello world!", "completely different"],
+                "id": [1, 2, 3],
+            }
+        )
+        result = block(df)
+        assert len(result) == 2
+        assert list(result["id"]) == [1, 3]
+
+    def test_group_by_missing_column_warns(self, make_block, caplog):
+        """When group_by column is missing, should warn and deduplicate globally."""
+        block = make_block(threshold=0.8, group_by="missing_col")
+        df = pd.DataFrame({"text": ["hello world", "hello world", "different"]})
+        result = block(df)
+        assert len(result) == 2
+        assert "group_by column 'missing_col' not found" in caplog.text
+
+    def test_single_row_dataframe(self, make_block):
+        """A single-row DataFrame should pass through unchanged."""
+        block = make_block()
+        df = pd.DataFrame({"text": ["only row"]})
+        result = block(df)
+        assert len(result) == 1
+        assert result["text"].iloc[0] == "only row"
+
+    def test_uses_first_input_col_only(self, make_block):
+        """When multiple input_cols given, only the first is used for comparison."""
+        block = make_block(input_cols=["text", "other"])
+        df = pd.DataFrame(
+            {
+                "text": ["hello", "hello"],
+                "other": ["world", "universe"],
+            }
+        )
+        result = block(df)
+        assert len(result) == 1


### PR DESCRIPTION
## Summary

Adds a `SimilarityFilterBlock` to `core/blocks/filtering/` that removes near-duplicate rows from a DataFrame based on text similarity using `difflib.SequenceMatcher` (zero new dependencies).

Original design by **UgaTheDev** (PR #665). This implementation incorporates all review feedback from that closed PR.

### Parameters

| Parameter | Type | Default | Description |
|-----------|------|---------|-------------|
| `input_cols` | `str \| list[str]` | required | Column(s) to compare for similarity (first column is used) |
| `threshold` | `float` | `0.85` | Similarity ratio (0.0–1.0). Rows above this vs any kept row are dropped |
| `group_by` | `str \| None` | `None` | If set, deduplication is scoped within groups of this column |

### Review fixes incorporated from PR #665

1. NaN handling in `group_by`: uses `dropna=False` to preserve rows with missing group keys
2. Empty string similarity: `_similarity("", "")` returns 1.0
3. `input_cols` validator: rejects empty lists via `@field_validator`
4. All tests use `__call__()` path (not `generate()`)
5. Empty DataFrame test asserts `EmptyDatasetError`
6. Missing column test asserts `MissingColumnError`
7. Module docstring describes algorithm as greedy sequential scan
8. No unnecessary `hasattr` guard on `model_post_init`
9. `pydantic` import in correct section
10. Logs when zero duplicates are found
11. Tests for NaN in group_by, NaN in comparison column, first-occurrence retention

### Files changed

| File | Change |
|------|--------|
| `src/sdg_hub/core/blocks/filtering/similarity_filter.py` | New block |
| `src/sdg_hub/core/blocks/filtering/__init__.py` | Added export |
| `src/sdg_hub/core/blocks/__init__.py` | Added export |
| `tests/blocks/filtering/test_similarity_filter.py` | 19 unit tests |

## Tracking

- **GitHub Issue:** Fixes #652
- **Multica Issue:** SDG-22
- **Original PR:** #665 (closed, author unresponsive)

## Test plan

- [x] `uv run pytest tests/structural/` — 138 passed
- [x] `uv run ruff check src/ tests/` — all checks passed
- [x] `uv run mypy src/sdg_hub` — no issues
- [x] `uv run pytest tests/blocks/filtering/ -v` — 37 passed (18 existing + 19 new)
- [x] `uv run pytest tests/blocks tests/connectors tests/flow tests/utils -m "not (examples or slow)"` — 990 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added a Similarity Filter block that removes near-duplicate rows based on text similarity comparison with a configurable threshold (0.0–1.0) and optional per-group deduplication.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Red-Hat-AI-Innovation-Team/sdg_hub/pull/779)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->