### PR TITLE
docs: enhance module docstring in eval/score.py

### DIFF
--- a/eval/score.py
+++ b/eval/score.py
@@ -1,14 +1,19 @@
 # SPDX-License-Identifier: Apache-2.0
 """Three-tier composite scoring script for SDG Hub.
 
-Tiers:
-  - Hygiene  (0.30): pytest, ruff, mypy, structural tests
-  - Growth   (0.20): registered blocks+flows+connectors, test coverage
-  - Project  (0.50): block tests, flow tests, connector tests
+Evaluates project health across three weighted tiers:
+
+  - Hygiene  (30%): pytest, ruff, mypy, structural tests
+  - Growth   (20%): registered blocks+flows+connectors, test coverage
+  - Project  (50%): block tests, flow tests, connector tests
+
+Each tier runs its checks and produces a 0–1 score. The composite score is
+the weighted sum of all tier scores (range 0.0–1.0). The process exits 0
+when the composite is at least 0.5, or 1 otherwise.
 
 Usage:
   uv run python eval/score.py          # human-readable output
-  uv run python eval/score.py --json   # JSON output
+  uv run python eval/score.py --json   # machine-readable JSON output
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- Enhanced the module docstring in `eval/score.py` to explain the composite score semantics (weighted sum of tier scores, 0.0–1.0 range, exit-code behavior).
- The three-tier structure and usage instructions were already present; this adds the missing "what the composite score represents" section.

Closes #806

## Test plan
- [x] `ruff check` passes
- [x] `mypy src/sdg_hub` passes
- [x] `pytest tests/structural/` passes (135 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal scoring documentation to clarify scoring tier descriptions and calculation methodologies.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Red-Hat-AI-Innovation-Team/sdg_hub/pull/812)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->