### PR TITLE
chore: update QUALITY.md with 2026-05-11 grading results

### DIFF
--- a/docs/agent-knowledge/QUALITY.md
+++ b/docs/agent-knowledge/QUALITY.md
@@ -1,19 +1,35 @@
 # Quality Grades
 
-Last updated: 2026-05-08
+Last updated: 2026-05-11
 
 Quality grades by domain. Grades are populated when the quality grading
 Autopilot runs (Phase 4).
 
+**Composite score: 0.955** (eval/score.py)
+**971 tests passing, 90% overall coverage**
+
 | Domain | Test Coverage | Lint | Types | Docs | Overall |
 |---|---|---|---|---|---|
-| blocks/llm | -- | -- | -- | -- | Pending |
-| blocks/parsing | -- | -- | -- | -- | Pending |
-| blocks/transform | -- | -- | -- | -- | Pending |
-| blocks/filtering | -- | -- | -- | -- | Pending |
-| blocks/agent | -- | -- | -- | -- | Pending |
-| blocks/mcp | -- | -- | -- | -- | Pending |
-| blocks/code | -- | -- | -- | -- | Pending |
-| flow/ | -- | -- | -- | -- | Pending |
-| connectors/ | -- | -- | -- | -- | Pending |
-| utils/ | -- | -- | -- | -- | Pending |
+| blocks/llm | B (84%) | A | A | B | B |
+| blocks/parsing | A (91%) | A | A | C | B |
+| blocks/transform | A (95%) | A | A | C | B |
+| blocks/filtering | B (87%) | A | A | C | B |
+| blocks/agent | A (91%) | A | A | B | A |
+| blocks/mcp | B (85%) | A | A | A | A |
+| blocks/code | B (88%) | A | A | A | A |
+| flow/ | B (89%) | A | A | A | A |
+| connectors/ | A (91%) | A | A | A | A |
+| utils/ | A (93%) | A | A | A | A |
+
+### Grade Scale
+
+- **A**: >= 90% coverage / all checks pass / full docstring coverage
+- **B**: >= 80% coverage / minor gaps in docs
+- **C**: >= 70% coverage / significant doc gaps
+
+### Notes
+
+- Lint: `ruff check` passes clean across all domains
+- Types: `mypy` passes clean across all domains
+- Docs gaps: blocks/transform (7 classes missing docstrings), blocks/filtering
+  (class docstring missing), blocks/parsing (3 methods missing docstrings)


### PR DESCRIPTION
## Summary

- Ran `eval/score.py` — composite score **0.955**
- Ran `pytest --cov` — **971 tests passing**, **90% overall coverage**
- All domains pass ruff lint and mypy type checks
- Updated `docs/agent-knowledge/QUALITY.md` with per-domain grades

## Tracking

- **Multica Issue:** SDG-72

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Quality documentation updated with comprehensive metrics: 971 passing tests and 90% overall code coverage.
  * Added domain-specific quality grades for coverage, lint, types, and documentation.
  * Included current tool status and documentation gaps by domain.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Red-Hat-AI-Innovation-Team/sdg_hub/pull/800)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->