### PR TITLE
docs: update agent-knowledge verified dates to 2026-05-11

### DIFF
--- a/docs/agent-knowledge/index.md
+++ b/docs/agent-knowledge/index.md
@@ -8,15 +8,15 @@ to your current task -- do not load all files at once.
 
 | File | Topic | Last verified |
 |------|-------|---------------|
-| [core-principles.md](core-principles.md) | Golden rules that apply to all contributions | 2026-05-08 |
-| [block-invariants.md](block-invariants.md) | Rules every block must follow | 2026-05-08 |
-| [flow-invariants.md](flow-invariants.md) | Rules every flow YAML must follow | 2026-05-08 |
-| [connector-invariants.md](connector-invariants.md) | Rules every connector must follow | 2026-05-08 |
-| [testing-standards.md](testing-standards.md) | What "tested" means and how to write tests | 2026-05-08 |
-| [grading-criteria.md](grading-criteria.md) | Quality criteria with hard thresholds | 2026-05-08 |
-| [decision-rubric.md](decision-rubric.md) | When to auto-fix, flag, or escalate | 2026-05-08 |
-| [QUALITY.md](QUALITY.md) | Quality grades per domain/layer | 2026-05-08 |
-| [tech-debt-tracker.md](tech-debt-tracker.md) | Known debt, prioritized | 2026-05-08 |
+| [core-principles.md](core-principles.md) | Golden rules that apply to all contributions | 2026-05-11 |
+| [block-invariants.md](block-invariants.md) | Rules every block must follow | 2026-05-11 |
+| [flow-invariants.md](flow-invariants.md) | Rules every flow YAML must follow | 2026-05-11 |
+| [connector-invariants.md](connector-invariants.md) | Rules every connector must follow | 2026-05-11 |
+| [testing-standards.md](testing-standards.md) | What "tested" means and how to write tests | 2026-05-11 |
+| [grading-criteria.md](grading-criteria.md) | Quality criteria with hard thresholds | 2026-05-11 |
+| [decision-rubric.md](decision-rubric.md) | When to auto-fix, flag, or escalate | 2026-05-11 |
+| [QUALITY.md](QUALITY.md) | Quality grades per domain/layer | 2026-05-11 |
+| [tech-debt-tracker.md](tech-debt-tracker.md) | Known debt, prioritized | 2026-05-11 |
 
 ## Progressive Disclosure
 


### PR DESCRIPTION
## Summary
- Updated all 9 "Last verified" dates in `docs/agent-knowledge/index.md` from `2026-05-08` to `2026-05-11`
- Daily doc gardening confirmed all docs are current, cross-links resolve, and code references are valid

## Tracking
- **Multica Issue:** SDG-54
- **Parent Issue:** SDG-53

## Test plan
- [ ] Verify all 9 dates in the table show `2026-05-11`
- [ ] Confirm no other content was changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated metadata for agent knowledge documentation resources.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Red-Hat-AI-Innovation-Team/sdg_hub/pull/795)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->