### PR TITLE
chore: update QUALITY.md with 2026-05-11 daily grading

### DIFF
--- a/docs/agent-knowledge/QUALITY.md
+++ b/docs/agent-knowledge/QUALITY.md
@@ -1,19 +1,28 @@
 # Quality Grades
 
-Last updated: 2026-05-08
+Last updated: 2026-05-11
 
-Quality grades by domain. Grades are populated when the quality grading
-Autopilot runs (Phase 4).
+Composite score: **1.0** (all tiers passing)
+
+| Tier | Weight | Score |
+|---|---|---|
+| Hygiene (pytest, ruff, mypy, structural) | 30% | 1.0 |
+| Growth (registry count, test coverage) | 20% | 1.0 |
+| Project (block, flow, connector tests) | 50% | 1.0 |
+
+## Per-Domain Grades
+
+971 tests passing, 90% overall coverage.
 
 | Domain | Test Coverage | Lint | Types | Docs | Overall |
 |---|---|---|---|---|---|
-| blocks/llm | -- | -- | -- | -- | Pending |
-| blocks/parsing | -- | -- | -- | -- | Pending |
-| blocks/transform | -- | -- | -- | -- | Pending |
-| blocks/filtering | -- | -- | -- | -- | Pending |
-| blocks/agent | -- | -- | -- | -- | Pending |
-| blocks/mcp | -- | -- | -- | -- | Pending |
-| blocks/code | -- | -- | -- | -- | Pending |
-| flow/ | -- | -- | -- | -- | Pending |
-| connectors/ | -- | -- | -- | -- | Pending |
-| utils/ | -- | -- | -- | -- | Pending |
+| blocks/llm | 84% | Pass | Pass | Pass | B |
+| blocks/parsing | 92% | Pass | Pass | Pass | A |
+| blocks/transform | 95% | Pass | Pass | Pass | A |
+| blocks/filtering | 87% | Pass | Pass | Pass | B |
+| blocks/agent | 91% | Pass | Pass | Pass | A |
+| blocks/mcp | 85% | Pass | Pass | Pass | B |
+| blocks/code | 89% | Pass | Pass | Pass | B |
+| flow/ | 89% | Pass | Pass | Pass | B |
+| connectors/ | 92% | Pass | Pass | Pass | A |
+| utils/ | 93% | Pass | Pass | Pass | A |


### PR DESCRIPTION
## Summary

- Ran `eval/score.py` — composite score: **1.0** (all tiers passing)
- Ran `pytest --cov` — 971 tests passing, 90% overall coverage
- Updated `docs/agent-knowledge/QUALITY.md` with per-domain grades (coverage, lint, types, docs)

## Tracking

- **Multica Issue:** SDG-56
- **Parent Issue:** SDG-55

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated quality report with actual metrics, including composite score of 1.0 (all tiers passing), tier weights and scores, per-domain grades for coverage, linting, types and documentation, plus test statistics (971 tests passing, 90% overall coverage).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Red-Hat-AI-Innovation-Team/sdg_hub/pull/796)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->