### PR TITLE
chore: add root conftest.py with shared test fixtures

### DIFF
--- a/docs/agent-knowledge/tech-debt-tracker.md
+++ b/docs/agent-knowledge/tech-debt-tracker.md
@@ -5,28 +5,11 @@ resolved; new items are added as they are discovered.
 
 ## High Priority
 
-- **Legacy .isort.cfg and .pylintrc redundant with ruff.** These config files
-  are superseded by ruff which handles both linting and import sorting. Being
-  removed in Phase 1.
-
-- **Stale \_\_pycache\_\_ directories for deleted test modules.** Leftover
-  bytecode caches exist for test modules that have been removed:
-  `tests/blocks/evaluation/`, `tests/blocks/utilblocks/`,
-  `tests/blocks/column_ops/`. These should be cleaned up and added to
-  `.gitignore` if not already excluded.
-
 - **Two documentation systems (MkDocs + Next.js) creating drift risk.** Having
   two separate documentation builds means content can diverge. Consolidate to
   a single system or establish a clear ownership boundary between them.
 
 ## Medium Priority
-
-- **No top-level conftest.py with shared test fixtures.** Common test helpers
-  (mock LLM clients, sample datasets, temporary flow YAML) are duplicated
-  across test modules instead of shared via a root `conftest.py`.
-
-- **No .env.example at project root.** New contributors have no reference for
-  which environment variables are expected. Being added in Phase 1.
 
 - **Some block categories missing in CLAUDE.md block category table.** The
   `blocks/code` category and any newly added categories are not listed in the

--- a/tests/blocks/llm/test_llm_chat_block.py
+++ b/tests/blocks/llm/test_llm_chat_block.py
@@ -13,37 +13,13 @@ from sdg_hub.core.blocks.llm import LLMChatBlock
 from sdg_hub.core.utils.error_handling import BlockValidationError
 
 
-class MockMessage:
-    """Mock message class that behaves like LiteLLM message for dict() conversion."""
-
-    def __init__(self, content):
-        self.content = content
-
-    def __iter__(self):
-        return iter(["content"])
-
-    def __getitem__(self, key):
-        if key == "content":
-            return self.content
-        raise KeyError(key)
-
-    def keys(self):
-        return ["content"]
-
-    def values(self):
-        return [self.content]
-
-    def items(self):
-        return [("content", self.content)]
-
-
 @pytest.fixture
-def mock_litellm_completion():
+def mock_litellm_completion(mock_message_class):
     """Mock LiteLLM completion function."""
     with patch("sdg_hub.core.blocks.llm.llm_chat_block.completion") as mock_completion:
         mock_response = MagicMock()
         choice = MagicMock()
-        choice.message = MockMessage("Test response")
+        choice.message = mock_message_class("Test response")
         mock_response.choices = [choice]
         # Mock model_dump() to return a proper dict structure
         mock_response.model_dump.return_value = {
@@ -56,14 +32,14 @@ def mock_litellm_completion():
 
 
 @pytest.fixture
-def mock_litellm_completion_multiple():
+def mock_litellm_completion_multiple(mock_message_class):
     """Mock LiteLLM completion function for multiple responses (n > 1)."""
     with patch("sdg_hub.core.blocks.llm.llm_chat_block.completion") as mock_completion:
         mock_response = MagicMock()
         choices = []
         for i in range(3):
             choice = MagicMock()
-            choice.message = MockMessage(f"Response {i + 1}")
+            choice.message = mock_message_class(f"Response {i + 1}")
             choices.append(choice)
         mock_response.choices = choices
         # Mock model_dump() to return a proper dict structure for multiple responses
@@ -81,14 +57,14 @@ def mock_litellm_completion_multiple():
 
 
 @pytest.fixture
-def mock_litellm_acompletion():
+def mock_litellm_acompletion(mock_message_class):
     """Mock LiteLLM async completion function."""
     with patch(
         "sdg_hub.core.blocks.llm.llm_chat_block.acompletion"
     ) as mock_acompletion:
         mock_response = MagicMock()
         choice = MagicMock()
-        choice.message = MockMessage("Test async response")
+        choice.message = mock_message_class("Test async response")
         mock_response.choices = [choice]
         # Mock model_dump() to return a proper dict structure
         mock_response.model_dump.return_value = {

--- a/tests/blocks/mcp_blocks/test_mcp_agent_block.py
+++ b/tests/blocks/mcp_blocks/test_mcp_agent_block.py
@@ -7,33 +7,6 @@ import pandas as pd
 import pytest
 
 
-class MockMessage:
-    """Mock message class that behaves like LiteLLM message."""
-
-    def __init__(self, content, tool_calls=None):
-        self.content = content
-        self.tool_calls = tool_calls or []
-
-    def model_dump(self):
-        result = {
-            "role": "assistant",
-            "content": self.content,
-        }
-        if self.tool_calls:
-            result["tool_calls"] = [
-                {
-                    "id": tc.id,
-                    "type": "function",
-                    "function": {
-                        "name": tc.function.name,
-                        "arguments": tc.function.arguments,
-                    },
-                }
-                for tc in self.tool_calls
-            ]
-        return result
-
-
 class MockToolCall:
     """Mock tool call from LLM response."""
 
@@ -65,12 +38,6 @@ class MockToolsResponse:
 
     def __init__(self, tools):
         self.tools = tools
-
-
-@pytest.fixture
-def sample_dataset():
-    """Create a sample dataset with queries."""
-    return pd.DataFrame({"question": ["What is Python?", "How do I use asyncio?"]})
 
 
 @pytest.fixture
@@ -218,7 +185,7 @@ class TestMCPAgentBlockGeneration:
     """Tests for MCPAgentBlock generation."""
 
     def test_generation_no_tool_calls(
-        self, sample_dataset, mock_sse_client, mock_client_session
+        self, sample_dataset, mock_sse_client, mock_client_session, mock_message_class
     ):
         """Test generation when LLM responds without tool calls."""
         from sdg_hub.core.blocks.mcp import MCPAgentBlock
@@ -231,7 +198,9 @@ class TestMCPAgentBlockGeneration:
         ) as mock_acompletion:
             mock_response = MagicMock()
             mock_response.choices = [
-                MagicMock(message=MockMessage("Python is a programming language."))
+                MagicMock(
+                    message=mock_message_class("Python is a programming language.")
+                )
             ]
 
             async def mock_completion(*args, **kwargs):
@@ -250,7 +219,7 @@ class TestMCPAgentBlockGeneration:
             result = block.generate(sample_dataset)
 
             assert "answer" in result.columns.tolist()
-            assert len(result["answer"]) == 2
+            assert len(result["answer"]) == 3
             # Output is now a trace dict
             trace = result["answer"].iloc[0]
             assert isinstance(trace, dict)
@@ -261,7 +230,9 @@ class TestMCPAgentBlockGeneration:
             final_msg = trace["messages"][-1]
             assert final_msg["content"] == "Python is a programming language."
 
-    def test_generation_with_tool_calls(self, mock_sse_client, mock_client_session):
+    def test_generation_with_tool_calls(
+        self, mock_sse_client, mock_client_session, mock_message_class
+    ):
         """Test generation when LLM makes tool calls."""
         from sdg_hub.core.blocks.mcp import MCPAgentBlock
 
@@ -276,12 +247,14 @@ class TestMCPAgentBlockGeneration:
             # First response: tool call
             tool_call = MockToolCall("call_123", "search", '{"query": "weather"}')
             first_response = MagicMock()
-            first_response.choices = [MagicMock(message=MockMessage(None, [tool_call]))]
+            first_response.choices = [
+                MagicMock(message=mock_message_class(None, [tool_call]))
+            ]
 
             # Second response: final answer
             second_response = MagicMock()
             second_response.choices = [
-                MagicMock(message=MockMessage("The weather is sunny."))
+                MagicMock(message=mock_message_class("The weather is sunny."))
             ]
 
             call_count = 0
@@ -316,7 +289,9 @@ class TestMCPAgentBlockGeneration:
             assert final_msg["content"] == "The weather is sunny."
             assert mock_session.call_tool.called
 
-    def test_generation_with_system_prompt(self, mock_sse_client, mock_client_session):
+    def test_generation_with_system_prompt(
+        self, mock_sse_client, mock_client_session, mock_message_class
+    ):
         """Test generation includes system prompt in messages."""
         from sdg_hub.core.blocks.mcp import MCPAgentBlock
 
@@ -328,7 +303,7 @@ class TestMCPAgentBlockGeneration:
             "sdg_hub.core.blocks.mcp.mcp_agent_block.acompletion"
         ) as mock_acompletion:
             mock_response = MagicMock()
-            mock_response.choices = [MagicMock(message=MockMessage("Hi there!"))]
+            mock_response.choices = [MagicMock(message=mock_message_class("Hi there!"))]
 
             async def mock_completion(*args, **kwargs):
                 # Verify system prompt is included
@@ -354,7 +329,7 @@ class TestMCPAgentBlockGeneration:
             assert trace["messages"][-1]["content"] == "Hi there!"
 
     def test_generation_max_iterations_reached(
-        self, mock_sse_client, mock_client_session
+        self, mock_sse_client, mock_client_session, mock_message_class
     ):
         """Test generation handles max iterations limit."""
         from sdg_hub.core.blocks.mcp import MCPAgentBlock
@@ -369,7 +344,9 @@ class TestMCPAgentBlockGeneration:
             # Always return tool calls (never completes)
             tool_call = MockToolCall("call_123", "search", '{"query": "test"}')
             mock_response = MagicMock()
-            mock_response.choices = [MagicMock(message=MockMessage(None, [tool_call]))]
+            mock_response.choices = [
+                MagicMock(message=mock_message_class(None, [tool_call]))
+            ]
 
             async def mock_completion(*args, **kwargs):
                 return mock_response

--- a/tests/blocks/transform/test_text_concat.py
+++ b/tests/blocks/transform/test_text_concat.py
@@ -8,18 +8,6 @@ import pytest
 from sdg_hub.core.blocks.transform import TextConcatBlock
 
 
-@pytest.fixture
-def sample_dataset():
-    """Create a sample dataset for testing."""
-    return pd.DataFrame(
-        {
-            "context": ["Context 1", "Context 2", "Context 3"],
-            "question": ["Question 1", "Question 2", "Question 3"],
-            "other_col": ["Other 1", "Other 2", "Other 3"],
-        }
-    )
-
-
 def test_basic_text_concat(sample_dataset):
     """Test basic text concatenation with default separator."""
     block = TextConcatBlock(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared test fixtures and helpers for the SDG Hub test suite."""
+
+import pandas as pd
+import pytest
+
+
+class MockMessage:
+    """Mock message class that behaves like a LiteLLM message.
+
+    Supports both the dict-like interface used by LLMChatBlock and
+    the model_dump() interface used by MCPAgentBlock.
+    """
+
+    def __init__(self, content, tool_calls=None):
+        self.content = content
+        self.tool_calls = tool_calls or []
+
+    def __iter__(self):
+        return iter(["content"])
+
+    def __getitem__(self, key):
+        if key == "content":
+            return self.content
+        raise KeyError(key)
+
+    def keys(self):
+        return ["content"]
+
+    def values(self):
+        return [self.content]
+
+    def items(self):
+        return [("content", self.content)]
+
+    def model_dump(self):
+        result = {
+            "role": "assistant",
+            "content": self.content,
+        }
+        if self.tool_calls:
+            result["tool_calls"] = [
+                {
+                    "id": tc.id,
+                    "type": "function",
+                    "function": {
+                        "name": tc.function.name,
+                        "arguments": tc.function.arguments,
+                    },
+                }
+                for tc in self.tool_calls
+            ]
+        return result
+
+
+@pytest.fixture
+def mock_message_class():
+    """Provides the MockMessage class for constructing mock LLM responses."""
+    return MockMessage
+
+
+@pytest.fixture
+def sample_dataset():
+    """Generic sample dataset for block and flow tests."""
+    return pd.DataFrame(
+        {
+            "question": ["Question 1", "Question 2", "Question 3"],
+            "context": ["Context 1", "Context 2", "Context 3"],
+            "input": ["test input 1", "test input 2", "test input 3"],
+            "label": ["label1", "label2", "label3"],
+            "other_col": ["Other 1", "Other 2", "Other 3"],
+        }
+    )

--- a/tests/flow/conftest.py
+++ b/tests/flow/conftest.py
@@ -50,17 +50,6 @@ def sample_metadata():
 
 
 @pytest.fixture
-def sample_dataset():
-    """Create a sample dataset for testing."""
-    return pd.DataFrame(
-        {
-            "input": ["test input 1", "test input 2", "test input 3"],
-            "label": ["label1", "label2", "label3"],
-        }
-    )
-
-
-@pytest.fixture
 def empty_dataset():
     """Create an empty dataset for testing."""
     return pd.DataFrame({"input": [], "label": []})


### PR DESCRIPTION
## Summary

- Add `tests/conftest.py` with shared `sample_dataset` fixture and unified `MockMessage` class (with `mock_message_class` fixture)
- Refactor `test_text_concat.py`, `tests/flow/conftest.py`, `test_mcp_agent_block.py`, and `test_llm_chat_block.py` to use shared fixtures instead of local duplicates
- Clean up `docs/agent-knowledge/tech-debt-tracker.md`: remove 4 resolved items (isort/pylintrc, __pycache__, .env.example, conftest)

## Test plan

- [x] `uv run pytest tests/structural/` — 135 passed, 4 xfailed
- [x] `uv run ruff check src/ tests/` — all checks passed
- [x] `uv run mypy src/sdg_hub` — no issues
- [x] `uv run pytest tests/blocks tests/connectors tests/flow tests/utils -m "not (examples or slow)"` — 971 passed

## Tracking

- **Multica Issue:** SDG-76
- **Parent Issue:** SDG-74 (weekly tech debt paydown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)