### PR TITLE
chore: update QUALITY.md with 2026-05-10 grading results

### DIFF
--- a/docs/agent-knowledge/QUALITY.md
+++ b/docs/agent-knowledge/QUALITY.md
@@ -1,19 +1,21 @@
 # Quality Grades
 
-Last updated: 2026-05-08
+Last updated: 2026-05-10
 
 Quality grades by domain. Grades are populated when the quality grading
 Autopilot runs (Phase 4).
 
+Composite score: **1.0000** (all 971 tests pass)
+
 | Domain | Test Coverage | Lint | Types | Docs | Overall |
 |---|---|---|---|---|---|
-| blocks/llm | -- | -- | -- | -- | Pending |
-| blocks/parsing | -- | -- | -- | -- | Pending |
-| blocks/transform | -- | -- | -- | -- | Pending |
-| blocks/filtering | -- | -- | -- | -- | Pending |
-| blocks/agent | -- | -- | -- | -- | Pending |
-| blocks/mcp | -- | -- | -- | -- | Pending |
-| blocks/code | -- | -- | -- | -- | Pending |
-| flow/ | -- | -- | -- | -- | Pending |
-| connectors/ | -- | -- | -- | -- | Pending |
-| utils/ | -- | -- | -- | -- | Pending |
+| blocks/llm | 84% | Pass | Pass | 80% | B+ |
+| blocks/parsing | 92% | Pass | Pass | 40% | B |
+| blocks/transform | 95% | Pass | Pass | 89% | A |
+| blocks/filtering | 87% | Pass | Pass | 100% | A |
+| blocks/agent | 91% | Pass | Pass | 66% | B+ |
+| blocks/mcp | 85% | Pass | Pass | 100% | A |
+| blocks/code | 89% | Pass | Pass | 100% | A |
+| flow/ | 89% | Pass | Pass | 71% | B+ |
+| connectors/ | 91% | Pass | Pass | 54% | B |
+| utils/ | 93% | Pass | Pass | 31% | B |


### PR DESCRIPTION
## Summary

- Ran daily quality grading for 2026-05-10
- Composite score: **1.0000** — all 971 tests pass
- All 10 domains pass lint (ruff) and type checks (mypy)
- Test coverage ranges from 84% (blocks/llm) to 95% (blocks/transform)
- Four domains graded A, three B+, three B (docstring coverage is the differentiator)

## Tracking

- **Multica Issue:** SDG-48
- **Parent Issue:** SDG-47

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated quality metrics documentation with complete per-domain grades, test coverage status, validation results, and composite score calculations. Replaced placeholder entries with actual performance data.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Red-Hat-AI-Innovation-Team/sdg_hub/pull/793)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->