### PR TITLE
chore: add root tests/conftest.py with shared fixtures

### DIFF
--- a/docs/agent-knowledge/tech-debt-tracker.md
+++ b/docs/agent-knowledge/tech-debt-tracker.md
@@ -5,28 +5,11 @@ resolved; new items are added as they are discovered.
 
 ## High Priority
 
-- **Legacy .isort.cfg and .pylintrc redundant with ruff.** These config files
-  are superseded by ruff which handles both linting and import sorting. Being
-  removed in Phase 1.
-
-- **Stale \_\_pycache\_\_ directories for deleted test modules.** Leftover
-  bytecode caches exist for test modules that have been removed:
-  `tests/blocks/evaluation/`, `tests/blocks/utilblocks/`,
-  `tests/blocks/column_ops/`. These should be cleaned up and added to
-  `.gitignore` if not already excluded.
-
 - **Two documentation systems (MkDocs + Next.js) creating drift risk.** Having
   two separate documentation builds means content can diverge. Consolidate to
   a single system or establish a clear ownership boundary between them.
 
 ## Medium Priority
-
-- **No top-level conftest.py with shared test fixtures.** Common test helpers
-  (mock LLM clients, sample datasets, temporary flow YAML) are duplicated
-  across test modules instead of shared via a root `conftest.py`.
-
-- **No .env.example at project root.** New contributors have no reference for
-  which environment variables are expected. Being added in Phase 1.
 
 - **Some block categories missing in CLAUDE.md block category table.** The
   `blocks/code` category and any newly added categories are not listed in the

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared test fixtures available to all test modules."""
+
+# Standard
+import shutil
+import tempfile
+
+# Third Party
+import pandas as pd
+import pytest
+
+# First Party
+from sdg_hub import BaseBlock
+
+
+class MockBlock(BaseBlock):
+    """Mock block for testing that inherits from BaseBlock."""
+
+    def __init__(
+        self, block_name="test_block", input_cols=None, output_cols=None, **kwargs
+    ):
+        super().__init__(
+            block_name=block_name,
+            input_cols=input_cols or ["input"],
+            output_cols=output_cols or ["output"],
+            **kwargs,
+        )
+
+    def __call__(self, dataset, **kwargs):
+        """Mock block execution."""
+        result = dataset.copy()
+
+        if isinstance(self.output_cols, list):
+            for col in self.output_cols:
+                result[col] = [
+                    f"{self.block_name}_{col}_{i}" for i in range(len(dataset))
+                ]
+        else:
+            result[self.output_cols] = [
+                f"{self.block_name}_{self.output_cols}_{i}" for i in range(len(dataset))
+            ]
+        return result
+
+    def generate(self, dataset, **kwargs):
+        """Generate method for BaseBlock compatibility."""
+        return self(dataset, **kwargs)
+
+
+@pytest.fixture
+def mock_block():
+    """Create a mock block for testing."""
+
+    def _create_mock_block(name="test_block", input_cols=None, output_cols=None):
+        return MockBlock(
+            block_name=name,
+            input_cols=input_cols or ["input"],
+            output_cols=output_cols or ["output"],
+        )
+
+    return _create_mock_block
+
+
+@pytest.fixture
+def sample_dataset():
+    """Create a sample dataset for testing."""
+    return pd.DataFrame(
+        {
+            "input": ["test input 1", "test input 2", "test input 3"],
+            "label": ["label1", "label2", "label3"],
+        }
+    )
+
+
+@pytest.fixture
+def empty_dataset():
+    """Create an empty dataset for testing."""
+    return pd.DataFrame({"input": [], "label": []})
+
+
+@pytest.fixture
+def temp_dir():
+    """Create a temporary directory for tests."""
+    d = tempfile.mkdtemp()
+    yield d
+    shutil.rmtree(d, ignore_errors=True)

--- a/tests/flow/conftest.py
+++ b/tests/flow/conftest.py
@@ -1,32 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Shared test fixtures for flow tests."""
+"""Flow-specific test fixtures."""
 
 # Standard
 from pathlib import Path
 from unittest.mock import Mock
-import tempfile
 
 # Third Party
-import pandas as pd
 import pytest
 import yaml
 
 # First Party
-from sdg_hub import BaseBlock, FlowMetadata
+from sdg_hub import FlowMetadata
 from sdg_hub.core.flow.metadata import ModelCompatibility, ModelOption
-
-
-@pytest.fixture
-def temp_dir():
-    """Create a temporary directory for tests."""
-    temp_dir = tempfile.mkdtemp()
-    yield temp_dir
-
-    # Cleanup
-    # Standard
-    import shutil
-
-    shutil.rmtree(temp_dir)
 
 
 @pytest.fixture
@@ -47,72 +32,6 @@ def sample_metadata():
         estimated_cost="low",
         estimated_duration="1-2 minutes",
     )
-
-
-@pytest.fixture
-def sample_dataset():
-    """Create a sample dataset for testing."""
-    return pd.DataFrame(
-        {
-            "input": ["test input 1", "test input 2", "test input 3"],
-            "label": ["label1", "label2", "label3"],
-        }
-    )
-
-
-@pytest.fixture
-def empty_dataset():
-    """Create an empty dataset for testing."""
-    return pd.DataFrame({"input": [], "label": []})
-
-
-class MockBlock(BaseBlock):
-    """Mock block for testing that inherits from BaseBlock."""
-
-    def __init__(
-        self, block_name="test_block", input_cols=None, output_cols=None, **kwargs
-    ):
-        super().__init__(
-            block_name=block_name,
-            input_cols=input_cols or ["input"],
-            output_cols=output_cols or ["output"],
-            **kwargs,
-        )
-
-    def __call__(self, dataset, **kwargs):
-        """Mock block execution."""
-        # Make a copy to avoid modifying the original
-        result = dataset.copy()
-
-        # Add output columns
-        if isinstance(self.output_cols, list):
-            for col in self.output_cols:
-                result[col] = [
-                    f"{self.block_name}_{col}_{i}" for i in range(len(dataset))
-                ]
-        else:
-            result[self.output_cols] = [
-                f"{self.block_name}_{self.output_cols}_{i}" for i in range(len(dataset))
-            ]
-        return result
-
-    def generate(self, dataset, **kwargs):
-        """Generate method for BaseBlock compatibility."""
-        return self(dataset, **kwargs)
-
-
-@pytest.fixture
-def mock_block():
-    """Create a mock block for testing."""
-
-    def _create_mock_block(name="test_block", input_cols=None, output_cols=None):
-        return MockBlock(
-            block_name=name,
-            input_cols=input_cols or ["input"],
-            output_cols=output_cols or ["output"],
-        )
-
-    return _create_mock_block
 
 
 @pytest.fixture

--- a/tests/flow/test_agent_config.py
+++ b/tests/flow/test_agent_config.py
@@ -15,7 +15,7 @@ import yaml
 
 from sdg_hub import Flow, FlowMetadata
 from sdg_hub.core.flow.metadata import RecommendedModels
-from tests.flow.conftest import MockBlock
+from tests.conftest import MockBlock
 
 
 @pytest.fixture()

--- a/tests/flow/test_base.py
+++ b/tests/flow/test_base.py
@@ -50,7 +50,7 @@ class TestFlow:
     def create_mock_block(self, name="test_block", input_cols=None, output_cols=None):
         """Create a mock block for testing."""
         # First Party
-        from tests.flow.conftest import MockBlock
+        from tests.conftest import MockBlock
 
         return MockBlock(
             block_name=name,
@@ -399,7 +399,7 @@ class TestFlow:
     def test_dry_run_block_execution_failure(self):
         """Test dry_run exception handling when a block fails during execution."""
         # Create a block that raises an exception when executed
-        from tests.flow.conftest import MockBlock
+        from tests.conftest import MockBlock
 
         class FailingBlock(MockBlock):
             """Mock block that raises an exception during execution."""
@@ -555,7 +555,7 @@ class TestFlow:
         """Create a mock LLM block with model attributes."""
         # First Party
         from pydantic import SecretStr
-        from tests.flow.conftest import MockBlock
+        from tests.conftest import MockBlock
 
         block = MockBlock(block_name=name, input_cols=["input"], output_cols=["output"])
         # Set block_type to "llm" for detection
@@ -1505,7 +1505,7 @@ class TestFlow:
     def test_block_produces_empty_dataset_raises_empty_dataset_error(self):
         """Test that EmptyDatasetError is raised (not wrapped) when block produces empty dataset."""
         # First Party
-        from tests.flow.conftest import MockBlock
+        from tests.conftest import MockBlock
 
         # Create a block that returns empty dataset
         block = MockBlock(block_name="empty_producer")
@@ -1544,7 +1544,7 @@ class TestFlow:
     def test_dry_run_reraises_flow_validation_error(self):
         """Test that dry_run re-raises FlowValidationError without wrapping."""
         # First Party
-        from tests.flow.conftest import MockBlock
+        from tests.conftest import MockBlock
 
         block = self.create_mock_block("failing_block")
         flow = Flow(blocks=[block], metadata=self.test_metadata)
@@ -1568,7 +1568,7 @@ class TestFlow:
         import os
 
         # First Party
-        from tests.flow.conftest import MockBlock
+        from tests.conftest import MockBlock
 
         log_dir = Path(self.temp_dir) / "logs"
         os.makedirs(log_dir, exist_ok=True)
@@ -1603,7 +1603,7 @@ class TestFlow:
         agent_api_key=None,
     ):
         """Create a mock block with agent attributes for testing."""
-        from tests.flow.conftest import MockBlock
+        from tests.conftest import MockBlock
 
         block = MockBlock(block_name=name, input_cols=["input"], output_cols=["output"])
         block.block_type = "agent"

--- a/tests/flow/test_time_estimation.py
+++ b/tests/flow/test_time_estimation.py
@@ -19,7 +19,7 @@ from sdg_hub.core.utils.time_estimator import (
     estimate_execution_time,
     is_llm_using_block,
 )
-from tests.flow.conftest import MockBlock
+from tests.conftest import MockBlock
 
 
 class TestTimeEstimation:


### PR DESCRIPTION
## Summary

- Add root `tests/conftest.py` with shared fixtures (`sample_dataset`, `empty_dataset`, `temp_dir`, `MockBlock`, `mock_block`) to eliminate duplication across test modules
- Remove duplicated fixtures from `tests/flow/conftest.py`, keeping flow-specific fixtures in place
- Update `MockBlock` import paths in `test_agent_config.py`, `test_base.py`, and `test_time_estimation.py`
- Clean up `docs/agent-knowledge/tech-debt-tracker.md`: remove 4 already-resolved items

## Verification

- `uv run pytest tests/blocks tests/connectors tests/flow tests/utils -m "not (examples or slow)"` — 971 passed
- `uv run pytest tests/structural/` — 135 passed, 4 xfailed
- `uv run ruff check src/ tests/` — All checks passed
- `uv run mypy src/sdg_hub` — Success, no issues

## Tracking

- **Multica Issue:** SDG-61
- **Parent Multica Issue:** SDG-60 (weekly tech debt paydown)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated technical debt priority tracker to reflect current project priorities.

* **Chores**
  * Reorganized test infrastructure and fixtures for improved maintainability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Red-Hat-AI-Innovation-Team/sdg_hub/pull/798)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->