### PR TITLE
fix: remove --dangerously-skip-permissions from Get Started docs

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -1,6 +1,6 @@
 # Get Started
 
-Get up and running with SDG Hub in two steps using [Claude Code](https://claude.ai/claude-code).
+Get up and running with SDG Hub in minutes using [Claude Code](https://claude.ai/claude-code).
 
 ## Prerequisites
 
@@ -12,10 +12,12 @@ Get up and running with SDG Hub in two steps using [Claude Code](https://claude.
 
 ## Step 1: Bootstrap SDG Hub
 
-Run this command to install SDG Hub and clone the repository:
+Download the bootstrap script and review it before running:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Red-Hat-AI-Innovation-Team/sdg_hub/main/scripts/bootstrap.sh | claude --dangerously-skip-permissions
+curl -fsSL https://raw.githubusercontent.com/Red-Hat-AI-Innovation-Team/sdg_hub/main/scripts/bootstrap.sh -o bootstrap.sh
+less bootstrap.sh   # review the script
+bash bootstrap.sh
 ```
 
 ### What this does


### PR DESCRIPTION
## Summary

- Replaced the unsafe `curl | claude --dangerously-skip-permissions` one-liner in `docs/get-started.md` with a safe two-step workflow: download the script, review it, then run it with `bash`
- No changes needed to `scripts/bootstrap.sh` — it is a standard bash script that works independently of Claude Code flags

## Tracking
- **GitHub Issue:** Fixes #825
- **Multica Issue:** SDG-107

## Checklist
- [x] Tests pass (982 passed)
- [x] Structural tests pass (135 passed)
- [x] Ruff clean (pre-existing `_version.py` warnings only)
- [x] Mypy clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated "Get Started" guide introduction describing faster setup process
  * Revised initial setup instructions to require downloading and reviewing the bootstrap script before execution

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Red-Hat-AI-Innovation-Team/sdg_hub/pull/833)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->