### PR TITLE
ci: add path filter to Score Gate workflow

### DIFF
--- a/.github/workflows/score-gate.yml
+++ b/.github/workflows/score-gate.yml
@@ -9,6 +9,12 @@ on:
     types:
       - opened
       - synchronize
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'eval/**'
+      - 'pyproject.toml'
+      - '.github/workflows/score-gate.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

- Adds `paths` filter to the Score Gate workflow trigger so it only runs when Python source (`src/**`), tests (`tests/**`), eval scripts (`eval/**`), `pyproject.toml`, or the workflow file itself change.
- Dockerfile-only, docs-only, and workflow-only PRs now skip the Score Gate, preventing false failures like PR #766.
- Follows the same path-filtering pattern used by `lint.yml` and `test.yml`.

## Tracking

- **GitHub Issue:** Fixes #780
- **Multica Issue:** SDG-36

## Test plan

- [ ] Verify the workflow YAML is valid (validated locally with PyYAML)
- [ ] Create a test PR with only a Dockerfile change — Score Gate should not trigger
- [ ] Create a test PR with a Python file change — Score Gate should trigger as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow trigger configuration to optimize test execution by restricting automated checks to relevant code and configuration files.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Red-Hat-AI-Innovation-Team/sdg_hub/pull/785)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->