### PR TITLE
chore: remove 13 orphaned test fixtures

### DIFF
--- a/tests/flow/conftest.py
+++ b/tests/flow/conftest.py
@@ -2,68 +2,13 @@
 """Shared test fixtures for flow tests."""
 
 # Standard
-from pathlib import Path
-from unittest.mock import Mock
 import tempfile
 
 # Third Party
-import pandas as pd
 import pytest
-import yaml
 
 # First Party
-from sdg_hub import BaseBlock, FlowMetadata
-from sdg_hub.core.flow.metadata import ModelCompatibility, ModelOption
-
-
-@pytest.fixture
-def temp_dir():
-    """Create a temporary directory for tests."""
-    temp_dir = tempfile.mkdtemp()
-    yield temp_dir
-
-    # Cleanup
-    # Standard
-    import shutil
-
-    shutil.rmtree(temp_dir)
-
-
-@pytest.fixture
-def sample_metadata():
-    """Create sample flow metadata."""
-    return FlowMetadata(
-        name="Test Flow",
-        description="A test flow for testing",
-        version="1.0.0",
-        author="Test Author",
-        recommended_models=[
-            ModelOption(name="test-model", compatibility=ModelCompatibility.REQUIRED),
-            ModelOption(
-                name="fallback-model", compatibility=ModelCompatibility.COMPATIBLE
-            ),
-        ],
-        tags=["test", "example"],
-        estimated_cost="low",
-        estimated_duration="1-2 minutes",
-    )
-
-
-@pytest.fixture
-def sample_dataset():
-    """Create a sample dataset for testing."""
-    return pd.DataFrame(
-        {
-            "input": ["test input 1", "test input 2", "test input 3"],
-            "label": ["label1", "label2", "label3"],
-        }
-    )
-
-
-@pytest.fixture
-def empty_dataset():
-    """Create an empty dataset for testing."""
-    return pd.DataFrame({"input": [], "label": []})
+from sdg_hub import BaseBlock
 
 
 class MockBlock(BaseBlock):
@@ -102,6 +47,19 @@ class MockBlock(BaseBlock):
 
 
 @pytest.fixture
+def temp_dir():
+    """Create a temporary directory for tests."""
+    temp_dir = tempfile.mkdtemp()
+    yield temp_dir
+
+    # Cleanup
+    # Standard
+    import shutil
+
+    shutil.rmtree(temp_dir)
+
+
+@pytest.fixture
 def mock_block():
     """Create a mock block for testing."""
 
@@ -113,85 +71,3 @@ def mock_block():
         )
 
     return _create_mock_block
-
-
-@pytest.fixture
-def sample_flow_yaml(temp_dir):
-    """Create a sample flow YAML file."""
-
-    def _create_flow_yaml(name="Test Flow", **kwargs):
-        flow_config = {
-            "metadata": {
-                "name": name,
-                "description": f"Test flow: {name}",
-                "version": "1.0.0",
-                "author": "Test Author",
-                "recommended_models": [
-                    {"name": "test-model", "compatibility": "required"}
-                ],
-                "tags": ["test"],
-                **kwargs,
-            },
-            "blocks": [
-                {
-                    "block_type": "LLMChatBlock",
-                    "block_config": {
-                        "block_name": "test_block",
-                        "input_cols": "input",
-                        "output_cols": "output",
-                        "model": "test/model",
-                    },
-                }
-            ],
-        }
-
-        file_path = Path(temp_dir) / f"{name.lower().replace(' ', '_')}.yaml"
-        with open(file_path, "w") as f:
-            yaml.dump(flow_config, f)
-
-        return str(file_path)
-
-    return _create_flow_yaml
-
-
-@pytest.fixture
-def flow_registry_setup(temp_dir):
-    """Set up flow registry for testing."""
-    # First Party
-    from src.sdg_hub.flow.registry import FlowRegistry
-
-    # Clear existing state
-    FlowRegistry._entries.clear()
-    FlowRegistry._search_paths.clear()
-
-    # Create test flows directory
-    flows_dir = Path(temp_dir) / "test_flows"
-    flows_dir.mkdir()
-
-    yield flows_dir
-
-    # Cleanup
-    FlowRegistry._entries.clear()
-    FlowRegistry._search_paths.clear()
-
-
-@pytest.fixture
-def mock_block_registry():
-    """Mock the BlockRegistry for testing."""
-    # Standard
-    from unittest.mock import patch
-
-    with patch("src.sdg_hub.flow.base.BlockRegistry") as mock_registry:
-        # Mock the get method to return a mock block class
-        def mock_get(block_type):
-            mock_class = Mock()
-            mock_instance = Mock()
-            mock_instance.block_name = "test_block"
-            mock_instance.__class__.__name__ = block_type
-            mock_class.return_value = mock_instance
-            return mock_class
-
-        mock_registry._get.side_effect = mock_get
-        mock_registry.list_blocks.return_value = ["LLMChatBlock", "MockBlock"]
-
-        yield mock_registry

--- a/tests/integration/knowledge_tuning/enhanced_summary_knowledge_tuning/conftest.py
+++ b/tests/integration/knowledge_tuning/enhanced_summary_knowledge_tuning/conftest.py
@@ -50,15 +50,3 @@ def notebook_path():
     return Path(
         "examples/knowledge_tuning/enhanced_summary_knowledge_tuning/knowledge_generation.ipynb"
     )
-
-
-@pytest.fixture(scope="session")
-def converted_script_dir(tmp_path_factory):
-    """Directory for converted notebook scripts."""
-    return tmp_path_factory.mktemp("converted_scripts")
-
-
-@pytest.fixture(scope="session")
-def test_output_dir(tmp_path_factory):
-    """Directory for test outputs."""
-    return tmp_path_factory.mktemp("test_outputs")

--- a/ui/tests/backend/conftest.py
+++ b/ui/tests/backend/conftest.py
@@ -336,21 +336,6 @@ def temp_dir() -> Generator[str, None, None]:
 
 
 @pytest.fixture
-def sample_dataset() -> pd.DataFrame:
-    """Create a sample dataset for testing."""
-    return pd.DataFrame({
-        "input": ["test input 1", "test input 2", "test input 3"],
-        "label": ["label1", "label2", "label3"],
-    })
-
-
-@pytest.fixture
-def empty_dataset() -> pd.DataFrame:
-    """Create an empty dataset for testing."""
-    return pd.DataFrame({"input": [], "label": []})
-
-
-@pytest.fixture
 def sample_jsonl_file(temp_dir) -> str:
     """Create a sample JSONL file."""
     file_path = Path(temp_dir) / "test_data.jsonl"
@@ -362,18 +347,6 @@ def sample_jsonl_file(temp_dir) -> str:
     with open(file_path, "w") as f:
         for item in data:
             f.write(json.dumps(item) + "\n")
-    return str(file_path)
-
-
-@pytest.fixture
-def sample_csv_file(temp_dir) -> str:
-    """Create a sample CSV file."""
-    file_path = Path(temp_dir) / "test_data.csv"
-    df = pd.DataFrame({
-        "input": ["test 1", "test 2", "test 3"],
-        "label": ["a", "b", "c"],
-    })
-    df.to_csv(file_path, index=False)
     return str(file_path)
 
 
@@ -566,45 +539,6 @@ def test_client(mock_sdg_hub, temp_dir) -> TestClient:
     finally:
         for p in patches:
             p.stop()
-
-
-@pytest.fixture
-def saved_config_file(temp_dir) -> str:
-    """Create a saved configurations file."""
-    file_path = Path(temp_dir) / "saved_configurations.json"
-    configs = [
-        {
-            "id": "config-1",
-            "flow_name": "Test Flow",
-            "flow_id": "test-flow-id",
-            "model_configuration": {"model": "test-model"},
-            "dataset_configuration": {"data_files": "test.jsonl"},
-            "status": "configured",
-            "created_at": "2024-01-01T00:00:00",
-        }
-    ]
-    with open(file_path, "w") as f:
-        json.dump(configs, f)
-    return str(file_path)
-
-
-@pytest.fixture
-def runs_history_file(temp_dir) -> str:
-    """Create a runs history file."""
-    file_path = Path(temp_dir) / "runs_history.json"
-    runs = [
-        {
-            "run_id": "run-1",
-            "config_id": "config-1",
-            "flow_name": "Test Flow",
-            "status": "completed",
-            "start_time": "2024-01-01T00:00:00",
-            "output_samples": 100,
-        }
-    ]
-    with open(file_path, "w") as f:
-        json.dump(runs, f)
-    return str(file_path)
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

Removes 13 orphaned pytest fixtures that are defined in conftest.py files but never used by any test or other fixture:

- **tests/flow/conftest.py (6):** `sample_metadata`, `sample_dataset`, `empty_dataset`, `sample_flow_yaml`, `flow_registry_setup`, `mock_block_registry`
- **tests/integration/knowledge_tuning/enhanced_summary_knowledge_tuning/conftest.py (2):** `converted_script_dir`, `test_output_dir`
- **ui/tests/backend/conftest.py (5):** `sample_dataset`, `empty_dataset`, `sample_csv_file`, `saved_config_file`, `runs_history_file`

Also removes imports that became unused after fixture deletion (Path, Mock, pandas, yaml, FlowMetadata, ModelCompatibility, ModelOption from tests/flow/conftest.py).

None of the removed fixtures use `autouse=True` and none are consumed by other fixtures.

## Tracking

- **Multica Issue:** SDG-31
- **Parent Multica Issue:** SDG-30 (dead code scan)

## Verification

- `uv run pytest tests/structural/` — 135 passed, 4 xfailed
- `uv run ruff check src/ tests/` — All checks passed
- `uv run mypy src/sdg_hub` — Success, no issues found in 73 source files
- `uv run pytest tests/blocks tests/connectors tests/flow tests/utils -m "not (examples or slow)"` — 971 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Reorganized test configuration and fixtures across multiple test modules (flow, knowledge tuning, and backend test suites) to improve overall code structure and clarity.
  * Simplified test setup and dependency management by reducing redundancy in test fixture definitions.
  * Enhanced testing infrastructure organization for improved maintainability and consistency across test modules.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Red-Hat-AI-Innovation-Team/sdg_hub/pull/784)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->