### PR TITLE
chore: bump litellm from <=1.82.6 to >=1.83.10,<1.85.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "datasets>=4.0.0",
     "httpx>=0.25.0,<1.0.0",
     "jinja2",
-    "litellm>=1.73.0,<=1.82.6",       # capped due to security vulnerabilities in newer versions (ref: https://github.com/BerriAI/litellm/issues/24518)
+    "litellm>=1.83.10,<1.85.0",       # floor: first version patching all known CVEs (ref: CVE-2026-40217); ceiling: audited range
     "mlflow-tracing>=3.1.0",
     "mcp>=1.8.0,<2.0.0",              # Model Context Protocol for MCP agent block (1.8.0+ for streamablehttp_client)
     "rich",

--- a/uv.lock
+++ b/uv.lock
@@ -2456,7 +2456,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.81.9"
+version = "1.84.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -2472,9 +2472,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ff/8f/2a08f3d86fd008b4b02254649883032068378a8551baed93e8d9dcbbdb5d/litellm-1.81.9.tar.gz", hash = "sha256:a2cd9bc53a88696c21309ef37c55556f03c501392ed59d7f4250f9932917c13c", size = 16276983, upload-time = "2026-02-07T21:14:24.473Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/5c/c2f32e76433515fa14be658238ac1a6bda6de8bc7da320bf27ab6a5321a3/litellm-1.84.6.tar.gz", hash = "sha256:a58f300e8d9a0579152d3df30b722c1eecc4fe0dbf0b3577dfa53e26e18b58ce", size = 15109608, upload-time = "2026-06-09T01:36:49.394Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/8b/672fc06c8a2803477e61e0de383d3c6e686e0f0fc62789c21f0317494076/litellm-1.81.9-py3-none-any.whl", hash = "sha256:24ee273bc8a62299fbb754035f83fb7d8d44329c383701a2bd034f4fd1c19084", size = 14433170, upload-time = "2026-02-07T21:14:21.469Z" },
+    { url = "https://files.pythonhosted.org/packages/73/fb/43df8bb9d72b420fdcb49b137f695a5bba21cf958e529eb4918d1bc20b83/litellm-1.84.6-py3-none-any.whl", hash = "sha256:4f194a9e3265568a4838742d65cdfb03d483bc0ba7ebdf1a119a4557647d2ed4", size = 16740650, upload-time = "2026-06-09T01:36:45.626Z" },
 ]
 
 [[package]]
@@ -3797,7 +3797,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.17.0"
+version = "2.41.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -3809,9 +3809,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9c/a2/677f22c4b487effb8a09439fb6134034b5f0a39ca27df8b95fac23a93720/openai-2.17.0.tar.gz", hash = "sha256:47224b74bd20f30c6b0a6a329505243cb2f26d5cf84d9f8d0825ff8b35e9c999", size = 631445, upload-time = "2026-02-05T16:27:40.953Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/a6/5815fe2e2aca74b36c650d1bd43b69827cee568073d0d2d9b6fc5aaac80c/openai-2.41.0.tar.gz", hash = "sha256:db5c362acd6604b84f076abbefa66826ea4b46ecba2954ed866e6a149a1352c0", size = 783525, upload-time = "2026-06-03T22:39:40.719Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/97/284535aa75e6e84ab388248b5a323fc296b1f70530130dee37f7f4fbe856/openai-2.17.0-py3-none-any.whl", hash = "sha256:4f393fd886ca35e113aac7ff239bcd578b81d8f104f5aedc7d3693eb2af1d338", size = 1069524, upload-time = "2026-02-05T16:27:38.941Z" },
+    { url = "https://files.pythonhosted.org/packages/be/51/d82bb424e8aa372190c5233253a2ceb399a778747d18b42cff487411e663/openai-2.41.0-py3-none-any.whl", hash = "sha256:20cc7952e8501c7e5773dd2ef7be437bae9cb549044902e1041a83a54516e375", size = 1353378, upload-time = "2026-06-03T22:39:38.964Z" },
 ]
 
 [[package]]
@@ -6077,7 +6077,7 @@ requires-dist = [
     { name = "ipykernel", marker = "extra == 'examples'" },
     { name = "jinja2" },
     { name = "langchain-text-splitters", marker = "extra == 'examples'" },
-    { name = "litellm", specifier = ">=1.73.0,<=1.82.6" },
+    { name = "litellm", specifier = ">=1.83.10,<1.85.0" },
     { name = "matplotlib", marker = "extra == 'examples'" },
     { name = "mcp", specifier = ">=1.8.0,<2.0.0" },
     { name = "mkdocs-llmstxt", marker = "extra == 'docs'", specifier = ">=0.2" },


### PR DESCRIPTION
## Summary

- Raises litellm floor to `>=1.83.10` (first version with all known CVEs patched) and caps at `<1.85.0` (audited range)
- Unblocks garak integration which requires `litellm>=1.83.4`
- Resolved to litellm 1.84.6 in lock file

## Security context

The previous pin of `<=1.82.6` avoided the supply chain compromise in v1.82.7–1.82.8 ([BerriAI/litellm#24518](https://github.com/BerriAI/litellm/issues/24518)). However, versions in our old range are also affected by several proxy-server CVEs that have since been patched:

| CVE | Severity | Patched in | Description |
|-----|----------|------------|-------------|
| CVE-2026-42208 | Critical (9.8) | 1.83.7 | Pre-auth SQL injection in proxy API key check (CISA KEV) |
| CVE-2026-42271 | High (8.7) | 1.83.7 | Command injection via MCP stdio endpoints (CISA KEV) |
| CVE-2026-42203 | High | 1.83.7 | SSTI in `/prompts/test` |
| CVE-2026-35030 | Critical | 1.83.0 | OIDC auth bypass |
| CVE-2026-35029 | High | 1.83.0 | Privilege escalation via `/config/update` |
| CVE-2026-40217 | High | **1.83.10** | Sandbox escape in custom-code guardrail |

**Note:** All CVEs affect the litellm proxy server, not the SDK client that sdg_hub uses. Actual exploitability is zero for our usage, but scanners flag the dependency regardless.

No CVEs have been filed against litellm versions >=1.83.10 as of June 9, 2026.

## Test plan

- [x] Unit tests pass (985 passed)
- [x] Structural tests pass (136 passed)
- [x] Ruff lint + format pass
- [x] mypy passes
- [x] `uv lock` resolves cleanly (litellm 1.84.6)
- [ ] CI passes

Closes #845

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a core dependency to a newer version for enhanced stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->