### PR TITLE
feat: add few-shot sampling to SamplerBlock

### DIFF
--- a/docs/blocks/transform-blocks.md
+++ b/docs/blocks/transform-blocks.md
@@ -315,22 +315,29 @@ print(result["selected_response"].tolist())
 
 ## SamplerBlock
 
-Randomly samples a specified number of values from a list, set, or weighted dictionary column and outputs the sampled values to a new column.
+Randomly samples values from a list column (cell mode) or across rows of a scalar column (column mode).
+
+**Cell mode** (default): samples from a list, set, or weighted dictionary within each row and outputs to a single column. When `input_cols` contains dictionaries, values are treated as weights for weighted sampling.
+
+**Column mode** (`source: "column"`): samples scalar values from a column across all rows and writes each sample into a separate output column — useful for constructing few-shot example sets for LLM prompts.
 
 ### Configuration
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `block_name` | `str` | required | Unique identifier for this block instance |
-| `input_cols` | `list[str]` | required | Single input column containing lists/sets/dicts to sample from |
-| `output_cols` | `list[str]` | required | Single output column for sampled values |
-| `num_samples` | `int` | `5` | Number of values to sample from each list |
+| `input_cols` | `list[str]` | required | Single input column to sample from |
+| `output_cols` | `list[str]` | required | Cell mode: single output column. Column mode: one column per sample (`len` must equal `num_samples`) |
+| `num_samples` | `int` | `5` | Number of values to sample |
 | `random_seed` | `int` or `null` | `null` | Seed for reproducible sampling |
-| `return_scalar` | `bool` | `false` | When `num_samples=1`, return a scalar instead of a single-element list |
+| `return_scalar` | `bool` | `false` | Cell mode only. When `num_samples=1`, return a scalar instead of a single-element list |
+| `source` | `"cell"` or `"column"` | `"cell"` | `"cell"` samples from a list within each row; `"column"` samples scalar values across rows |
+| `exclude_self` | `bool` | `true` | Column mode only. Exclude the current row's value from the sampling pool |
+| `exclude_by_value` | `bool` | `false` | Column mode only. When `true` and `exclude_self` is `true`, exclude all pool entries matching the current row's value (not just its index). Use after `RowMultiplierBlock` to avoid sampling duplicated copies of the same row |
+| `replace` | `bool` | `false` | Sample with replacement (`true`) or without (`false`) |
+| `sample_range` | `list[int]` or `null` | `null` | Column mode only. Restrict the sampling pool to rows `[start, end)` |
 
-When `input_cols` contains dictionaries, values are treated as weights for weighted sampling (without replacement).
-
-### Python Example
+### Python Example — Cell Mode
 
 ```python
 from sdg_hub.core.blocks import SamplerBlock
@@ -356,7 +363,27 @@ print(result["sampled_keywords"].tolist())
 # Output: Two randomly sampled keywords per row
 ```
 
-### YAML Example
+### Python Example — Column Mode
+
+```python
+block = SamplerBlock(
+    block_name="fewshot",
+    source="column",
+    input_cols=["question"],
+    output_cols=["example1", "example2"],
+    num_samples=2,
+    random_seed=42,
+)
+
+dataset = pd.DataFrame({
+    "question": ["What is AI?", "Define ML", "Explain NLP", "What is CV?"],
+})
+
+result = block(dataset)
+# Each row gets 2 values sampled from other rows' questions
+```
+
+### YAML Example — Cell Mode
 
 ```yaml
 - block_type: "SamplerBlock"
@@ -369,6 +396,23 @@ print(result["sampled_keywords"].tolist())
     num_samples: 2
     random_seed: 42
     return_scalar: false
+```
+
+### YAML Example — Column Mode
+
+```yaml
+- block_type: "SamplerBlock"
+  block_config:
+    block_name: "fewshot_examples"
+    source: "column"
+    input_cols:
+      - "question"
+    output_cols:
+      - "example1"
+      - "example2"
+    num_samples: 2
+    exclude_self: true
+    random_seed: 42
 ```
 
 ---

--- a/docs/blocks/transform-blocks.md
+++ b/docs/blocks/transform-blocks.md
@@ -335,7 +335,6 @@ Randomly samples values from a list column (cell mode) or across rows of a scala
 | `exclude_self` | `bool` | `true` | Column mode only. Exclude the current row's value from the sampling pool |
 | `exclude_by_value` | `bool` | `false` | Column mode only. When `true` and `exclude_self` is `true`, exclude all pool entries matching the current row's value (not just its index). Use after `RowMultiplierBlock` to avoid sampling duplicated copies of the same row |
 | `replace` | `bool` | `false` | Sample with replacement (`true`) or without (`false`) |
-| `sample_range` | `list[int]` or `null` | `null` | Column mode only. Restrict the sampling pool to rows `[start, end)` |
 
 ### Python Example — Cell Mode
 

--- a/docs/blocks/transform-blocks.md
+++ b/docs/blocks/transform-blocks.md
@@ -327,7 +327,7 @@ Randomly samples values from a list column (cell mode) or across rows of a scala
 |-----------|------|---------|-------------|
 | `block_name` | `str` | required | Unique identifier for this block instance |
 | `input_cols` | `list[str]` | required | Single input column to sample from |
-| `output_cols` | `list[str]` | required | Cell mode: single output column. Column mode: one column per sample (`len` must equal `num_samples`) |
+| `output_cols` | `list[str]` | required | Cell mode: single output column. Column mode: one column per sample (`len` must equal `num_samples`), or a single name to auto-expand (e.g., `"fewshot"` with `num_samples=3` produces `fewshot_1`, `fewshot_2`, `fewshot_3`) |
 | `num_samples` | `int` | `5` | Number of values to sample |
 | `random_seed` | `int` or `null` | `null` | Seed for reproducible sampling |
 | `return_scalar` | `bool` | `false` | Cell mode only. When `num_samples=1`, return a scalar instead of a single-element list |
@@ -335,6 +335,7 @@ Randomly samples values from a list column (cell mode) or across rows of a scala
 | `exclude_self` | `bool` | `true` | Column mode only. Exclude the current row's value from the sampling pool |
 | `exclude_by_value` | `bool` | `false` | Column mode only. When `true` and `exclude_self` is `true`, exclude all pool entries matching the current row's value (not just its index). Use after `RowMultiplierBlock` to avoid sampling duplicated copies of the same row |
 | `replace` | `bool` | `false` | Sample with replacement (`true`) or without (`false`) |
+| `sample_range` | `list[int]` or `null` | `null` | Column mode only. Restrict the sampling pool to rows `[start, end)` |
 
 ### Python Example — Cell Mode
 
@@ -406,12 +407,11 @@ result = block(dataset)
     source: "column"
     input_cols:
       - "question"
-    output_cols:
-      - "example1"
-      - "example2"
-    num_samples: 2
+    output_cols: "example"
+    num_samples: 3
     exclude_self: true
     random_seed: 42
+    # output_cols auto-expands to: example_1, example_2, example_3
 ```
 
 ---

--- a/docs/reference/blocks.md
+++ b/docs/reference/blocks.md
@@ -42,7 +42,7 @@ When reading raw markdown, refer to the quick reference below.
 | UniformColumnValueSetter | `from sdg_hub.core.blocks import UniformColumnValueSetter` | Replaces all values in a column with a summary statistic (mode, mean, median) |
 | JSONStructureBlock | `from sdg_hub.core.blocks.transform.json_structure_block import JSONStructureBlock` | Combines multiple columns into a single JSON object column |
 | RowMultiplierBlock | `from sdg_hub.core.blocks.transform.row_multiplier import RowMultiplierBlock` | Duplicates each row a configurable number of times |
-| SamplerBlock | `from sdg_hub.core.blocks.transform.sampler import SamplerBlock` | Randomly samples n values from a list column |
+| SamplerBlock | `from sdg_hub.core.blocks.transform.sampler import SamplerBlock` | Randomly samples values from a list column (cell mode) or across rows (column mode) |
 
 ### Filtering Blocks
 

--- a/src/sdg_hub/core/blocks/transform/sampler.py
+++ b/src/sdg_hub/core/blocks/transform/sampler.py
@@ -277,7 +277,11 @@ class SamplerBlock(BaseBlock):
         for idx in range(n_rows):
             if self.exclude_self:
                 if self.exclude_by_value:
-                    mask = pool_values != all_values[idx]
+                    val = all_values[idx]
+                    if pd.isna(val):
+                        mask = pd.notna(pool_values)
+                    else:
+                        mask = pool_values != val
                 else:
                     mask = pool_indices != idx
                 row_pool = pool_values[mask]

--- a/src/sdg_hub/core/blocks/transform/sampler.py
+++ b/src/sdg_hub/core/blocks/transform/sampler.py
@@ -64,9 +64,6 @@ class SamplerBlock(BaseBlock):
         pool entries matching the current row's value, not just its index.
     replace : bool
         Sample with replacement (True) or without (False).
-    sample_range : list[int], optional
-        Column mode only. Restrict the sampling pool to rows
-        ``[start, end)``. Default ``None`` uses all rows.
     """
 
     block_type: str = "transform"
@@ -100,11 +97,6 @@ class SamplerBlock(BaseBlock):
         default=False,
         description="Sample with replacement (True) or without (False)",
     )
-    sample_range: Optional[list[int]] = Field(
-        default=None,
-        description="When source='column', restrict sampling pool to rows [start, end). "
-        "Default None uses all rows.",
-    )
 
     @field_validator("input_cols", mode="after")
     @classmethod
@@ -120,21 +112,6 @@ class SamplerBlock(BaseBlock):
         """Validate that num_samples is at least 1."""
         if v < 1:
             raise ValueError("num_samples must be at least 1")
-        return v
-
-    @field_validator("sample_range", mode="after")
-    @classmethod
-    def validate_sample_range(cls, v: Optional[list[int]]) -> Optional[list[int]]:
-        """Validate sample_range is a valid [start, end) pair."""
-        if v is None:
-            return v
-        if len(v) != 2:
-            raise ValueError("sample_range must be a 2-element list [start, end)")
-        start, end = v
-        if start < 0 or end < 0:
-            raise ValueError("sample_range values must be non-negative")
-        if start >= end:
-            raise ValueError("sample_range start must be less than end")
         return v
 
     @model_validator(mode="after")
@@ -159,15 +136,7 @@ class SamplerBlock(BaseBlock):
         if self.source != "column":
             return
 
-        if self.sample_range is not None:
-            start, end = self.sample_range
-            if end > len(dataset):
-                raise ValueError(
-                    f"sample_range end ({end}) exceeds dataset length ({len(dataset)})"
-                )
-            pool_size = end - start
-        else:
-            pool_size = len(dataset)
+        pool_size = len(dataset)
 
         if not self.replace:
             min_required = self.num_samples + (1 if self.exclude_self else 0)
@@ -251,13 +220,8 @@ class SamplerBlock(BaseBlock):
         output_cols = cast(list[str], self.output_cols)
 
         all_values = samples[input_col].to_numpy()
-        if self.sample_range is not None:
-            start, end = self.sample_range
-            pool_values = all_values[start:end]
-            pool_indices = np.arange(start, end)
-        else:
-            pool_values = all_values
-            pool_indices = np.arange(len(all_values))
+        pool_values = all_values
+        pool_indices = np.arange(len(all_values))
 
         n_rows = len(samples)
         rng = np.random.default_rng(self.random_seed)
@@ -274,6 +238,11 @@ class SamplerBlock(BaseBlock):
                 row_pool = pool_values[mask]
             else:
                 row_pool = pool_values
+
+            if len(row_pool) == 0:
+                raise ValueError(
+                    f"Row {idx} has no eligible pool entries after exclusion"
+                )
 
             if len(row_pool) < self.num_samples and not self.replace:
                 raise ValueError(

--- a/src/sdg_hub/core/blocks/transform/sampler.py
+++ b/src/sdg_hub/core/blocks/transform/sampler.py
@@ -64,6 +64,9 @@ class SamplerBlock(BaseBlock):
         pool entries matching the current row's value, not just its index.
     replace : bool
         Sample with replacement (True) or without (False).
+    sample_range : list[int], optional
+        Column mode only. Restrict the sampling pool to rows
+        ``[start, end)``. Default ``None`` uses all rows.
     """
 
     block_type: str = "transform"
@@ -97,6 +100,11 @@ class SamplerBlock(BaseBlock):
         default=False,
         description="Sample with replacement (True) or without (False)",
     )
+    sample_range: Optional[list[int]] = Field(
+        default=None,
+        description="When source='column', restrict sampling pool to rows [start, end). "
+        "Default None uses all rows.",
+    )
 
     @field_validator("input_cols", mode="after")
     @classmethod
@@ -114,19 +122,43 @@ class SamplerBlock(BaseBlock):
             raise ValueError("num_samples must be at least 1")
         return v
 
+    @field_validator("sample_range", mode="after")
+    @classmethod
+    def validate_sample_range(cls, v: Optional[list[int]]) -> Optional[list[int]]:
+        """Validate sample_range is a valid [start, end) pair."""
+        if v is None:
+            return v
+        if len(v) != 2:
+            raise ValueError("sample_range must be a 2-element list [start, end)")
+        start, end = v
+        if start < 0 or end < 0:
+            raise ValueError("sample_range values must be non-negative")
+        if start >= end:
+            raise ValueError("sample_range start must be less than end")
+        return v
+
     @model_validator(mode="after")
     def validate_output_cols_for_source(self) -> "SamplerBlock":
         """Validate output_cols length based on source mode."""
-        output_cols = self.output_cols
+        output_cols = cast(list[str], self.output_cols)
         if self.source == "cell":
             if not output_cols or len(output_cols) != 1:
                 raise ValueError(
                     "SamplerBlock requires exactly one output column in cell mode"
                 )
         else:
-            if not output_cols or len(output_cols) != self.num_samples:
+            if not output_cols:
                 raise ValueError(
-                    f"output_cols length ({len(output_cols) if output_cols else 0}) must match "
+                    "SamplerBlock requires at least one output column in column mode"
+                )
+            if len(output_cols) == 1 and self.num_samples > 1:
+                base = output_cols[0]
+                self.output_cols = [
+                    f"{base}_{i}" for i in range(1, self.num_samples + 1)
+                ]
+            elif len(output_cols) != self.num_samples:
+                raise ValueError(
+                    f"output_cols length ({len(output_cols)}) must match "
                     f"num_samples ({self.num_samples}) in column mode"
                 )
         return self
@@ -136,7 +168,15 @@ class SamplerBlock(BaseBlock):
         if self.source != "column":
             return
 
-        pool_size = len(dataset)
+        if self.sample_range is not None:
+            start, end = self.sample_range
+            if end > len(dataset):
+                raise ValueError(
+                    f"sample_range end ({end}) exceeds dataset length ({len(dataset)})"
+                )
+            pool_size = end - start
+        else:
+            pool_size = len(dataset)
 
         if not self.replace:
             min_required = self.num_samples + (1 if self.exclude_self else 0)
@@ -220,8 +260,13 @@ class SamplerBlock(BaseBlock):
         output_cols = cast(list[str], self.output_cols)
 
         all_values = samples[input_col].to_numpy()
-        pool_values = all_values
-        pool_indices = np.arange(len(all_values))
+        if self.sample_range is not None:
+            start, end = self.sample_range
+            pool_values = all_values[start:end]
+            pool_indices = np.arange(start, end)
+        else:
+            pool_values = all_values
+            pool_indices = np.arange(len(all_values))
 
         n_rows = len(samples)
         rng = np.random.default_rng(self.random_seed)

--- a/src/sdg_hub/core/blocks/transform/sampler.py
+++ b/src/sdg_hub/core/blocks/transform/sampler.py
@@ -1,55 +1,78 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Sampler block for randomly sampling values from list columns.
+"""Sampler block for randomly sampling values from list columns or across rows.
 
 This module provides a block for sampling a specified number of values
-from list or set columns in each row of a dataset.
+from list or set columns in each row of a dataset (cell mode), or from
+scalar values across all rows of a column (column mode).
 """
 
 # Standard
-from typing import Any, Optional, cast
+from typing import Any, Literal, Optional, cast
 
-from pydantic import Field, field_validator
+from pydantic import Field, field_validator, model_validator
 
 # Third Party
 import numpy as np
 import pandas as pd
 
 # Local
+from ...utils.logger_config import setup_logger
 from ..base import BaseBlock
 from ..registry import BlockRegistry
+
+logger = setup_logger(__name__)
 
 
 @BlockRegistry.register(
     "SamplerBlock",
     "transform",
-    "Randomly samples n values from a list column and outputs to a new column",
+    "Randomly samples values from a list column (cell mode) or across rows (column mode)",
 )
 class SamplerBlock(BaseBlock):
-    """Block for randomly sampling values from list columns.
+    """Block for randomly sampling values from list columns or across rows.
 
-    This block samples a specified number of values from each row's list/set
-    and outputs the sampled values to a new column.
+    In ``cell`` mode (default), this block samples a specified number of
+    values from each row's list/set and outputs the sampled values to a
+    new column.
+
+    In ``column`` mode, this block samples scalar values from a column
+    across all rows and writes each sample into a separate output column,
+    useful for constructing few-shot example sets for LLM prompts.
 
     Attributes
     ----------
     block_name : str
         Name of the block.
     input_cols : list[str]
-        Single input column containing lists/sets to sample from.
+        Single input column to sample from.
     output_cols : list[str]
-        Single output column for sampled values.
+        Cell mode: single output column. Column mode: one output column
+        per sample (length must equal ``num_samples``).
     num_samples : int
-        Number of values to sample from each list.
+        Number of values to sample.
     random_seed : int, optional
         Random seed for reproducibility.
     return_scalar : bool
-        When num_samples=1, return scalar value instead of single-element list.
+        Cell mode only. When num_samples=1, return scalar instead of list.
+    source : str
+        ``"cell"`` samples from a list within each row;
+        ``"column"`` samples scalar values from the column across rows.
+    exclude_self : bool
+        Column mode only. Exclude the current row's value from the pool.
+    exclude_by_value : bool
+        Column mode only. When True and exclude_self is True, exclude all
+        pool entries matching the current row's value, not just its index.
+    replace : bool
+        Sample with replacement (True) or without (False).
+    sample_range : list[int], optional
+        Column mode only. Restrict the sampling pool to rows
+        ``[start, end)``. Default ``None`` uses all rows.
     """
 
     block_type: str = "transform"
 
     num_samples: int = Field(
-        default=5, description="Number of values to randomly sample from each list"
+        default=5, description="Number of values to randomly sample"
     )
     random_seed: Optional[int] = Field(
         default=None, description="Random seed for reproducibility"
@@ -57,6 +80,30 @@ class SamplerBlock(BaseBlock):
     return_scalar: bool = Field(
         default=False,
         description="When num_samples=1, return scalar value instead of single-element list",
+    )
+    source: Literal["cell", "column"] = Field(
+        default="cell",
+        description="Sampling source: 'cell' samples from a list within each row; "
+        "'column' samples scalar values from the column across rows",
+    )
+    exclude_self: bool = Field(
+        default=True,
+        description="When source='column', exclude the current row's value from the pool",
+    )
+    exclude_by_value: bool = Field(
+        default=False,
+        description="When source='column' and exclude_self=True, exclude all pool entries "
+        "matching the current row's value (not just the current index). "
+        "Use after RowMultiplierBlock to avoid sampling duplicated copies of the same row.",
+    )
+    replace: bool = Field(
+        default=False,
+        description="Sample with replacement (True) or without (False)",
+    )
+    sample_range: Optional[list[int]] = Field(
+        default=None,
+        description="When source='column', restrict sampling pool to rows [start, end). "
+        "Default None uses all rows.",
     )
 
     @field_validator("input_cols", mode="after")
@@ -67,14 +114,6 @@ class SamplerBlock(BaseBlock):
             raise ValueError("SamplerBlock requires exactly one input column")
         return v
 
-    @field_validator("output_cols", mode="after")
-    @classmethod
-    def validate_output_cols(cls, v: list[str]) -> list[str]:
-        """Validate that exactly one output column is specified."""
-        if not v or len(v) != 1:
-            raise ValueError("SamplerBlock requires exactly one output column")
-        return v
-
     @field_validator("num_samples", mode="after")
     @classmethod
     def validate_num_samples(cls, v: int) -> int:
@@ -82,6 +121,63 @@ class SamplerBlock(BaseBlock):
         if v < 1:
             raise ValueError("num_samples must be at least 1")
         return v
+
+    @field_validator("sample_range", mode="after")
+    @classmethod
+    def validate_sample_range(cls, v: Optional[list[int]]) -> Optional[list[int]]:
+        """Validate sample_range is a valid [start, end) pair."""
+        if v is None:
+            return v
+        if len(v) != 2:
+            raise ValueError("sample_range must be a 2-element list [start, end)")
+        start, end = v
+        if start < 0 or end < 0:
+            raise ValueError("sample_range values must be non-negative")
+        if start >= end:
+            raise ValueError("sample_range start must be less than end")
+        return v
+
+    @model_validator(mode="after")
+    def validate_output_cols_for_source(self) -> "SamplerBlock":
+        """Validate output_cols length based on source mode."""
+        output_cols = self.output_cols
+        if self.source == "cell":
+            if not output_cols or len(output_cols) != 1:
+                raise ValueError(
+                    "SamplerBlock requires exactly one output column in cell mode"
+                )
+        else:
+            if not output_cols or len(output_cols) != self.num_samples:
+                raise ValueError(
+                    f"output_cols length ({len(output_cols) if output_cols else 0}) must match "
+                    f"num_samples ({self.num_samples}) in column mode"
+                )
+        return self
+
+    def _validate_custom(self, dataset: pd.DataFrame) -> None:
+        """Validate dataset constraints for column mode."""
+        if self.source != "column":
+            return
+
+        if self.sample_range is not None:
+            start, end = self.sample_range
+            if end > len(dataset):
+                raise ValueError(
+                    f"sample_range end ({end}) exceeds dataset length ({len(dataset)})"
+                )
+            pool_size = end - start
+        else:
+            pool_size = len(dataset)
+
+        if not self.replace:
+            min_required = self.num_samples + (1 if self.exclude_self else 0)
+            if pool_size < min_required:
+                raise ValueError(
+                    f"Sampling pool has {pool_size} rows but needs at least "
+                    f"{min_required} to sample {self.num_samples} values "
+                    f"without replacement"
+                    f"{' with exclude_self=True' if self.exclude_self else ''}"
+                )
 
     def _sample_values(self, values: Any, rng: np.random.Generator) -> list[Any]:
         """Sample values from a list or set.
@@ -107,18 +203,16 @@ class SamplerBlock(BaseBlock):
                 return []
             items = list(values.keys())
             weights = np.array(list(values.values()), dtype=float)
-            # Validate weights are finite and non-negative
             if not np.all(np.isfinite(weights)) or np.any(weights < 0):
                 raise ValueError("Weights must be finite and non-negative")
-            # Filter out zero weights
             mask = weights > 0
             items = [items[i] for i in range(len(items)) if mask[i]]
             weights = weights[mask]
             if len(items) == 0:
                 return []
             p = weights / weights.sum()
-            n = min(self.num_samples, len(items))
-            indices = rng.choice(len(items), size=n, replace=False, p=p)
+            n = self.num_samples if self.replace else min(self.num_samples, len(items))
+            indices = rng.choice(len(items), size=n, replace=self.replace, p=p)
             return [items[i] for i in indices]
 
         # Convert to list if it's a set or other iterable
@@ -136,9 +230,67 @@ class SamplerBlock(BaseBlock):
         if len(values) == 0:
             return []
 
-        n = min(self.num_samples, len(values))
-        indices = rng.choice(len(values), size=n, replace=False)
+        n = self.num_samples if self.replace else min(self.num_samples, len(values))
+        indices = rng.choice(len(values), size=n, replace=self.replace)
         return [values[i] for i in indices]
+
+    def _generate_column_mode(self, samples: pd.DataFrame) -> pd.DataFrame:
+        """Sample values from a column across all rows.
+
+        Parameters
+        ----------
+        samples : pd.DataFrame
+            Input dataset.
+
+        Returns
+        -------
+        pd.DataFrame
+            Dataset with sampled columns added.
+        """
+        input_col = cast(list[str], self.input_cols)[0]
+        output_cols = cast(list[str], self.output_cols)
+
+        all_values = samples[input_col].to_numpy()
+        if self.sample_range is not None:
+            start, end = self.sample_range
+            pool_values = all_values[start:end]
+            pool_indices = np.arange(start, end)
+        else:
+            pool_values = all_values
+            pool_indices = np.arange(len(all_values))
+
+        n_rows = len(samples)
+        rng = np.random.default_rng(self.random_seed)
+        result = samples.copy()
+
+        sampled = np.empty((n_rows, self.num_samples), dtype=object)
+
+        for idx in range(n_rows):
+            if self.exclude_self:
+                if self.exclude_by_value:
+                    mask = pool_values != all_values[idx]
+                else:
+                    mask = pool_indices != idx
+                row_pool = pool_values[mask]
+            else:
+                row_pool = pool_values
+
+            if len(row_pool) < self.num_samples and not self.replace:
+                raise ValueError(
+                    f"Row {idx} has only {len(row_pool)} eligible pool entries "
+                    f"after exclusion, but num_samples={self.num_samples} "
+                    f"(without replacement)"
+                )
+
+            indices = rng.choice(
+                len(row_pool), size=self.num_samples, replace=self.replace
+            )
+            sampled[idx] = row_pool[indices]
+
+        for j, col in enumerate(output_cols):
+            result[col] = sampled[:, j]
+
+        return result
 
     def generate(self, samples: pd.DataFrame, **kwargs: Any) -> pd.DataFrame:
         """Generate a dataset with sampled values.
@@ -151,8 +303,11 @@ class SamplerBlock(BaseBlock):
         Returns
         -------
         pd.DataFrame
-            Dataset with sampled values in output column.
+            Dataset with sampled values in output column(s).
         """
+        if self.source == "column":
+            return self._generate_column_mode(samples)
+
         input_cols = cast(list[str], self.input_cols)
         output_cols = cast(list[str], self.output_cols)
         input_col = input_cols[0]
@@ -160,7 +315,6 @@ class SamplerBlock(BaseBlock):
 
         result = samples.copy()
 
-        # Create random number generator
         rng = np.random.default_rng(self.random_seed)
 
         result[output_col] = result[input_col].apply(

--- a/src/sdg_hub/core/blocks/transform/sampler.py
+++ b/src/sdg_hub/core/blocks/transform/sampler.py
@@ -163,10 +163,42 @@ class SamplerBlock(BaseBlock):
                 )
         return self
 
+    @model_validator(mode="after")
+    def validate_mode_specific_params(self) -> "SamplerBlock":
+        """Reject mode-irrelevant parameters set to non-default values."""
+        if self.source == "cell":
+            if self.sample_range is not None:
+                raise ValueError(
+                    "sample_range is only valid in column mode (source='column')"
+                )
+            if self.exclude_by_value:
+                raise ValueError(
+                    "exclude_by_value is only valid in column mode (source='column')"
+                )
+        else:
+            if self.return_scalar:
+                raise ValueError(
+                    "return_scalar is only valid in cell mode (source='cell')"
+                )
+        if self.exclude_by_value and not self.exclude_self:
+            raise ValueError("exclude_by_value requires exclude_self=True")
+        return self
+
     def _validate_custom(self, dataset: pd.DataFrame) -> None:
         """Validate dataset constraints for column mode."""
         if self.source != "column":
             return
+
+        input_col = cast(list[str], self.input_cols)[0]
+        non_null = dataset[input_col].dropna()
+        if not non_null.empty:
+            first_val = non_null.iloc[0]
+            if isinstance(first_val, (list, dict, set, np.ndarray)):
+                raise ValueError(
+                    f"Column '{input_col}' contains {type(first_val).__name__} values. "
+                    f"Column mode requires scalar values. "
+                    f"Use source='cell' for list/dict/set columns."
+                )
 
         if self.sample_range is not None:
             start, end = self.sample_range

--- a/src/sdg_hub/core/blocks/transform/sampler.py
+++ b/src/sdg_hub/core/blocks/transform/sampler.py
@@ -16,11 +16,8 @@ import numpy as np
 import pandas as pd
 
 # Local
-from ...utils.logger_config import setup_logger
 from ..base import BaseBlock
 from ..registry import BlockRegistry
-
-logger = setup_logger(__name__)
 
 
 @BlockRegistry.register(

--- a/tests/blocks/transform/test_sampler.py
+++ b/tests/blocks/transform/test_sampler.py
@@ -843,6 +843,79 @@ def test_column_mode_empty_pool_with_replacement():
         block.generate(dataset)
 
 
+# --- Mode-specific parameter validation tests ---
+
+
+def test_cell_mode_rejects_sample_range():
+    """Cell mode rejects sample_range."""
+    with pytest.raises(ValueError, match="sample_range is only valid in column mode"):
+        SamplerBlock(
+            block_name="test",
+            input_cols=["items"],
+            output_cols=["sampled"],
+            num_samples=2,
+            sample_range=[0, 5],
+        )
+
+
+def test_cell_mode_rejects_exclude_by_value():
+    """Cell mode rejects exclude_by_value=True."""
+    with pytest.raises(
+        ValueError, match="exclude_by_value is only valid in column mode"
+    ):
+        SamplerBlock(
+            block_name="test",
+            input_cols=["items"],
+            output_cols=["sampled"],
+            num_samples=2,
+            exclude_by_value=True,
+        )
+
+
+def test_column_mode_rejects_return_scalar():
+    """Column mode rejects return_scalar=True."""
+    with pytest.raises(ValueError, match="return_scalar is only valid in cell mode"):
+        SamplerBlock(
+            block_name="test",
+            source="column",
+            input_cols=["q"],
+            output_cols=["s1"],
+            num_samples=1,
+            return_scalar=True,
+        )
+
+
+def test_exclude_by_value_requires_exclude_self():
+    """exclude_by_value=True with exclude_self=False raises."""
+    with pytest.raises(ValueError, match="exclude_by_value requires exclude_self=True"):
+        SamplerBlock(
+            block_name="test",
+            source="column",
+            input_cols=["q"],
+            output_cols=["s1"],
+            num_samples=1,
+            exclude_self=False,
+            exclude_by_value=True,
+        )
+
+
+def test_column_mode_rejects_non_scalar_input():
+    """Column mode rejects list-valued columns with a helpful message."""
+    dataset = pd.DataFrame({"items": [["a", "b"], ["c", "d"], ["e", "f"]]})
+
+    block = SamplerBlock(
+        block_name="test",
+        source="column",
+        input_cols=["items"],
+        output_cols=["s1"],
+        num_samples=1,
+        exclude_self=False,
+    )
+
+    with pytest.raises(ValueError, match="contains list values.*Use source='cell'"):
+        block(dataset)
+
+
 # --- Auto-generated output column name tests ---
 
 

--- a/tests/blocks/transform/test_sampler.py
+++ b/tests/blocks/transform/test_sampler.py
@@ -423,6 +423,9 @@ def test_column_mode_basic():
         ]
         for s in shots:
             assert s in dataset["question"].tolist()
+        assert len(shots) == len(set(shots)), (
+            f"Row {idx} has duplicate samples (replace=False)"
+        )
 
 
 def test_column_mode_exclude_self():
@@ -583,6 +586,35 @@ def test_column_mode_sample_range_exceeds_dataset():
 
     with pytest.raises(ValueError, match="exceeds dataset length"):
         block(dataset)
+
+
+def test_column_mode_sample_range_with_exclude_self():
+    """Rows outside sample_range still exclude themselves via index."""
+    dataset = pd.DataFrame({"val": [f"v{i}" for i in range(10)]})
+
+    block = SamplerBlock(
+        block_name="test_col",
+        source="column",
+        input_cols=["val"],
+        output_cols=["s1", "s2"],
+        num_samples=2,
+        exclude_self=True,
+        sample_range=[0, 5],
+        random_seed=42,
+    )
+
+    result = block.generate(dataset)
+
+    pool = {"v0", "v1", "v2", "v3", "v4"}
+    for idx in range(len(result)):
+        shots = [result["s1"].iloc[idx], result["s2"].iloc[idx]]
+        for s in shots:
+            assert s in pool, f"Row {idx} sampled '{s}' outside range [0, 5)"
+        if idx < 5:
+            own_value = result["val"].iloc[idx]
+            assert own_value not in shots, (
+                f"Row {idx} sampled its own value '{own_value}' with exclude_self=True"
+            )
 
 
 def test_column_mode_with_replacement():

--- a/tests/blocks/transform/test_sampler.py
+++ b/tests/blocks/transform/test_sampler.py
@@ -511,6 +511,80 @@ def test_column_mode_preserves_existing_columns():
     assert list(result["extra"]) == [1, 2, 3, 4]
 
 
+def test_column_mode_sample_range():
+    """sample_range restricts the pool to the specified row range."""
+    dataset = pd.DataFrame({"val": [f"v{i}" for i in range(10)]})
+
+    block = SamplerBlock(
+        block_name="test_col",
+        source="column",
+        input_cols=["val"],
+        output_cols=["s1", "s2"],
+        num_samples=2,
+        exclude_self=False,
+        sample_range=[0, 3],
+        random_seed=42,
+    )
+
+    result = block.generate(dataset)
+
+    pool = {"v0", "v1", "v2"}
+    for idx in range(len(result)):
+        shots = [result["s1"].iloc[idx], result["s2"].iloc[idx]]
+        for s in shots:
+            assert s in pool, f"Row {idx} sampled '{s}' outside range [0, 3)"
+
+
+def test_column_mode_sample_range_validation():
+    """Rejects invalid sample_range values."""
+    with pytest.raises(ValueError, match="2-element list"):
+        SamplerBlock(
+            block_name="test",
+            source="column",
+            input_cols=["q"],
+            output_cols=["s1"],
+            num_samples=1,
+            sample_range=[0],
+        )
+
+    with pytest.raises(ValueError, match="start must be less than end"):
+        SamplerBlock(
+            block_name="test",
+            source="column",
+            input_cols=["q"],
+            output_cols=["s1"],
+            num_samples=1,
+            sample_range=[5, 3],
+        )
+
+    with pytest.raises(ValueError, match="non-negative"):
+        SamplerBlock(
+            block_name="test",
+            source="column",
+            input_cols=["q"],
+            output_cols=["s1"],
+            num_samples=1,
+            sample_range=[-1, 3],
+        )
+
+
+def test_column_mode_sample_range_exceeds_dataset():
+    """Rejects sample_range that exceeds dataset length."""
+    dataset = pd.DataFrame({"val": ["a", "b", "c"]})
+
+    block = SamplerBlock(
+        block_name="test",
+        source="column",
+        input_cols=["val"],
+        output_cols=["s1"],
+        num_samples=1,
+        sample_range=[0, 10],
+    )
+
+    with pytest.raises(ValueError, match="exceeds dataset length"):
+        block(dataset)
+
+
 def test_column_mode_with_replacement():
     """Column mode with replace=True allows duplicate samples."""
     dataset = pd.DataFrame({"val": ["a", "b"]})
@@ -744,3 +818,55 @@ def test_column_mode_empty_pool_with_replacement():
 
     with pytest.raises(ValueError, match="no eligible pool entries"):
         block.generate(dataset)
+
+
+# --- Auto-generated output column name tests ---
+
+
+def test_column_mode_auto_output_cols():
+    """Single output_cols string auto-expands to num_samples indexed columns."""
+    dataset = pd.DataFrame({"question": [f"q{i}" for i in range(10)]})
+
+    block = SamplerBlock(
+        block_name="test_col",
+        source="column",
+        input_cols=["question"],
+        output_cols=["fewshot"],
+        num_samples=3,
+        random_seed=42,
+    )
+
+    assert block.output_cols == ["fewshot_1", "fewshot_2", "fewshot_3"]
+
+    result = block.generate(dataset)
+
+    assert len(result) == 10
+    assert "fewshot_1" in result.columns
+    assert "fewshot_2" in result.columns
+    assert "fewshot_3" in result.columns
+
+
+def test_column_mode_auto_output_cols_explicit_still_works():
+    """Explicit output_cols list matching num_samples is used as-is."""
+    block = SamplerBlock(
+        block_name="test_col",
+        source="column",
+        input_cols=["question"],
+        output_cols=["ex1", "ex2", "ex3"],
+        num_samples=3,
+    )
+
+    assert block.output_cols == ["ex1", "ex2", "ex3"]
+
+
+def test_column_mode_auto_output_cols_single_sample():
+    """Single output_cols with num_samples=1 stays as-is (no expansion needed)."""
+    block = SamplerBlock(
+        block_name="test_col",
+        source="column",
+        input_cols=["question"],
+        output_cols=["fewshot"],
+        num_samples=1,
+    )
+
+    assert block.output_cols == ["fewshot"]

--- a/tests/blocks/transform/test_sampler.py
+++ b/tests/blocks/transform/test_sampler.py
@@ -801,6 +801,29 @@ def test_column_mode_exclude_by_value_with_replacement():
         assert all(s == "b" for s in shots), f"Row {idx} should only sample 'b'"
 
 
+def test_column_mode_exclude_by_value_nan():
+    """exclude_by_value correctly excludes NaN entries from the pool."""
+    dataset = pd.DataFrame({"q": [float("nan"), float("nan"), "a", "b"]})
+
+    block = SamplerBlock(
+        block_name="test_col",
+        source="column",
+        input_cols=["q"],
+        output_cols=["s1"],
+        num_samples=1,
+        exclude_self=True,
+        exclude_by_value=True,
+        random_seed=42,
+    )
+
+    result = block.generate(dataset)
+
+    for idx in range(2):
+        assert pd.notna(result["s1"].iloc[idx]), (
+            f"Row {idx} (NaN) should not sample NaN with exclude_by_value=True"
+        )
+
+
 def test_column_mode_empty_pool_with_replacement():
     """Raises clear error when exclude_by_value empties the pool, even with replacement."""
     dataset = pd.DataFrame({"q": ["a", "a", "a"]})

--- a/tests/blocks/transform/test_sampler.py
+++ b/tests/blocks/transform/test_sampler.py
@@ -137,14 +137,14 @@ def test_sampler_validation_input_cols():
 def test_sampler_validation_output_cols():
     """Test validation errors for output_cols."""
     with pytest.raises(
-        ValueError, match="SamplerBlock requires exactly one output column"
+        ValueError, match="SamplerBlock requires exactly one output column in cell mode"
     ):
         SamplerBlock(
             block_name="test", input_cols=["items"], output_cols=[], num_samples=3
         )
 
     with pytest.raises(
-        ValueError, match="SamplerBlock requires exactly one output column"
+        ValueError, match="SamplerBlock requires exactly one output column in cell mode"
     ):
         SamplerBlock(
             block_name="test",
@@ -392,3 +392,410 @@ def test_sampler_return_scalar_with_dict():
     # Should return scalar value
     assert not isinstance(result["sampled"].iloc[0], list)
     assert result["sampled"].iloc[0] in ["a", "b", "c"]
+
+
+# --- Column mode tests ---
+
+
+def test_column_mode_basic():
+    """Column mode samples K values from the column into K output columns."""
+    dataset = pd.DataFrame({"question": [f"q{i}" for i in range(10)]})
+
+    block = SamplerBlock(
+        block_name="test_col",
+        source="column",
+        input_cols=["question"],
+        output_cols=["fs1", "fs2", "fs3"],
+        num_samples=3,
+        random_seed=42,
+    )
+
+    result = block.generate(dataset)
+
+    assert len(result) == 10
+    assert list(result.columns) == ["question", "fs1", "fs2", "fs3"]
+
+    for idx in range(len(result)):
+        shots = [
+            result["fs1"].iloc[idx],
+            result["fs2"].iloc[idx],
+            result["fs3"].iloc[idx],
+        ]
+        for s in shots:
+            assert s in dataset["question"].tolist()
+
+
+def test_column_mode_exclude_self():
+    """When exclude_self=True, a row's own value never appears in its samples."""
+    dataset = pd.DataFrame({"question": [f"q{i}" for i in range(20)]})
+
+    block = SamplerBlock(
+        block_name="test_col",
+        source="column",
+        input_cols=["question"],
+        output_cols=["fs1", "fs2"],
+        num_samples=2,
+        exclude_self=True,
+        random_seed=0,
+    )
+
+    result = block.generate(dataset)
+
+    for idx in range(len(result)):
+        own_value = result["question"].iloc[idx]
+        shots = [result["fs1"].iloc[idx], result["fs2"].iloc[idx]]
+        assert own_value not in shots, (
+            f"Row {idx} value '{own_value}' should not appear in its own shots"
+        )
+
+
+def test_column_mode_exclude_self_false():
+    """When exclude_self=False, self-sampling is allowed."""
+    dataset = pd.DataFrame({"question": ["a", "b", "c"]})
+
+    block = SamplerBlock(
+        block_name="test_col",
+        source="column",
+        input_cols=["question"],
+        output_cols=["fs1", "fs2"],
+        num_samples=2,
+        exclude_self=False,
+        random_seed=42,
+    )
+
+    result = block.generate(dataset)
+
+    assert len(result) == 3
+    for idx in range(len(result)):
+        shots = [result["fs1"].iloc[idx], result["fs2"].iloc[idx]]
+        for s in shots:
+            assert s in ["a", "b", "c"]
+
+
+def test_column_mode_reproducibility():
+    """Same random_seed produces identical results in column mode."""
+    dataset = pd.DataFrame({"question": [f"q{i}" for i in range(20)]})
+
+    kwargs = dict(
+        block_name="test_col",
+        source="column",
+        input_cols=["question"],
+        output_cols=["fs1", "fs2", "fs3"],
+        num_samples=3,
+        random_seed=123,
+    )
+
+    result1 = SamplerBlock(**kwargs).generate(dataset)
+    result2 = SamplerBlock(**kwargs).generate(dataset)
+
+    pd.testing.assert_frame_equal(result1, result2)
+
+
+def test_column_mode_preserves_existing_columns():
+    """Output DataFrame retains all original columns in column mode."""
+    dataset = pd.DataFrame({"question": ["a", "b", "c", "d"], "extra": [1, 2, 3, 4]})
+
+    block = SamplerBlock(
+        block_name="test_col",
+        source="column",
+        input_cols=["question"],
+        output_cols=["fs1"],
+        num_samples=1,
+        exclude_self=True,
+        random_seed=42,
+    )
+
+    result = block.generate(dataset)
+
+    assert "extra" in result.columns
+    assert list(result["extra"]) == [1, 2, 3, 4]
+
+
+def test_column_mode_sample_range():
+    """sample_range restricts the pool to the specified row range."""
+    dataset = pd.DataFrame({"val": [f"v{i}" for i in range(10)]})
+
+    block = SamplerBlock(
+        block_name="test_col",
+        source="column",
+        input_cols=["val"],
+        output_cols=["s1", "s2"],
+        num_samples=2,
+        exclude_self=False,
+        sample_range=[0, 3],
+        random_seed=42,
+    )
+
+    result = block.generate(dataset)
+
+    pool = {"v0", "v1", "v2"}
+    for idx in range(len(result)):
+        shots = [result["s1"].iloc[idx], result["s2"].iloc[idx]]
+        for s in shots:
+            assert s in pool, f"Row {idx} sampled '{s}' outside range [0, 3)"
+
+
+def test_column_mode_sample_range_validation():
+    """Rejects invalid sample_range values."""
+    with pytest.raises(ValueError, match="2-element list"):
+        SamplerBlock(
+            block_name="test",
+            source="column",
+            input_cols=["q"],
+            output_cols=["s1"],
+            num_samples=1,
+            sample_range=[0],
+        )
+
+    with pytest.raises(ValueError, match="start must be less than end"):
+        SamplerBlock(
+            block_name="test",
+            source="column",
+            input_cols=["q"],
+            output_cols=["s1"],
+            num_samples=1,
+            sample_range=[5, 3],
+        )
+
+    with pytest.raises(ValueError, match="non-negative"):
+        SamplerBlock(
+            block_name="test",
+            source="column",
+            input_cols=["q"],
+            output_cols=["s1"],
+            num_samples=1,
+            sample_range=[-1, 3],
+        )
+
+
+def test_column_mode_sample_range_exceeds_dataset():
+    """Rejects sample_range that exceeds dataset length."""
+    dataset = pd.DataFrame({"val": ["a", "b", "c"]})
+
+    block = SamplerBlock(
+        block_name="test",
+        source="column",
+        input_cols=["val"],
+        output_cols=["s1"],
+        num_samples=1,
+        sample_range=[0, 10],
+    )
+
+    with pytest.raises(ValueError, match="exceeds dataset length"):
+        block(dataset)
+
+
+def test_column_mode_with_replacement():
+    """Column mode with replace=True allows duplicate samples."""
+    dataset = pd.DataFrame({"val": ["a", "b"]})
+
+    block = SamplerBlock(
+        block_name="test_col",
+        source="column",
+        input_cols=["val"],
+        output_cols=["s1", "s2", "s3", "s4", "s5"],
+        num_samples=5,
+        exclude_self=False,
+        replace=True,
+        random_seed=42,
+    )
+
+    result = block.generate(dataset)
+
+    assert len(result) == 2
+    for idx in range(len(result)):
+        shots = [result[f"s{j + 1}"].iloc[idx] for j in range(5)]
+        for s in shots:
+            assert s in ["a", "b"]
+
+
+def test_cell_mode_with_replacement():
+    """Cell mode with replace=True allows duplicate samples."""
+    data = {"items": [["a", "b"]]}
+    dataset = pd.DataFrame(data)
+
+    block = SamplerBlock(
+        block_name="test_replace",
+        input_cols=["items"],
+        output_cols=["sampled"],
+        num_samples=5,
+        replace=True,
+        random_seed=42,
+    )
+
+    result = block.generate(dataset)
+
+    assert len(result["sampled"].iloc[0]) == 5
+    for s in result["sampled"].iloc[0]:
+        assert s in ["a", "b"]
+
+
+def test_column_mode_output_cols_mismatch():
+    """Rejects output_cols length != num_samples in column mode."""
+    with pytest.raises(
+        ValueError, match="output_cols length .* must match num_samples"
+    ):
+        SamplerBlock(
+            block_name="test",
+            source="column",
+            input_cols=["q"],
+            output_cols=["fs1", "fs2"],
+            num_samples=3,
+        )
+
+
+def test_column_mode_too_few_rows():
+    """Rejects dataset too small to sample from without replacement."""
+    dataset = pd.DataFrame({"val": ["a", "b"]})
+
+    block = SamplerBlock(
+        block_name="test",
+        source="column",
+        input_cols=["val"],
+        output_cols=["s1", "s2"],
+        num_samples=2,
+        exclude_self=True,
+    )
+
+    with pytest.raises(ValueError, match="needs at least 3"):
+        block(dataset)
+
+
+def test_column_mode_called_via_dunder_call():
+    """Column mode works correctly when invoked via __call__."""
+    dataset = pd.DataFrame({"question": [f"q{i}" for i in range(10)]})
+
+    block = SamplerBlock(
+        block_name="test_col",
+        source="column",
+        input_cols=["question"],
+        output_cols=["fs1", "fs2"],
+        num_samples=2,
+        random_seed=42,
+    )
+
+    result = block(dataset)
+
+    assert len(result) == 10
+    assert "fs1" in result.columns
+    assert "fs2" in result.columns
+
+
+# --- exclude_by_value tests ---
+
+
+def test_column_mode_exclude_by_value():
+    """exclude_by_value excludes all pool entries matching the current row's value."""
+    dataset = pd.DataFrame({"q": ["a", "a", "a", "b", "c"]})
+
+    block = SamplerBlock(
+        block_name="test_col",
+        source="column",
+        input_cols=["q"],
+        output_cols=["s1"],
+        num_samples=1,
+        exclude_self=True,
+        exclude_by_value=True,
+        random_seed=42,
+    )
+
+    result = block.generate(dataset)
+
+    # Rows 0, 1, 2 all have value "a" — none of their samples should be "a"
+    for idx in range(3):
+        assert result["s1"].iloc[idx] != "a", (
+            f"Row {idx} sampled 'a' despite exclude_by_value=True"
+        )
+
+
+def test_column_mode_exclude_by_value_after_multiply():
+    """Simulates RowMultiplierBlock then column-mode sampling with exclude_by_value."""
+    # Simulate 3 original rows multiplied 2x
+    original = pd.DataFrame({"q": ["alpha", "beta", "gamma"]})
+    multiplied = pd.concat([original] * 2, ignore_index=True)
+    # multiplied: alpha, beta, gamma, alpha, beta, gamma
+
+    block = SamplerBlock(
+        block_name="test_col",
+        source="column",
+        input_cols=["q"],
+        output_cols=["fs1"],
+        num_samples=1,
+        exclude_self=True,
+        exclude_by_value=True,
+        random_seed=42,
+    )
+
+    result = block.generate(multiplied)
+
+    for idx in range(len(result)):
+        own_value = result["q"].iloc[idx]
+        assert result["fs1"].iloc[idx] != own_value, (
+            f"Row {idx} (value='{own_value}') sampled itself"
+        )
+
+
+def test_column_mode_exclude_by_value_false_allows_duplicates():
+    """Without exclude_by_value, index-only exclusion lets duplicate values through."""
+    # 4 copies of "a" and 1 "b" — index exclusion removes only one "a"
+    dataset = pd.DataFrame({"q": ["a", "a", "a", "a", "b"]})
+
+    block = SamplerBlock(
+        block_name="test_col",
+        source="column",
+        input_cols=["q"],
+        output_cols=["s1", "s2", "s3"],
+        num_samples=3,
+        exclude_self=True,
+        exclude_by_value=False,
+        random_seed=42,
+    )
+
+    result = block.generate(dataset)
+
+    # Row 0 has value "a", but with index-only exclusion the other "a" copies are eligible
+    row0_shots = [result["s1"].iloc[0], result["s2"].iloc[0], result["s3"].iloc[0]]
+    assert "a" in row0_shots, "Index-only exclusion should still allow duplicate values"
+
+
+def test_column_mode_exclude_by_value_pool_too_small():
+    """Raises when exclude_by_value leaves too few pool entries for without-replacement."""
+    # All values are "a" except one "b" — after excluding "a", only 1 left, need 2
+    dataset = pd.DataFrame({"q": ["a", "a", "a", "b"]})
+
+    block = SamplerBlock(
+        block_name="test_col",
+        source="column",
+        input_cols=["q"],
+        output_cols=["s1", "s2"],
+        num_samples=2,
+        exclude_self=True,
+        exclude_by_value=True,
+    )
+
+    with pytest.raises(ValueError, match="eligible pool entries"):
+        block.generate(dataset)
+
+
+def test_column_mode_exclude_by_value_with_replacement():
+    """exclude_by_value works with replace=True."""
+    dataset = pd.DataFrame({"q": ["a", "a", "b"]})
+
+    block = SamplerBlock(
+        block_name="test_col",
+        source="column",
+        input_cols=["q"],
+        output_cols=["s1", "s2", "s3"],
+        num_samples=3,
+        exclude_self=True,
+        exclude_by_value=True,
+        replace=True,
+        random_seed=42,
+    )
+
+    result = block.generate(dataset)
+
+    # Rows 0 and 1 (value "a") can only sample "b" — all 3 shots must be "b"
+    for idx in range(2):
+        shots = [result[f"s{j + 1}"].iloc[idx] for j in range(3)]
+        assert all(s == "b" for s in shots), f"Row {idx} should only sample 'b'"

--- a/tests/blocks/transform/test_sampler.py
+++ b/tests/blocks/transform/test_sampler.py
@@ -511,80 +511,6 @@ def test_column_mode_preserves_existing_columns():
     assert list(result["extra"]) == [1, 2, 3, 4]
 
 
-def test_column_mode_sample_range():
-    """sample_range restricts the pool to the specified row range."""
-    dataset = pd.DataFrame({"val": [f"v{i}" for i in range(10)]})
-
-    block = SamplerBlock(
-        block_name="test_col",
-        source="column",
-        input_cols=["val"],
-        output_cols=["s1", "s2"],
-        num_samples=2,
-        exclude_self=False,
-        sample_range=[0, 3],
-        random_seed=42,
-    )
-
-    result = block.generate(dataset)
-
-    pool = {"v0", "v1", "v2"}
-    for idx in range(len(result)):
-        shots = [result["s1"].iloc[idx], result["s2"].iloc[idx]]
-        for s in shots:
-            assert s in pool, f"Row {idx} sampled '{s}' outside range [0, 3)"
-
-
-def test_column_mode_sample_range_validation():
-    """Rejects invalid sample_range values."""
-    with pytest.raises(ValueError, match="2-element list"):
-        SamplerBlock(
-            block_name="test",
-            source="column",
-            input_cols=["q"],
-            output_cols=["s1"],
-            num_samples=1,
-            sample_range=[0],
-        )
-
-    with pytest.raises(ValueError, match="start must be less than end"):
-        SamplerBlock(
-            block_name="test",
-            source="column",
-            input_cols=["q"],
-            output_cols=["s1"],
-            num_samples=1,
-            sample_range=[5, 3],
-        )
-
-    with pytest.raises(ValueError, match="non-negative"):
-        SamplerBlock(
-            block_name="test",
-            source="column",
-            input_cols=["q"],
-            output_cols=["s1"],
-            num_samples=1,
-            sample_range=[-1, 3],
-        )
-
-
-def test_column_mode_sample_range_exceeds_dataset():
-    """Rejects sample_range that exceeds dataset length."""
-    dataset = pd.DataFrame({"val": ["a", "b", "c"]})
-
-    block = SamplerBlock(
-        block_name="test",
-        source="column",
-        input_cols=["val"],
-        output_cols=["s1"],
-        num_samples=1,
-        sample_range=[0, 10],
-    )
-
-    with pytest.raises(ValueError, match="exceeds dataset length"):
-        block(dataset)
-
-
 def test_column_mode_with_replacement():
     """Column mode with replace=True allows duplicate samples."""
     dataset = pd.DataFrame({"val": ["a", "b"]})
@@ -799,3 +725,22 @@ def test_column_mode_exclude_by_value_with_replacement():
     for idx in range(2):
         shots = [result[f"s{j + 1}"].iloc[idx] for j in range(3)]
         assert all(s == "b" for s in shots), f"Row {idx} should only sample 'b'"
+
+
+def test_column_mode_empty_pool_with_replacement():
+    """Raises clear error when exclude_by_value empties the pool, even with replacement."""
+    dataset = pd.DataFrame({"q": ["a", "a", "a"]})
+
+    block = SamplerBlock(
+        block_name="test_col",
+        source="column",
+        input_cols=["q"],
+        output_cols=["s1"],
+        num_samples=1,
+        exclude_self=True,
+        exclude_by_value=True,
+        replace=True,
+    )
+
+    with pytest.raises(ValueError, match="no eligible pool entries"):
+        block.generate(dataset)


### PR DESCRIPTION
Extend SamplerBlock with cross-row column sampling capabilities for constructing few-shot example sets for LLM prompts.

## Summary

Extends the existing `SamplerBlock` with a `source="column"` mode that samples scalar values across rows into separate output columns. Also adds `replace` (with/without replacement) and `exclude_by_value` (value-based exclusion for use after `RowMultiplierBlock`) options. All new fields default to preserving existing behavior -- fully backwards compatible.

## Examples

### Multiply rows, then sample few-shot columns

The primary use case: duplicate each row with `RowMultiplierBlock`, then use `SamplerBlock` in column mode to give each copy a **different** set of few-shot examples drawn from other rows. `exclude_by_value` ensures no row samples its own value -- even across duplicated copies.

```yaml
# Step 1: duplicate each row
- block_type: RowMultiplierBlock
  block_config:
    block_name: replicate
    num_samples: 2
    shuffle: false

# Step 2: sample from the column, excluding own value
- block_type: SamplerBlock
  block_config:
    block_name: fewshot
    source: column
    input_cols: [val]
    output_cols: [fs1, fs2]
    num_samples: 2
    exclude_self: true
    exclude_by_value: true
    random_seed: 42
```

### Column mode basics (`source="column"`)

Without `RowMultiplierBlock` -- just sample across rows directly.

```yaml
- block_type: SamplerBlock
  block_config:
    block_name: fewshot
    source: column
    input_cols: [question]
    output_cols: [example1, example2]
    num_samples: 2
    random_seed: 42
```

### `replace=True` -- sample with replacement

```yaml
- block_type: SamplerBlock
  block_config:
    block_name: with_rep
    source: column
    input_cols: [fruit]
    output_cols: [s1, s2, s3]
    num_samples: 3
    exclude_self: false
    replace: true
    random_seed: 42
```

## Changes

- **`src/sdg_hub/core/blocks/transform/sampler.py`** -- Added `source`, `exclude_self`, `exclude_by_value`, and `replace` fields, a `_generate_column_mode()` method, `_validate_custom()` override for runtime dataset checks, and updated validators to handle both modes. Passed `replace` through to existing cell-mode `_sample_values()`. Added `logger` setup to match upstream convention. Updated registry description.
- **`tests/blocks/transform/test_sampler.py`** -- Added 16 new tests covering column mode basics, `exclude_self` on/off, `exclude_by_value`, reproducibility, with-replacement in both modes, output_cols mismatch, too-few-rows errors, and empty-pool-with-replacement edge case. Updated existing output_cols validation test to match new error message.
- **`docs/blocks/transform-blocks.md`** -- Rewrote SamplerBlock section with both modes documented, updated config table, added Python and YAML examples for column mode.
- **`docs/reference/blocks.md`** -- Updated one-line description to reflect both modes.

## Test Plan

- 35/35 sampler tests pass (19 existing + 16 new)
- 1001/1001 full unit suite passes
- 136 structural tests pass
- Verified backwards compatibility: old-style construction, `get_config()`/`from_config()` roundtrip, YAML flow config loading, `return_scalar`, pool-smaller-than-num_samples capping all produce identical results to upstream

## Checklist

- [x] Tests pass (`uv run pytest`)
- [x] Structural tests pass (`uv run pytest tests/structural/`)
- [x] Lint clean (`uv run ruff check src/ tests/`)
- [x] Types clean (`uv run mypy src/sdg_hub`)
- [x] Docs updated if public API changed
- [x] No new lint warnings introduced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added **column mode** to SamplerBlock to sample scalar values across rows into multiple output columns (alongside existing cell mode).
  * Added column-mode controls: `source`, `exclude_self`, `exclude_by_value`, `replace`, `sample_range`, plus deterministic runs via `random_seed`.
  * Output columns now auto-expand when using column mode with a single provided name.

* **Documentation**
  * Updated SamplerBlock docs and reference tables with clarified cell vs column semantics and refreshed Python/YAML examples.

* **Tests**
  * Expanded test coverage for column-mode sampling, validation, exclusions (including NaN handling), and replacement behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->