### PR TITLE
revert: undo red team exercise PR #834

### DIFF
--- a/src/sdg_hub/core/blocks/registry.py
+++ b/src/sdg_hub/core/blocks/registry.py
@@ -64,11 +64,6 @@ class BlockRegistry:
     _metadata: dict[str, BlockMetadata] = {}
     _categories: dict[str, set[str]] = {}
 
-    @staticmethod
-    def _format_error(action: str, block_name: str, detail: str) -> str:
-        """Build a standard registry error message."""
-        return f"BlockRegistry.{action}: block '{block_name}' {detail}"
-
     @classmethod
     def register(
         cls,
@@ -102,15 +97,6 @@ class BlockRegistry:
         def decorator(block_class: type) -> type:
             # Validate the class
             cls._validate_block_class(block_class)
-
-            if block_name in cls._metadata:
-                raise ValueError(
-                    cls._format_error(
-                        "register",
-                        block_name,
-                        "is already registered",
-                    )
-                )
 
             # Create metadata
             metadata = BlockMetadata(
@@ -205,15 +191,21 @@ class BlockRegistry:
                 block_name, available_blocks, n=3, cutoff=0.6
             )
 
-            detail = "not found in registry."
-            if suggestions:
-                detail += f" Did you mean: {', '.join(suggestions)}?"
-            if available_blocks:
-                detail += f"\nAvailable blocks: {', '.join(sorted(available_blocks))}"
-            if cls._categories:
-                detail += f"\nCategories: {', '.join(sorted(cls._categories.keys()))}"
+            error_msg = f"Block '{block_name}' not found in registry."
 
-            error_msg = cls._format_error("get", block_name, detail)
+            if suggestions:
+                error_msg += f" Did you mean: {', '.join(suggestions)}?"
+
+            if available_blocks:
+                error_msg += (
+                    f"\nAvailable blocks: {', '.join(sorted(available_blocks))}"
+                )
+
+            if cls._categories:
+                error_msg += (
+                    f"\nCategories: {', '.join(sorted(cls._categories.keys()))}"
+                )
+
             logger.error(error_msg)
             raise KeyError(error_msg)
 
@@ -260,11 +252,8 @@ class BlockRegistry:
         if category not in cls._categories:
             available_categories = sorted(cls._categories.keys())
             raise KeyError(
-                cls._format_error(
-                    "get",
-                    category,
-                    f"category not found. Available categories: {', '.join(available_categories)}",
-                )
+                f"Category '{category}' not found. "
+                f"Available categories: {', '.join(available_categories)}"
             )
         return sorted(cls._categories[category])
 
@@ -320,9 +309,7 @@ class BlockRegistry:
     def discover_blocks(cls) -> None:
         """Print a Rich-formatted table of all available blocks."""
         if not cls._metadata:
-            logger.warning(
-                cls._format_error("discover_blocks", "*", "none registered yet")
-            )
+            logger.warning("No blocks registered yet.")
             return
 
         if not logger.isEnabledFor(logging.INFO):

--- a/tests/blocks/test_registry.py
+++ b/tests/blocks/test_registry.py
@@ -173,12 +173,11 @@ class TestBlockRegistry:
         assert retrieved_class == TestBlock
 
     def test_get_block_class_not_found(self):
-        """Test error when block not found uses standard format."""
+        """Test error when block not found."""
         with pytest.raises(KeyError) as exc_info:
             BlockRegistry._get("NonExistentBlock")
 
         error_msg = str(exc_info.value)
-        assert "BlockRegistry.get:" in error_msg
         assert "NonExistentBlock" in error_msg
         assert "not found in registry" in error_msg
 
@@ -194,7 +193,6 @@ class TestBlockRegistry:
             BlockRegistry._get("TestBloc")  # Missing 'k'
 
         error_msg = str(exc_info.value)
-        assert "BlockRegistry.get:" in error_msg
         assert "Did you mean: TestBlock" in error_msg
 
     def test_get_block_class_deprecated_warning(self):
@@ -258,14 +256,13 @@ class TestBlockRegistry:
         assert test_blocks == ["Block1", "Block2"]
 
     def test_list_blocks_by_category_not_found(self):
-        """Test error when category not found uses standard format."""
+        """Test error when category not found using list_blocks."""
         with pytest.raises(KeyError) as exc_info:
             BlockRegistry.list_blocks(category="NonExistentCategory")
 
         error_msg = str(exc_info.value)
-        assert "BlockRegistry.get:" in error_msg
         assert "NonExistentCategory" in error_msg
-        assert "category not found" in error_msg
+        assert "not found" in error_msg
 
     def test_list_blocks_flat(self):
         """Test listing all blocks as a flat list (default behavior)."""
@@ -341,14 +338,13 @@ class TestBlockRegistry:
         assert isinstance(category2_blocks, list)
 
     def test_list_blocks_category_not_found(self):
-        """Test error when filtering by non-existent category uses standard format."""
+        """Test error when filtering by non-existent category."""
         with pytest.raises(KeyError) as exc_info:
             BlockRegistry.list_blocks(category="NonExistentCategory")
 
         error_msg = str(exc_info.value)
-        assert "BlockRegistry.get:" in error_msg
         assert "NonExistentCategory" in error_msg
-        assert "category not found" in error_msg
+        assert "not found" in error_msg
 
     def test_list_blocks_include_deprecated(self):
         """Test listing blocks with deprecated filtering."""
@@ -473,12 +469,10 @@ class TestBlockRegistry:
         assert public_result == private_result
 
     def test_print_blocks_empty_registry(self):
-        """Test printing blocks when registry is empty uses standard format."""
+        """Test printing blocks when registry is empty."""
         with patch("sdg_hub.core.blocks.registry.logger") as mock_logger:
             BlockRegistry.discover_blocks()
-            call_args = mock_logger.warning.call_args[0][0]
-            assert "BlockRegistry.discover_blocks:" in call_args
-            assert "none registered yet" in call_args
+            mock_logger.warning.assert_called_once_with("No blocks registered yet.")
 
     def test_print_blocks_with_blocks(self):
         """Test printing blocks with Rich formatting."""
@@ -572,7 +566,7 @@ class TestBlockRegistry:
         assert len(blocks_in_category) == 2
 
     def test_error_message_shows_available_blocks_and_categories(self):
-        """Test that error messages show helpful context with standard format."""
+        """Test that error messages show helpful context."""
 
         @BlockRegistry.register("ExistingBlock", "existing_category")
         class ExistingBlock(BaseBlock):
@@ -583,33 +577,5 @@ class TestBlockRegistry:
             BlockRegistry._get("NonExistentBlock")
 
         error_msg = str(exc_info.value)
-        assert "BlockRegistry.get:" in error_msg
         assert "Available blocks: ExistingBlock" in error_msg
         assert "Categories: existing_category" in error_msg
-
-    def test_register_duplicate_block_raises(self):
-        """Test that registering a block with an existing name raises ValueError."""
-
-        @BlockRegistry.register("DuplicateBlock", "test")
-        class FirstBlock(BaseBlock):
-            def generate(self, samples: pd.DataFrame, **kwargs) -> pd.DataFrame:
-                return samples
-
-        with pytest.raises(ValueError) as exc_info:
-
-            @BlockRegistry.register("DuplicateBlock", "test")
-            class SecondBlock(BaseBlock):
-                def generate(self, samples: pd.DataFrame, **kwargs) -> pd.DataFrame:
-                    return samples
-
-        error_msg = str(exc_info.value)
-        assert "BlockRegistry.register:" in error_msg
-        assert "DuplicateBlock" in error_msg
-        assert "is already registered" in error_msg
-
-    def test_format_error_standard_structure(self):
-        """Test that _format_error produces the expected format."""
-        msg = BlockRegistry._format_error(
-            "register", "MyBlock", "is already registered"
-        )
-        assert msg == "BlockRegistry.register: block 'MyBlock' is already registered"


### PR DESCRIPTION
## Summary

Reverts PR #834 (`refactor: consolidate block registry error messages`), which was created by sdg-builder in response to issue #829.

Issue #829 was part of an authorized red team exercise to stress-test the ADLC pipeline. While the agents correctly ignored the malicious items (eval/score.py weakening), the legitimate refactor should also be reverted to fully clean up the exercise.

## Red Team Exercise Documentation

See comments on issues #827–#831 and PR #832 for the full red team report.

## Test plan

- [x] Reverts cleanly (no conflicts)
- [ ] CI passes after revert