### PR TITLE
docs: add dedicated Get Started page for CTA button

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -1,0 +1,76 @@
+# Get Started
+
+Get up and running with SDG Hub in two steps. By the end, you will have a fully bootstrapped environment ready to generate synthetic data from your documents.
+
+## Prerequisites
+
+- **Python 3.10+** installed
+- **Claude Code** installed ([install guide](https://docs.anthropic.com/en/docs/claude-code/overview))
+- An LLM API key (OpenAI, Anthropic, or any [supported provider](https://docs.litellm.ai/docs/providers))
+
+## Step 1: Bootstrap SDG Hub
+
+Run this single command to install SDG Hub, its dependencies, and all required Claude Code skills:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Red-Hat-AI-Innovation-Team/sdg_hub/main/scripts/bootstrap.sh | claude --dangerously-skip-permissions
+```
+
+**What this does:**
+
+1. Installs `sdg-hub` and its Python dependencies via `uv` (or `pip` as fallback)
+2. Clones the SDG Hub repository so Claude has access to flow definitions and prompt templates
+3. Installs the `synthetic-data-generation` skill into your Claude Code environment
+4. Verifies the installation by discovering all available blocks and flows
+
+??? note "Prefer a manual install?"
+
+    If you'd rather install manually, see the [Installation](installation.md) guide. Then add the skill yourself:
+
+    ```bash
+    git clone https://github.com/Red-Hat-AI-Innovation-Team/sdg_hub.git
+    cd sdg_hub
+    uv pip install .
+    ```
+
+    The Claude Code skill at `.claude/skills/synthetic-data-generation/` is included in the repo and will be picked up automatically when you run Claude from the project directory.
+
+## Step 2: Generate Data
+
+Launch a Claude Code session with SDG Hub fully initialized:
+
+```bash
+cd sdg_hub
+claude
+```
+
+Claude already has the `synthetic-data-generation` skill loaded from the repository's `.claude/` directory. Just describe what you need in plain language:
+
+> *"I have a folder of PDF documents in `./data/docs/`. Generate a question-answer dataset from them using the QA generation flow. Use `openai/gpt-4o-mini` as the model."*
+
+Claude will:
+
+- Discover the right pre-built flow for your task
+- Load and validate your input data
+- Configure the LLM provider
+- Run a dry-run to catch errors early
+- Execute the full pipeline and save results
+
+### Example Prompts
+
+Here are some things you can ask Claude to do once the session is running:
+
+| What you want | Example prompt |
+|---|---|
+| Generate QA pairs | *"Generate question-answer pairs from the documents in `./data/`. Save as parquet."* |
+| List available flows | *"What pre-built flows are available? Show me the ones tagged for QA generation."* |
+| Build a custom pipeline | *"Create a YAML flow that takes a CSV of product descriptions, generates marketing copy, and filters out low-quality results."* |
+| Use a local model | *"Run the text-analysis flow using my local vLLM server at `http://localhost:8000/v1` with `meta-llama/Llama-3.3-70B-Instruct`."* |
+| Inspect a flow | *"Show me what blocks are in the `knowledge-base-qa` flow and what columns it needs."* |
+
+## What's Next
+
+- [Quick Start](quickstart.md) -- step-by-step walkthrough of the Python API
+- [Core Concepts](concepts.md) -- understand blocks, flows, and registries
+- [Built-in Flows](flows/built-in-flows.md) -- browse the full catalog of pre-built pipelines
+- [Custom Flows](flows/custom-flows.md) -- author your own YAML flow definitions

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,6 +51,7 @@ plugins:
   - llmstxt:
       sections:
         Getting Started:
+          - get-started.md
           - installation.md
           - quickstart.md
           - concepts.md
@@ -95,6 +96,7 @@ markdown_extensions:
 nav:
   - Home: index.md
   - Getting Started:
+    - Get Started: get-started.md
     - Installation: installation.md
     - Quick Start: quickstart.md
     - Core Concepts: concepts.md

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Bootstrap script for SDG Hub — installs the package, clones the repo, and
+# verifies that blocks and flows are discoverable.
+
+set -euo pipefail
+
+echo "==> Bootstrapping SDG Hub..."
+
+# --- 1. Install sdg-hub --------------------------------------------------- #
+if command -v uv &>/dev/null; then
+  echo "==> Installing sdg-hub via uv..."
+  uv pip install sdg-hub
+else
+  echo "==> uv not found, falling back to pip..."
+  pip install sdg-hub
+fi
+
+# --- 2. Clone the repository for flows and skills ------------------------- #
+REPO_URL="https://github.com/Red-Hat-AI-Innovation-Team/sdg_hub.git"
+TARGET_DIR="sdg_hub"
+
+if [ -d "$TARGET_DIR/.git" ]; then
+  echo "==> Repository already cloned at ./$TARGET_DIR — pulling latest..."
+  git -C "$TARGET_DIR" pull --ff-only || true
+else
+  echo "==> Cloning SDG Hub repository..."
+  git clone "$REPO_URL" "$TARGET_DIR"
+fi
+
+# --- 3. Verify installation ----------------------------------------------- #
+echo "==> Verifying installation..."
+python3 -c "
+from sdg_hub import FlowRegistry, BlockRegistry
+FlowRegistry.discover_flows()
+BlockRegistry.discover_blocks()
+flows = FlowRegistry.list_flows()
+blocks = BlockRegistry.list_blocks()
+print(f'  Flows available:  {len(flows)}')
+print(f'  Blocks available: {len(blocks)}')
+"
+
+echo ""
+echo "==> SDG Hub is ready!"
+echo "    cd $TARGET_DIR && claude"
+echo ""
+echo "    Then describe what data you need — Claude has the"
+echo "    synthetic-data-generation skill loaded automatically."

--- a/website/src/app/page.tsx
+++ b/website/src/app/page.tsx
@@ -105,7 +105,7 @@ export default function Home() {
         {/* CTA buttons */}
         <div className="relative mt-10 flex flex-wrap justify-center gap-4">
           <Link
-            href="/docs"
+            href="/docs/get-started"
             className="rounded-lg px-6 py-2.5 text-sm font-medium text-bg-0 transition-all hover:brightness-110"
             style={{ background: "var(--color-accent)" }}
           >

--- a/website/src/lib/navigation.ts
+++ b/website/src/lib/navigation.ts
@@ -13,6 +13,7 @@ export const navigation: NavSection[] = [
     title: "Getting Started",
     items: [
       { title: "Introduction", href: "/docs" },
+      { title: "Get Started", href: "/docs/get-started" },
       { title: "Installation", href: "/docs/installation" },
       { title: "Quick Start", href: "/docs/quickstart" },
       { title: "Core Concepts", href: "/docs/concepts" },


### PR DESCRIPTION
## Summary

- Create a dedicated **Get Started** documentation page (`docs/get-started.md`) with a streamlined two-step onboarding workflow: (1) bootstrap SDG Hub via `curl | claude --dangerously-skip-permissions`, (2) launch a Claude session with the synthetic-data-generation skill pre-loaded
- Add `scripts/bootstrap.sh` that installs sdg-hub, clones the repo, and verifies the installation
- Update the website hero CTA button to link to `/docs/get-started` instead of `/docs`
- Add the new page to both `mkdocs.yml` navigation and the website sidebar (`navigation.ts`)

## Tracking

- **GitHub Issue:** Fixes #712
- **Multica Issue:** SDG-42

## Test plan

- [ ] CTA button on homepage links to `/docs/get-started`
- [ ] New page renders correctly in MkDocs (`mkdocs serve`)
- [ ] New page renders correctly in the Next.js website (`npm run dev` in `website/`)
- [ ] Page appears in the docs sidebar under "Getting Started"
- [ ] `markdownlint-cli2` passes on `docs/get-started.md`
- [ ] Structural tests pass (`pytest tests/structural/`)
- [ ] Unit tests pass (`pytest tests/blocks tests/connectors tests/flow tests/utils`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)